### PR TITLE
Fun dice UI with full UX overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Set Roll
+# Setlist Roller
 
 A dice-powered setlist generator for bands who like to live dangerously.
 
@@ -6,30 +6,30 @@ A dice-powered setlist generator for bands who like to live dangerously.
 
 You've got 40 songs, three members who switch instruments, two alternate tunings, and a capo that keeps disappearing. Building a setlist by hand means either constant gear changes or playing the same safe order every gig.
 
-Set Roll fixes that. Tell it your songs and who plays what. It figures out the order that keeps transitions smooth — fewer tuning breaks, fewer awkward silences while someone swaps guitars. Then you roll the dice and it hands you a setlist.
+Setlist Roller fixes that. Tell it your songs and who plays what. It figures out the order that keeps transitions smooth — fewer tuning breaks, fewer awkward silences while someone swaps guitars. Then you roll the dice and it hands you a setlist.
 
 Think of it as a roadie for your setlist.
 
 ## How it works
 
 1. **Add your songs** — title, key, covers, instrumentals, whatever you play
-2. **Tell it about gear switches** — if someone plays acoustic on one song and electric on the next, or changes tuning, Set Roll wants to know
+2. **Tell it about gear switches** — if someone plays acoustic on one song and electric on the next, or changes tuning, Setlist Roller wants to know
 3. **Roll** — pick how many songs, hit the dice, get a setlist that flows
 4. **Tweak it** — drag songs around, crank the variety slider from "safe pick" to "hold my beer", set demands like "no banjo tonight" or "at least 3 songs on the 12-string"
 5. **Lock it in** — save it, print it, tape it to the monitor wedge
 
-You only need to tell Set Roll about members who **switch gear between songs**. If your drummer plays the same kit every night, leave them out. This isn't about taking attendance — it's about tracking transitions.
+You only need to tell Setlist Roller about members who **switch gear between songs**. If your drummer plays the same kit every night, leave them out. This isn't about taking attendance — it's about tracking transitions.
 
 ## Your data stays yours
 
-Most apps store your stuff on their servers. If they shut down, your data goes with them. Set Roll doesn't work that way.
+Most apps store your stuff on their servers. If they shut down, your data goes with them. Setlist Roller doesn't work that way.
 
-Set Roll uses [remoteStorage](https://remotestorage.io) — an open standard that lets you pick where your data lives. You connect your own storage provider (there are free ones, or you can run your own), and that's where your songs and settings go. Not our server. Not anyone else's server. Yours.
+Setlist Roller uses [remoteStorage](https://remotestorage.io) — an open standard that lets you pick where your data lives. You connect your own storage provider (there are free ones, or you can run your own), and that's where your songs and settings go. Not our server. Not anyone else's server. Yours.
 
 **What that means in practice:**
 - No account to create with us — you bring your own storage
 - No one is mining your setlists for ad data
-- If Set Roll disappeared tomorrow, your data would still be right where you left it
+- If Setlist Roller disappeared tomorrow, your data would still be right where you left it
 - Switch to a different app that supports remoteStorage? Your data comes with you
 
 Saved setlists live on your device. Export everything as a backup file anytime. Nothing phones home.
@@ -61,4 +61,4 @@ npm run dev
 
 ## Open source
 
-Set Roll is free and open source under the [AGPL-3.0](https://www.gnu.org/licenses/agpl-3.0.en.html) license. That means anyone can use it, modify it, and share it — as long as they keep it open too. No one gets to take this and lock it behind a paywall. The code stays free, like the music should be.
+Setlist Roller is free and open source under the [AGPL-3.0](https://www.gnu.org/licenses/agpl-3.0.en.html) license. That means anyone can use it, modify it, and share it — as long as they keep it open too. No one gets to take this and lock it behind a paywall. The code stays free, like the music should be.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,64 @@
+# Set Roll
+
+A dice-powered setlist generator for bands who like to live dangerously.
+
+## The pitch
+
+You've got 40 songs, three members who switch instruments, two alternate tunings, and a capo that keeps disappearing. Building a setlist by hand means either constant gear changes or playing the same safe order every gig.
+
+Set Roll fixes that. Tell it your songs and who plays what. It figures out the order that keeps transitions smooth — fewer tuning breaks, fewer awkward silences while someone swaps guitars. Then you roll the dice and it hands you a setlist.
+
+Think of it as a roadie for your setlist.
+
+## How it works
+
+1. **Add your songs** — title, key, covers, instrumentals, whatever you play
+2. **Tell it about gear switches** — if someone plays acoustic on one song and electric on the next, or changes tuning, Set Roll wants to know
+3. **Roll** — pick how many songs, hit the dice, get a setlist that flows
+4. **Tweak it** — drag songs around, crank the variety slider from "safe pick" to "hold my beer", set demands like "no banjo tonight" or "at least 3 songs on the 12-string"
+5. **Lock it in** — save it, print it, tape it to the monitor wedge
+
+You only need to tell Set Roll about members who **switch gear between songs**. If your drummer plays the same kit every night, leave them out. This isn't about taking attendance — it's about tracking transitions.
+
+## Your data stays yours
+
+Most apps store your stuff on their servers. If they shut down, your data goes with them. Set Roll doesn't work that way.
+
+Set Roll uses [remoteStorage](https://remotestorage.io) — an open standard that lets you pick where your data lives. You connect your own storage provider (there are free ones, or you can run your own), and that's where your songs and settings go. Not our server. Not anyone else's server. Yours.
+
+**What that means in practice:**
+- No account to create with us — you bring your own storage
+- No one is mining your setlists for ad data
+- If Set Roll disappeared tomorrow, your data would still be right where you left it
+- Switch to a different app that supports remoteStorage? Your data comes with you
+
+Saved setlists live on your device. Export everything as a backup file anytime. Nothing phones home.
+
+## Features
+
+- **Gear-aware ordering** — tracks instruments, tunings, capos, and techniques per member per song
+- **Demands** — limit which instruments or tunings show up in a set
+- **Variety slider** — control how adventurous the setlist gets
+- **Drag to reorder** — move songs around after the roll
+- **Greatest Hits** — save and revisit your best setlists
+- **Export/import** — back up everything, restore on any device
+- **Works on your phone** — built for the stage, not the studio desk
+
+## Getting started
+
+Visit the app, connect your remoteStorage address, name your band, and start adding songs. When you've got a few in the catalog, head to the Roll tab and let the dice decide.
+
+The app walks you through it — there's a getting-started guide built right in.
+
+## For developers
+
+Built with [Svelte 5](https://svelte.dev), [Vite](https://vite.dev), and [remoteStorage](https://remotestorage.io). No backend, no database, no tracking. The setlist generator runs in a web worker so the UI stays snappy while it crunches numbers.
+
+```bash
+npm install
+npm run dev
+```
+
+## Open source
+
+Set Roll is free and open source under the [AGPL-3.0](https://www.gnu.org/licenses/agpl-3.0.en.html) license. That means anyone can use it, modify it, and share it — as long as they keep it open too. No one gets to take this and lock it behind a paywall. The code stays free, like the music should be.

--- a/index.html
+++ b/index.html
@@ -5,10 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="A playful unhosted setlist generator for bands who want fewer mid-show instrument gymnastics."
+      content="Set Roll — a dice-powered setlist generator for bands who like to live dangerously."
     />
-    <title>Band Setlist Generator</title>
-    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E%F0%9F%93%9D%3C/text%3E%3C/svg%3E" />
+    <title>Set Roll</title>
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E%F0%9F%8E%B2%3C/text%3E%3C/svg%3E" />
   </head>
   <body>
     <div id="app"></div>

--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Set Roll — a dice-powered setlist generator for bands who like to live dangerously."
+      content="Setlist Roller — a dice-powered setlist generator for bands who like to live dangerously."
     />
-    <title>Set Roll</title>
+    <title>Setlist Roller</title>
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E%F0%9F%8E%B2%3C/text%3E%3C/svg%3E" />
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "setlist-generator",
+  "name": "set-roll",
   "private": true,
   "version": "0.1.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "set-roll",
+  "name": "setlist-roller",
   "private": true,
   "version": "0.1.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "remotestoragejs": "^2.0.0-beta.8",
@@ -14,6 +16,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^5.0.3",
-    "vite": "^6.2.4"
+    "vite": "^6.2.4",
+    "vitest": "^3.2.4"
   }
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,6 +8,8 @@
     import RollScreen from "./lib/components/roll/RollScreen.svelte";
     import SongsScreen from "./lib/components/songs/SongsScreen.svelte";
     import BandScreen from "./lib/components/band/BandScreen.svelte";
+    import SavedScreen from "./lib/components/saved/SavedScreen.svelte";
+    import HelpScreen from "./lib/components/help/HelpScreen.svelte";
 
     const repo = createRemoteStorageRepository();
     const store = createAppStore(repo);
@@ -26,10 +28,10 @@
 {#if store.connectionStatus !== "connected"}
     <main class="connect-shell">
         <section class="connect-card">
-            <p class="eyebrow">Setlist Generator</p>
+            <p class="eyebrow">Set Roll</p>
             <h1>{store.appTitle}</h1>
             <p class="lede">
-                Connect to remoteStorage to keep your songs and presets safe.
+                Connect to remoteStorage so your songs survive the tour bus.
             </p>
 
             <label class="field">
@@ -59,10 +61,14 @@
         <main class="main-content">
             {#if store.activeView === "roll"}
                 <RollScreen />
+            {:else if store.activeView === "saved"}
+                <SavedScreen />
             {:else if store.activeView === "songs"}
                 <SongsScreen />
             {:else if store.activeView === "band"}
                 <BandScreen />
+            {:else if store.activeView === "help"}
+                <HelpScreen />
             {/if}
         </main>
 
@@ -75,7 +81,7 @@
         <div class="modal">
             <p class="eyebrow">First Run</p>
             <h3>Name Your Band</h3>
-            <p class="modal-desc">Give the generator something to call you.</p>
+            <p class="modal-desc">What do we call this operation? Don't overthink it.</p>
             <label class="field">
                 <span>Band name</span>
                 <input
@@ -99,11 +105,12 @@
     </div>
 {/if}
 
-<div class="toast-stack" aria-live="polite">
-    {#each store.toastMessages as toast (toast.id)}
-        <div class="toast {toast.tone}">{toast.message}</div>
-    {/each}
-</div>
+{#if store.toastMessages.length > 0}
+    {@const latest = store.toastMessages[store.toastMessages.length - 1]}
+    <div class="toast-pill {latest.tone}" aria-live="polite">
+        {latest.message}
+    </div>
+{/if}
 
 <style>
     /* ---- Connect screen ---- */
@@ -303,39 +310,46 @@
         flex-shrink: 0;
     }
 
-    /* ---- Toasts ---- */
-    .toast-stack {
+    /* ---- Toast pill ---- */
+    .toast-pill {
         position: fixed;
-        bottom: calc(var(--bottom-nav-height) + var(--safe-bottom) + var(--space-3));
-        left: var(--space-3);
-        right: var(--space-3);
-        display: grid;
-        gap: var(--space-2);
-        z-index: 40;
-        pointer-events: none;
-    }
-
-    .toast {
-        background: rgba(18, 27, 39, 0.95);
+        top: calc(env(safe-area-inset-top, 0px) + 48px);
+        left: 50%;
+        transform: translateX(-50%);
+        max-width: calc(100vw - 2rem);
+        padding: 5px 14px;
+        font-size: 0.78rem;
+        font-weight: 600;
+        text-align: center;
         color: #fff;
-        border-radius: var(--radius-md);
-        padding: 0.75rem 1rem;
-        box-shadow: 0 18px 34px rgba(18, 27, 39, 0.24);
-        animation: toast-in 180ms ease;
-        font-size: 0.85rem;
-        pointer-events: auto;
+        background: #1b3150;
+        border: none;
+        border-radius: 0 0 var(--radius-md, 12px) var(--radius-md, 12px);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+        z-index: 300;
+        pointer-events: none;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        animation: toast-slide-down 200ms ease;
     }
 
-    .toast.danger {
-        background: rgba(122, 36, 24, 0.96);
+    .toast-pill.danger {
+        background: #992f20;
+        color: #fff;
+    }
+
+    .toast-pill.warning {
+        background: #7a5c10;
+        color: #fff;
     }
 
     @keyframes spin {
         to { transform: rotate(360deg); }
     }
 
-    @keyframes toast-in {
-        from { opacity: 0; transform: translateY(8px); }
-        to { opacity: 1; transform: translateY(0); }
+    @keyframes toast-slide-down {
+        from { opacity: 0; transform: translateX(-50%) translateY(-8px); }
+        to { opacity: 1; transform: translateX(-50%) translateY(0); }
     }
 </style>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -28,7 +28,7 @@
 {#if store.connectionStatus !== "connected"}
     <main class="connect-shell">
         <section class="connect-card">
-            <p class="eyebrow">Set Roll</p>
+            <p class="eyebrow">Setlist Roller</p>
             <h1>{store.appTitle}</h1>
             <p class="lede">
                 Connect to remoteStorage so your songs survive the tour bus.

--- a/src/app.css
+++ b/src/app.css
@@ -95,3 +95,13 @@ h1, h2, h3 {
     letter-spacing: -0.04em;
     line-height: 1.05;
 }
+
+@media print {
+    @page {
+        margin: 0.5cm;
+    }
+
+    body {
+        background: #fff !important;
+    }
+}

--- a/src/lib/anxiety.js
+++ b/src/lib/anxiety.js
@@ -98,7 +98,7 @@ export function computeAnxiety(songs, config) {
     const propNames = Object.keys(config?.props || {});
     const propConfig = config?.props || {};
 
-    const totalTransitions = Math.max(1, songs.length - 1);
+    const totalTransitions = songs.length - 1;
     let totalWeighted = 0;
     let totalMemberChanges = 0;
     let spotsWithChanges = 0;
@@ -175,7 +175,7 @@ export function computeAnxiety(songs, config) {
     // Spread factor: changes spread across many spots = more dead-air moments = worse.
     // Using power curve so sparse changes (e.g. 3/14) are meaningfully dampened,
     // while dense disruption (most spots affected) stays close to full weight.
-    const spreadRatio = spotsWithChanges / totalTransitions;
+    const spreadRatio = totalTransitions > 0 ? spotsWithChanges / totalTransitions : 0;
     const adjustedWeighted = totalWeighted * Math.pow(spreadRatio, 0.7);
 
     // Dynamic scale from the band's own weights

--- a/src/lib/anxiety.js
+++ b/src/lib/anxiety.js
@@ -1,0 +1,319 @@
+/**
+ * Bass Player Anxiety — standalone setlist transition scoring.
+ *
+ * Analyses a fixed-order setlist and returns how many gear changes happen,
+ * where they happen, and a 0-10 "anxiety" score scaled to the band's own
+ * configuration weights.
+ *
+ * Usage:
+ *   import { computeAnxiety } from "./anxiety.js";
+ *   const result = computeAnxiety(songs, config);
+ *   // result.scaled          — 0-10 integer
+ *   // result.rawChanges      — total magnitude across all props
+ *   // result.weightedScore   — magnitude * weight, adjusted for spread
+ *   // result.transitionsDisrupted — how many song boundaries had a change
+ *   // result.totalTransitions     — songCount - 1
+ *   // result.details         — per-transition breakdown
+ */
+
+
+// ---------------------------------------------------------------------------
+// Change detection helpers (pure functions, no class state)
+// ---------------------------------------------------------------------------
+
+function normalizeValue(value) {
+    if (value === undefined || value === null) return "";
+    if (Array.isArray(value)) return value.slice().sort().join(",");
+    return String(value);
+}
+
+function displayValue(value) {
+    if (value === undefined || value === null || value === "") return "default";
+    if (Array.isArray(value)) return value.length === 0 ? "default" : value.join(", ");
+    return String(value);
+}
+
+/**
+ * Detect whether a member's instrument itself changed (e.g. guitar → banjo).
+ * Also detects members appearing / disappearing between songs.
+ */
+function detectInstrumentSetChange(prevPerf, nextPerf) {
+    const members = new Set([
+        ...Object.keys(prevPerf),
+        ...Object.keys(nextPerf)
+    ]);
+    const notes = [];
+    let magnitude = 0;
+
+    for (const member of Array.from(members).sort()) {
+        const prev = prevPerf[member];
+        const next = nextPerf[member];
+
+        if (!prev || !next) {
+            magnitude += 1;
+            notes.push(`${member} instrument on/off`);
+            continue;
+        }
+        if (prev.instrument !== next.instrument) {
+            magnitude += 1;
+            notes.push(`${member} instrument ${prev.instrument} -> ${next.instrument}`);
+        }
+    }
+
+    return { changed: magnitude > 0, magnitude, notes };
+}
+
+/**
+ * Detect value changes for a given field across all members present in
+ * EITHER song (not just shared members — a member disappearing or appearing
+ * is itself a change worth noting for field-level props).
+ */
+function detectFieldChange(prevPerf, nextPerf, field, scaleByDelta) {
+    const allMembers = new Set([
+        ...Object.keys(prevPerf),
+        ...Object.keys(nextPerf)
+    ]);
+    const notes = [];
+    let magnitude = 0;
+
+    for (const member of Array.from(allMembers).sort()) {
+        const prev = prevPerf[member];
+        const next = nextPerf[member];
+
+        // Member only in one song — skip field comparison (instrument set
+        // change handles the on/off transition).
+        if (!prev || !next) continue;
+
+        const prevValue = prev[field];
+        const nextValue = next[field];
+
+        const left = normalizeValue(prevValue);
+        const right = normalizeValue(nextValue);
+
+        if (left === right) continue;
+
+        const amount = scaleByDelta
+            ? Math.abs((Number(prevValue) || 0) - (Number(nextValue) || 0))
+            : 1;
+        if (!amount) continue;
+
+        magnitude += amount;
+        notes.push(`${member} ${field} ${displayValue(prevValue)} -> ${displayValue(nextValue)}`);
+    }
+
+    return { changed: magnitude > 0, magnitude, notes };
+}
+
+
+// ---------------------------------------------------------------------------
+// Per-transition scoring
+// ---------------------------------------------------------------------------
+
+/**
+ * Score one transition (prevSong → nextSong) across all configured props.
+ *
+ * @param {object|null} prevSong - previous song (null for first song)
+ * @param {object} nextSong - current song
+ * @param {string[]} propNames - ordered property names
+ * @param {object} propConfig - prop name → rule
+ * @param {object} weights - weightKey → numeric weight
+ * @returns {{ score: number, notes: string[], changes: object }}
+ */
+function scoreTransition(prevSong, nextSong, propNames, propConfig, weights) {
+    if (!prevSong) {
+        const changes = {};
+        for (const p of propNames) changes[p] = { changed: false, magnitude: 0, notes: [] };
+        return { score: 0, notes: [], changes };
+    }
+
+    const prevPerf = prevSong.performance || {};
+    const nextPerf = nextSong.performance || {};
+
+    const changes = {};
+    const notes = [];
+    let score = 0;
+
+    for (const propName of propNames) {
+        const rule = propConfig[propName] || {};
+        const kind = rule.kind || inferPropKind(propName);
+        let change;
+
+        if (kind === "instrumentSet") {
+            change = detectInstrumentSetChange(prevPerf, nextPerf);
+        } else if (kind === "instrumentDelta") {
+            change = detectFieldChange(prevPerf, nextPerf, rule.field || propName, true);
+        } else {
+            // instrumentField and instrumentBoolean both use field comparison.
+            // The normalizeValue handles arrays, strings, and booleans uniformly.
+            change = detectFieldChange(prevPerf, nextPerf, rule.field || propName, false);
+        }
+
+        changes[propName] = change;
+        if (change.changed) {
+            const weightKey = rule.weightKey || propName;
+            const w = weights[weightKey] || 0;
+            score += change.magnitude * w;
+            notes.push(...change.notes);
+        }
+    }
+
+    return { score, notes, changes };
+}
+
+function inferPropKind(propName) {
+    if (propName === "instruments") return "instrumentSet";
+    if (propName === "capo") return "instrumentDelta";
+    return "instrumentField";
+}
+
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+const DEFAULT_WEIGHTS = {
+    positionMiss: 8,
+    earlyCover: 6,
+    earlyInstrumental: 4
+};
+
+/**
+ * Compute the Bass Player Anxiety score for a fixed-order setlist.
+ *
+ * @param {object[]} songs - ordered array of song objects with `.performance`
+ * @param {object} config - app config with `.props` and `.general.weighting`
+ * @returns {AnxietyResult}
+ *
+ * @typedef {object} AnxietyResult
+ * @property {number} scaled - 0-10 integer score
+ * @property {number} rawChanges - total magnitude across all props & transitions
+ * @property {number} weightedScore - magnitude * weight, spread-adjusted
+ * @property {number} transitionsDisrupted - transitions with at least one change
+ * @property {number} totalTransitions - songCount - 1
+ * @property {TransitionDetail[]} details - per-transition breakdown
+ *
+ * @typedef {object} TransitionDetail
+ * @property {number} index - transition index (1-based, matching song position)
+ * @property {string} from - previous song name
+ * @property {string} to - current song name
+ * @property {object} changes - propName → { changed, magnitude, notes }
+ * @property {string[]} notes - aggregated human-readable notes
+ * @property {number} score - weighted score for this transition
+ */
+export function computeAnxiety(songs, config) {
+    const weights = Object.assign({}, DEFAULT_WEIGHTS, config?.general?.weighting || {});
+    const propNames = Object.keys(config?.props || {});
+    const propConfig = config?.props || {};
+
+    const totalTransitions = Math.max(1, songs.length - 1);
+    let totalWeighted = 0;
+    let totalRawChanges = 0;
+    let transitionsWithChanges = 0;
+    const details = [];
+
+    for (let i = 1; i < songs.length; i++) {
+        const prev = songs[i - 1];
+        const curr = songs[i];
+        const transition = scoreTransition(prev, curr, propNames, propConfig, weights);
+
+        let hasChange = false;
+        let transitionRaw = 0;
+
+        for (const propName of propNames) {
+            const change = transition.changes[propName];
+            if (change && change.changed) {
+                const weightKey = (propConfig[propName] || {}).weightKey || propName;
+                const w = weights[weightKey] || 0;
+                totalWeighted += change.magnitude * w;
+                totalRawChanges += change.magnitude;
+                transitionRaw += change.magnitude;
+                hasChange = true;
+            }
+        }
+
+        if (hasChange) transitionsWithChanges++;
+
+        details.push({
+            index: i,
+            from: prev.name || `Song ${i}`,
+            to: curr.name || `Song ${i + 1}`,
+            changes: transition.changes,
+            notes: transition.notes,
+            score: transition.score,
+            rawChanges: transitionRaw
+        });
+    }
+
+    // Spread factor: scattered changes = more dead-air moments = worse
+    const spreadRatio = transitionsWithChanges / totalTransitions;
+    const adjustedWeighted = totalWeighted * (0.5 + spreadRatio * 0.5);
+
+    // Dynamic scale from the band's own weights
+    let avgWeight = 0;
+    if (propNames.length > 0) {
+        let sumW = 0;
+        for (const propName of propNames) {
+            const weightKey = (propConfig[propName] || {}).weightKey || propName;
+            sumW += weights[weightKey] || 0;
+        }
+        avgWeight = sumW / propNames.length;
+    }
+
+    const mediumBaseline = totalTransitions * 0.3 * avgWeight;
+    const maxBaseline = totalTransitions * avgWeight * 2;
+
+    let scaled;
+    if (maxBaseline <= 0) {
+        scaled = 0;
+    } else if (adjustedWeighted <= mediumBaseline) {
+        scaled = Math.round((adjustedWeighted / mediumBaseline) * 5);
+    } else {
+        scaled = 5 + Math.round(((adjustedWeighted - mediumBaseline) / (maxBaseline - mediumBaseline)) * 5);
+    }
+    scaled = Math.max(0, Math.min(10, scaled));
+
+    return {
+        scaled,
+        rawChanges: totalRawChanges,
+        weightedScore: Math.round(adjustedWeighted * 10) / 10,
+        transitionsDisrupted: transitionsWithChanges,
+        totalTransitions,
+        details
+    };
+}
+
+
+/**
+ * Generate a human-readable label for a given anxiety result.
+ */
+export function anxietyLabel(result) {
+    const { scaled, rawChanges, transitionsDisrupted, totalTransitions } = result;
+    const spreadNote = transitionsDisrupted > 0
+        ? ` across ${transitionsDisrupted} of ${totalTransitions} transitions`
+        : "";
+
+    if (rawChanges === 0) {
+        return "Bass player is relaxed for once. Zero gear changes — smooth sailing.";
+    }
+    if (scaled <= 2) {
+        return `${rawChanges} gear change${rawChanges === 1 ? "" : "s"}${spreadNote}. Bass player barely notices.`;
+    }
+    if (scaled <= 5) {
+        return `${rawChanges} gear changes${spreadNote}. Bass player is rehearsing crowd work.`;
+    }
+    if (scaled <= 7) {
+        return `${rawChanges} gear changes${spreadNote}. Bass player is visibly sweating.`;
+    }
+    return `${rawChanges} gear changes${spreadNote}. Bass player is writing a stand-up set to fill all the dead air.`;
+}
+
+
+// Export internals for testing
+export const _internals = {
+    normalizeValue,
+    displayValue,
+    detectInstrumentSetChange,
+    detectFieldChange,
+    scoreTransition,
+    inferPropKind
+};

--- a/src/lib/anxiety.js
+++ b/src/lib/anxiety.js
@@ -5,104 +5,28 @@
  * where they happen, and a 0-10 "anxiety" score scaled to the band's own
  * configuration weights.
  *
+ * Per-member deduplication: when one member changes multiple things at the
+ * same transition (e.g. capo AND picking), it counts as ONE change scored
+ * at the highest-weighted prop that changed for that member.
+ *
  * Usage:
  *   import { computeAnxiety } from "./anxiety.js";
  *   const result = computeAnxiety(songs, config);
- *   // result.scaled          — 0-10 integer
- *   // result.rawChanges      — total magnitude across all props
- *   // result.weightedScore   — magnitude * weight, adjusted for spread
- *   // result.transitionsDisrupted — how many song boundaries had a change
- *   // result.totalTransitions     — songCount - 1
- *   // result.details         — per-transition breakdown
+ *   // result.scaled      — 0-10 integer
+ *   // result.changes     — total member-changes (deduplicated per member per spot)
+ *   // result.spots       — how many song boundaries had a change
+ *   // result.songCount   — total songs in setlist
+ *   // result.weightedScore — max-weight per member, adjusted for spread
+ *   // result.details     — per-transition breakdown
  */
 
-
-// ---------------------------------------------------------------------------
-// Change detection helpers (pure functions, no class state)
-// ---------------------------------------------------------------------------
-
-function normalizeValue(value) {
-    if (value === undefined || value === null) return "";
-    if (Array.isArray(value)) return value.slice().sort().join(",");
-    return String(value);
-}
-
-function displayValue(value) {
-    if (value === undefined || value === null || value === "") return "default";
-    if (Array.isArray(value)) return value.length === 0 ? "default" : value.join(", ");
-    return String(value);
-}
-
-/**
- * Detect whether a member's instrument itself changed (e.g. guitar → banjo).
- * Also detects members appearing / disappearing between songs.
- */
-function detectInstrumentSetChange(prevPerf, nextPerf) {
-    const members = new Set([
-        ...Object.keys(prevPerf),
-        ...Object.keys(nextPerf)
-    ]);
-    const notes = [];
-    let magnitude = 0;
-
-    for (const member of Array.from(members).sort()) {
-        const prev = prevPerf[member];
-        const next = nextPerf[member];
-
-        if (!prev || !next) {
-            magnitude += 1;
-            notes.push(`${member} instrument on/off`);
-            continue;
-        }
-        if (prev.instrument !== next.instrument) {
-            magnitude += 1;
-            notes.push(`${member} instrument ${prev.instrument} -> ${next.instrument}`);
-        }
-    }
-
-    return { changed: magnitude > 0, magnitude, notes };
-}
-
-/**
- * Detect value changes for a given field across all members present in
- * EITHER song (not just shared members — a member disappearing or appearing
- * is itself a change worth noting for field-level props).
- */
-function detectFieldChange(prevPerf, nextPerf, field, scaleByDelta) {
-    const allMembers = new Set([
-        ...Object.keys(prevPerf),
-        ...Object.keys(nextPerf)
-    ]);
-    const notes = [];
-    let magnitude = 0;
-
-    for (const member of Array.from(allMembers).sort()) {
-        const prev = prevPerf[member];
-        const next = nextPerf[member];
-
-        // Member only in one song — skip field comparison (instrument set
-        // change handles the on/off transition).
-        if (!prev || !next) continue;
-
-        const prevValue = prev[field];
-        const nextValue = next[field];
-
-        const left = normalizeValue(prevValue);
-        const right = normalizeValue(nextValue);
-
-        if (left === right) continue;
-
-        const amount = scaleByDelta
-            ? Math.abs((Number(prevValue) || 0) - (Number(nextValue) || 0))
-            : 1;
-        if (!amount) continue;
-
-        magnitude += amount;
-        notes.push(`${member} ${field} ${displayValue(prevValue)} -> ${displayValue(nextValue)}`);
-    }
-
-    return { changed: magnitude > 0, magnitude, notes };
-}
+import {
+    normalizeValue,
+    displayValue,
+    detectInstrumentSetChange,
+    detectFieldChange,
+    inferPropKind
+} from "./detection.js";
 
 
 // ---------------------------------------------------------------------------
@@ -111,13 +35,6 @@ function detectFieldChange(prevPerf, nextPerf, field, scaleByDelta) {
 
 /**
  * Score one transition (prevSong → nextSong) across all configured props.
- *
- * @param {object|null} prevSong - previous song (null for first song)
- * @param {object} nextSong - current song
- * @param {string[]} propNames - ordered property names
- * @param {object} propConfig - prop name → rule
- * @param {object} weights - weightKey → numeric weight
- * @returns {{ score: number, notes: string[], changes: object }}
  */
 function scoreTransition(prevSong, nextSong, propNames, propConfig, weights) {
     if (!prevSong) {
@@ -143,8 +60,6 @@ function scoreTransition(prevSong, nextSong, propNames, propConfig, weights) {
         } else if (kind === "instrumentDelta") {
             change = detectFieldChange(prevPerf, nextPerf, rule.field || propName, true);
         } else {
-            // instrumentField and instrumentBoolean both use field comparison.
-            // The normalizeValue handles arrays, strings, and booleans uniformly.
             change = detectFieldChange(prevPerf, nextPerf, rule.field || propName, false);
         }
 
@@ -158,12 +73,6 @@ function scoreTransition(prevSong, nextSong, propNames, propConfig, weights) {
     }
 
     return { score, notes, changes };
-}
-
-function inferPropKind(propName) {
-    if (propName === "instruments") return "instrumentSet";
-    if (propName === "capo") return "instrumentDelta";
-    return "instrumentField";
 }
 
 
@@ -183,22 +92,6 @@ const DEFAULT_WEIGHTS = {
  * @param {object[]} songs - ordered array of song objects with `.performance`
  * @param {object} config - app config with `.props` and `.general.weighting`
  * @returns {AnxietyResult}
- *
- * @typedef {object} AnxietyResult
- * @property {number} scaled - 0-10 integer score
- * @property {number} rawChanges - total magnitude across all props & transitions
- * @property {number} weightedScore - magnitude * weight, spread-adjusted
- * @property {number} transitionsDisrupted - transitions with at least one change
- * @property {number} totalTransitions - songCount - 1
- * @property {TransitionDetail[]} details - per-transition breakdown
- *
- * @typedef {object} TransitionDetail
- * @property {number} index - transition index (1-based, matching song position)
- * @property {string} from - previous song name
- * @property {string} to - current song name
- * @property {object} changes - propName → { changed, magnitude, notes }
- * @property {string[]} notes - aggregated human-readable notes
- * @property {number} score - weighted score for this transition
  */
 export function computeAnxiety(songs, config) {
     const weights = Object.assign({}, DEFAULT_WEIGHTS, config?.general?.weighting || {});
@@ -207,31 +100,66 @@ export function computeAnxiety(songs, config) {
 
     const totalTransitions = Math.max(1, songs.length - 1);
     let totalWeighted = 0;
-    let totalRawChanges = 0;
-    let transitionsWithChanges = 0;
+    let totalMemberChanges = 0;
+    let spotsWithChanges = 0;
     const details = [];
 
     for (let i = 1; i < songs.length; i++) {
         const prev = songs[i - 1];
         const curr = songs[i];
+
+        // Keep scoreTransition for per-prop notes/details
         const transition = scoreTransition(prev, curr, propNames, propConfig, weights);
 
-        let hasChange = false;
-        let transitionRaw = 0;
+        // Per-member scoring: each member counts once at their highest-weighted
+        // changed prop. If nick changes capo (2) AND picking (1), that's 1 change
+        // scored at weight 2, not 2 changes scored at 3.
+        const prevPerf = prev.performance || {};
+        const currPerf = curr.performance || {};
+        const allMembers = new Set([...Object.keys(prevPerf), ...Object.keys(currPerf)]);
 
-        for (const propName of propNames) {
-            const change = transition.changes[propName];
-            if (change && change.changed) {
-                const weightKey = (propConfig[propName] || {}).weightKey || propName;
+        let spotMemberChanges = 0;
+        let spotWeighted = 0;
+
+        for (const member of allMembers) {
+            let maxWeight = 0;
+
+            for (const propName of propNames) {
+                const rule = propConfig[propName] || {};
+                const kind = rule.kind || inferPropKind(propName);
+                const weightKey = rule.weightKey || propName;
                 const w = weights[weightKey] || 0;
-                totalWeighted += change.magnitude * w;
-                totalRawChanges += change.magnitude;
-                transitionRaw += change.magnitude;
-                hasChange = true;
+
+                const prevM = prevPerf[member];
+                const currM = currPerf[member];
+
+                let changed = false;
+
+                if (kind === "instrumentSet") {
+                    if (!prevM || !currM) changed = true;
+                    else if (prevM.instrument !== currM.instrument) changed = true;
+                } else {
+                    // instrumentField or instrumentDelta — only compare shared members
+                    if (prevM && currM) {
+                        const field = rule.field || propName;
+                        const left = normalizeValue(prevM[field]);
+                        const right = normalizeValue(currM[field]);
+                        if (left !== right) changed = true;
+                    }
+                }
+
+                if (changed && w > maxWeight) maxWeight = w;
+            }
+
+            if (maxWeight > 0) {
+                spotMemberChanges++;
+                spotWeighted += maxWeight;
             }
         }
 
-        if (hasChange) transitionsWithChanges++;
+        if (spotMemberChanges > 0) spotsWithChanges++;
+        totalWeighted += spotWeighted;
+        totalMemberChanges += spotMemberChanges;
 
         details.push({
             index: i,
@@ -239,14 +167,16 @@ export function computeAnxiety(songs, config) {
             to: curr.name || `Song ${i + 1}`,
             changes: transition.changes,
             notes: transition.notes,
-            score: transition.score,
-            rawChanges: transitionRaw
+            score: spotWeighted,
+            memberChanges: spotMemberChanges
         });
     }
 
-    // Spread factor: scattered changes = more dead-air moments = worse
-    const spreadRatio = transitionsWithChanges / totalTransitions;
-    const adjustedWeighted = totalWeighted * (0.5 + spreadRatio * 0.5);
+    // Spread factor: changes spread across many spots = more dead-air moments = worse.
+    // Using power curve so sparse changes (e.g. 3/14) are meaningfully dampened,
+    // while dense disruption (most spots affected) stays close to full weight.
+    const spreadRatio = spotsWithChanges / totalTransitions;
+    const adjustedWeighted = totalWeighted * Math.pow(spreadRatio, 0.7);
 
     // Dynamic scale from the band's own weights
     let avgWeight = 0;
@@ -259,8 +189,11 @@ export function computeAnxiety(songs, config) {
         avgWeight = sumW / propNames.length;
     }
 
-    const mediumBaseline = totalTransitions * 0.3 * avgWeight;
-    const maxBaseline = totalTransitions * avgWeight * 2;
+    // mediumBaseline: weighted score where anxiety hits 5/10
+    // maxBaseline: weighted score where anxiety hits 10/10
+    // Floor ensures short setlists don't spike to 10 from a single change
+    const mediumBaseline = Math.max(totalTransitions * 0.15 * avgWeight, avgWeight * 2);
+    const maxBaseline = Math.max(totalTransitions * 0.7 * avgWeight, avgWeight * 8);
 
     let scaled;
     if (maxBaseline <= 0) {
@@ -274,9 +207,10 @@ export function computeAnxiety(songs, config) {
 
     return {
         scaled,
-        rawChanges: totalRawChanges,
+        changes: totalMemberChanges,
+        spots: spotsWithChanges,
+        songCount: songs.length,
         weightedScore: Math.round(adjustedWeighted * 10) / 10,
-        transitionsDisrupted: transitionsWithChanges,
         totalTransitions,
         details
     };
@@ -287,24 +221,24 @@ export function computeAnxiety(songs, config) {
  * Generate a human-readable label for a given anxiety result.
  */
 export function anxietyLabel(result) {
-    const { scaled, rawChanges, transitionsDisrupted, totalTransitions } = result;
-    const spreadNote = transitionsDisrupted > 0
-        ? ` across ${transitionsDisrupted} of ${totalTransitions} transitions`
+    const { scaled, changes, spots, songCount } = result;
+    const spotNote = spots > 0
+        ? ` in ${spots} spot${spots === 1 ? "" : "s"} over ${songCount} songs`
         : "";
 
-    if (rawChanges === 0) {
+    if (changes === 0) {
         return "Bass player is relaxed for once. Zero gear changes — smooth sailing.";
     }
     if (scaled <= 2) {
-        return `${rawChanges} gear change${rawChanges === 1 ? "" : "s"}${spreadNote}. Bass player barely notices.`;
+        return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player barely notices.`;
     }
     if (scaled <= 5) {
-        return `${rawChanges} gear changes${spreadNote}. Bass player is rehearsing crowd work.`;
+        return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is rehearsing crowd work.`;
     }
     if (scaled <= 7) {
-        return `${rawChanges} gear changes${spreadNote}. Bass player is visibly sweating.`;
+        return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is visibly sweating.`;
     }
-    return `${rawChanges} gear changes${spreadNote}. Bass player is writing a stand-up set to fill all the dead air.`;
+    return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is writing a stand-up set to fill all the dead air.`;
 }
 
 

--- a/src/lib/anxiety.test.js
+++ b/src/lib/anxiety.test.js
@@ -215,7 +215,7 @@ describe("detectFieldChange", () => {
 
 
 // ===================================================================
-// scoreTransition
+// scoreTransition (per-prop, used for notes/details)
 // ===================================================================
 describe("scoreTransition", () => {
     const propNames = ["tuning", "capo", "instruments", "picking"];
@@ -322,16 +322,15 @@ describe("computeAnxiety — real setlist", () => {
         expect(result.totalTransitions).toBe(14);
     });
 
-    it("detects more than 5 raw gear changes", () => {
+    it("detects member-changes (deduplicated per member)", () => {
         const result = computeAnxiety(realSetlist, BAND_CONFIG);
-        // The user saw "5 gear changes across 2 of 14 transitions" — this was wrong.
-        // Manual count: nick's picking alone changes on nearly every transition.
-        expect(result.rawChanges).toBeGreaterThan(5);
+        // Per-member dedup means fewer than the old raw magnitude count
+        expect(result.changes).toBeGreaterThan(2);
     });
 
-    it("detects changes on more than 2 transitions", () => {
+    it("detects changes in more than 2 spots", () => {
         const result = computeAnxiety(realSetlist, BAND_CONFIG);
-        expect(result.transitionsDisrupted).toBeGreaterThan(2);
+        expect(result.spots).toBeGreaterThan(2);
     });
 
     it("scores anxiety higher than 3 for this change-heavy setlist", () => {
@@ -361,7 +360,6 @@ describe("computeAnxiety — real setlist", () => {
         const result = computeAnxiety(realSetlist, BAND_CONFIG);
 
         // Tubsies Requiem (clawhammer) → Run Along (picking)
-        // index 2 → index 3, detail index 2
         const t_tubsies_to_run = result.details[2];
         expect(t_tubsies_to_run.from).toBe("Tubsies Requiem");
         expect(t_tubsies_to_run.to).toBe("Run Along");
@@ -381,6 +379,152 @@ describe("computeAnxiety — real setlist", () => {
 
 
 // ===================================================================
+// computeAnxiety — tuning-heavy setlist (user's actual scenario)
+// ===================================================================
+describe("computeAnxiety — tuning-heavy 15-song setlist", () => {
+    // Simulates the user's setlist: 2 tuning changes (most expensive prop,
+    // weight 4) plus several technique changes across 15 songs.
+    const tuningSetlist = [
+        song("Song 1", "G", { mark: { instrument: "guitar", tuning: "Standard" }, nick: { instrument: "banjo", tuning: "Open G", picking: ["picking"] } }),
+        song("Song 2", "G", { mark: { instrument: "guitar", tuning: "Standard" }, nick: { instrument: "banjo", tuning: "Open G" } }),
+        song("Song 3", "D", { mark: { instrument: "guitar", tuning: "Standard" }, nick: { instrument: "banjo", tuning: "Open G" } }),
+        song("Song 4", "D", { mark: { instrument: "guitar", tuning: "DADDAD" }, nick: { instrument: "banjo", tuning: "Open D", picking: ["clawhammer"] } }),
+        song("Song 5", "D", { mark: { instrument: "guitar", tuning: "DADDAD" }, nick: { instrument: "banjo", tuning: "Open D" } }),
+        song("Song 6", "D", { mark: { instrument: "guitar", tuning: "DADDAD" }, nick: { instrument: "banjo", tuning: "Open D" } }),
+        song("Song 7", "C", { mark: { instrument: "guitar", tuning: "Standard" }, nick: { instrument: "banjo", tuning: "Open G" } }),
+        song("Song 8", "G", { mark: { instrument: "guitar", tuning: "Standard" }, nick: { instrument: "banjo", tuning: "Open G" } }),
+        song("Song 9", "G", { mark: { instrument: "guitar", tuning: "Standard" }, nick: { instrument: "banjo", tuning: "Open G" } }),
+        song("Song 10", "G", { mark: { instrument: "guitar", tuning: "Standard" }, nick: { instrument: "banjo", tuning: "Open G" } }),
+        song("Song 11", "E", { mark: { instrument: "guitar", tuning: "Standard" }, nick: { instrument: "banjo", tuning: "Open G", picking: ["slide", "picking"] } }),
+        song("Song 12", "E", { mark: { instrument: "guitar", tuning: "Standard" }, nick: { instrument: "banjo", tuning: "Open G", picking: ["picking", "slide"] } }),
+        song("Song 13", "D", { mark: { instrument: "guitar", tuning: "Standard" }, nick: { instrument: "banjo", tuning: "Open G" } }),
+        song("Song 14", "E", { mark: { instrument: "guitar", tuning: "Standard" }, nick: { instrument: "banjo", tuning: "Open G", picking: ["clawhammer", "slide"] } }),
+        song("Song 15", "D", { mark: { instrument: "guitar", tuning: "Standard" }, nick: { instrument: "banjo", tuning: "Open G", picking: ["picking"] } }),
+    ];
+
+    it("scores 7-8 for a setlist with 2 tuning changes and technique changes", () => {
+        const result = computeAnxiety(tuningSetlist, BAND_CONFIG);
+        // 2 tuning changes (weight 4 each, affecting 2 members) should drive anxiety high
+        expect(result.scaled).toBeGreaterThanOrEqual(7);
+        expect(result.scaled).toBeLessThanOrEqual(8);
+    });
+
+    it("tuning changes contribute more to weighted score than technique changes", () => {
+        const result = computeAnxiety(tuningSetlist, BAND_CONFIG);
+        // Transitions 3→4 and 6→7 have tuning changes (weight 4)
+        const tuningTransition1 = result.details[2]; // Song 3 → Song 4
+        const tuningTransition2 = result.details[5]; // Song 6 → Song 7
+        const techniqueOnly = result.details[0]; // Song 1 → Song 2 (picking change only)
+
+        expect(tuningTransition1.score).toBeGreaterThan(techniqueOnly.score);
+        expect(tuningTransition2.score).toBeGreaterThan(techniqueOnly.score);
+    });
+});
+
+
+// ===================================================================
+// computeAnxiety — low-anxiety setlist (few low-weight changes)
+// ===================================================================
+describe("computeAnxiety — low-anxiety 15-song setlist", () => {
+    // 3 spots with changes in a 15-song set, all low-weight (technique + capo).
+    // No tuning or instrument changes. Should score 1-3.
+    const mk = { instrument: "guitar", tuning: "Standard", capo: 0, picking: [] };
+    const nk = { instrument: "banjo", tuning: "Open G", capo: 0, picking: [] };
+
+    const lowSetlist = [
+        song("Song 1", "G", { mark: { ...mk }, nick: { ...nk, picking: ["clawhammer"] } }),
+        song("Song 2", "G", { mark: { ...mk }, nick: { ...nk, picking: ["clawhammer"] } }),
+        song("Song 3", "G", { mark: { ...mk }, nick: { ...nk, picking: ["clawhammer"] } }),
+        song("Song 4", "G", { mark: { ...mk }, nick: { ...nk, picking: ["clawhammer"] } }),
+        song("Song 5", "G", { mark: { ...mk }, nick: { ...nk, picking: ["clawhammer"] } }),
+        song("Song 6", "G", { mark: { ...mk }, nick: { ...nk, picking: ["slide", "picking"] } }),
+        song("Song 7", "G", { mark: { ...mk }, nick: { ...nk, picking: ["slide", "picking"] } }),
+        song("Song 8", "G", { mark: { ...mk }, nick: { ...nk, picking: ["slide", "picking"] } }),
+        song("Song 9", "G", { mark: { ...mk }, nick: { ...nk, picking: ["picking"] } }),
+        song("Song 10", "G", { mark: { ...mk }, nick: { ...nk, picking: ["picking"] } }),
+        song("Song 11", "D", { mark: { ...mk, capo: 2 }, nick: { ...nk, capo: 2, picking: ["picking"] } }),
+        song("Song 12", "D", { mark: { ...mk, capo: 2 }, nick: { ...nk, capo: 2, picking: ["picking"] } }),
+        song("Song 13", "D", { mark: { ...mk, capo: 2 }, nick: { ...nk, capo: 2, picking: ["picking"] } }),
+        song("Song 14", "D", { mark: { ...mk, capo: 2 }, nick: { ...nk, capo: 2, picking: ["picking"] } }),
+        song("Song 15", "D", { mark: { ...mk, capo: 2 }, nick: { ...nk, capo: 2, picking: ["picking"] } }),
+    ];
+
+    it("scores 1-3 for a setlist with only low-weight changes", () => {
+        const result = computeAnxiety(lowSetlist, BAND_CONFIG);
+        expect(result.spots).toBe(3);
+        // Per-member: T1 nick technique (1), T2 nick technique (1),
+        // T3 mark capo (1 member) + nick capo (1 member, max of capo vs no other change)
+        expect(result.changes).toBe(4);
+        expect(result.scaled).toBeGreaterThanOrEqual(1);
+        expect(result.scaled).toBeLessThanOrEqual(3);
+    });
+
+    it("low-weight setlist scores much lower than tuning-heavy setlist", () => {
+        const lowResult = computeAnxiety(lowSetlist, BAND_CONFIG);
+        // Compare against a setlist with 2 tuning changes (weight 4)
+        const tuningSetlist = [
+            song("T1", "G", { mark: { ...mk }, nick: { ...nk, picking: ["picking"] } }),
+            song("T2", "G", { mark: { ...mk }, nick: { ...nk } }),
+            song("T3", "D", { mark: { ...mk }, nick: { ...nk } }),
+            song("T4", "D", { mark: { ...mk, tuning: "DADDAD" }, nick: { ...nk, tuning: "Open D", picking: ["clawhammer"] } }),
+            song("T5", "D", { mark: { ...mk, tuning: "DADDAD" }, nick: { ...nk, tuning: "Open D" } }),
+            song("T6", "D", { mark: { ...mk, tuning: "DADDAD" }, nick: { ...nk, tuning: "Open D" } }),
+            song("T7", "C", { mark: { ...mk }, nick: { ...nk } }),
+            song("T8", "G", { mark: { ...mk }, nick: { ...nk } }),
+            song("T9", "G", { mark: { ...mk }, nick: { ...nk } }),
+            song("T10", "G", { mark: { ...mk }, nick: { ...nk } }),
+            song("T11", "E", { mark: { ...mk }, nick: { ...nk, picking: ["slide", "picking"] } }),
+            song("T12", "E", { mark: { ...mk }, nick: { ...nk, picking: ["picking", "slide"] } }),
+            song("T13", "D", { mark: { ...mk }, nick: { ...nk } }),
+            song("T14", "E", { mark: { ...mk }, nick: { ...nk, picking: ["clawhammer", "slide"] } }),
+            song("T15", "D", { mark: { ...mk }, nick: { ...nk, picking: ["picking"] } }),
+        ];
+        const highResult = computeAnxiety(tuningSetlist, BAND_CONFIG);
+
+        // Tuning-heavy should be at least 4 points higher
+        expect(highResult.scaled - lowResult.scaled).toBeGreaterThanOrEqual(4);
+    });
+});
+
+
+// ===================================================================
+// computeAnxiety — per-member dedup: one member changing multiple
+// props counts as ONE change at the highest weight
+// ===================================================================
+describe("computeAnxiety — per-member deduplication", () => {
+    it("nick changing capo AND picking counts as 1 change at capo weight", () => {
+        const songs = [
+            song("A", "G", { nick: { capo: 0, picking: ["picking"] } }),
+            song("B", "G", { nick: { capo: 2, picking: ["clawhammer"] } })
+        ];
+        const result = computeAnxiety(songs, BAND_CONFIG);
+        // One member changed — counts as 1, not 2
+        expect(result.changes).toBe(1);
+        expect(result.spots).toBe(1);
+    });
+
+    it("nick changing instrument + tuning + picking = 1 change at tuning weight", () => {
+        const songs = [
+            song("A", "G", { nick: { instrument: "banjo", tuning: "Open G", picking: ["picking"] } }),
+            song("B", "G", { nick: { instrument: "guitar", tuning: "Standard", picking: ["clawhammer"] } })
+        ];
+        const result = computeAnxiety(songs, BAND_CONFIG);
+        // One member, multiple props, but counts as 1 change at max weight (tuning=4)
+        expect(result.changes).toBe(1);
+    });
+
+    it("two members each changing = 2 changes", () => {
+        const songs = [
+            song("A", "G", { mark: { tuning: "Standard" }, nick: { tuning: "Open G" } }),
+            song("B", "G", { mark: { tuning: "DADDAD" }, nick: { tuning: "Open D" } })
+        ];
+        const result = computeAnxiety(songs, BAND_CONFIG);
+        expect(result.changes).toBe(2);
+    });
+});
+
+
+// ===================================================================
 // computeAnxiety — varying inputs
 // ===================================================================
 describe("computeAnxiety — no changes", () => {
@@ -390,8 +534,8 @@ describe("computeAnxiety — no changes", () => {
         );
         const result = computeAnxiety(songs, BAND_CONFIG);
         expect(result.scaled).toBe(0);
-        expect(result.rawChanges).toBe(0);
-        expect(result.transitionsDisrupted).toBe(0);
+        expect(result.changes).toBe(0);
+        expect(result.spots).toBe(0);
     });
 });
 
@@ -403,8 +547,8 @@ describe("computeAnxiety — single transition", () => {
         ];
         const result = computeAnxiety(songs, BAND_CONFIG);
         expect(result.totalTransitions).toBe(1);
-        expect(result.rawChanges).toBe(1);
-        expect(result.transitionsDisrupted).toBe(1);
+        expect(result.changes).toBe(1);
+        expect(result.spots).toBe(1);
         expect(result.details).toHaveLength(1);
         expect(result.scaled).toBeGreaterThan(0);
     });
@@ -420,7 +564,7 @@ describe("computeAnxiety — every transition has changes", () => {
             }));
         }
         const result = computeAnxiety(songs, BAND_CONFIG);
-        expect(result.transitionsDisrupted).toBe(9);
+        expect(result.spots).toBe(9);
         expect(result.scaled).toBeGreaterThanOrEqual(7);
     });
 });
@@ -447,8 +591,8 @@ describe("computeAnxiety — grouped vs scattered changes", () => {
         const scatteredResult = computeAnxiety(scattered, BAND_CONFIG);
         const groupedResult = computeAnxiety(grouped, BAND_CONFIG);
 
-        // Scattered should have higher anxiety (more transitions disrupted)
-        expect(scatteredResult.transitionsDisrupted).toBeGreaterThan(groupedResult.transitionsDisrupted);
+        // Scattered should have higher anxiety (more spots disrupted)
+        expect(scatteredResult.spots).toBeGreaterThan(groupedResult.spots);
         // The spread factor should make scattered score higher
         expect(scatteredResult.weightedScore).toBeGreaterThan(groupedResult.weightedScore);
     });
@@ -484,8 +628,8 @@ describe("computeAnxiety — weight sensitivity", () => {
         const result = computeAnxiety(baseSongs, zeroConfig);
         expect(result.weightedScore).toBe(0);
         expect(result.scaled).toBe(0);
-        // But raw changes should still be counted
-        expect(result.rawChanges).toBeGreaterThan(0);
+        // Per-member changes still happen, but max weight per member is 0
+        expect(result.changes).toBe(0);
     });
 });
 
@@ -501,7 +645,7 @@ describe("computeAnxiety — no props", () => {
         ];
         const result = computeAnxiety(songs, { general: { weighting: {} }, props: {} });
         expect(result.scaled).toBe(0);
-        expect(result.rawChanges).toBe(0);
+        expect(result.changes).toBe(0);
     });
 });
 
@@ -526,7 +670,7 @@ describe("computeAnxiety — edge cases", () => {
     it("handles songs with no performance data", () => {
         const songs = [song("A", "G"), song("B", "D"), song("C", "E")];
         const result = computeAnxiety(songs, BAND_CONFIG);
-        expect(result.rawChanges).toBe(0);
+        expect(result.changes).toBe(0);
         expect(result.scaled).toBe(0);
     });
 
@@ -538,7 +682,13 @@ describe("computeAnxiety — edge cases", () => {
         ];
         const result = computeAnxiety(songs, BAND_CONFIG);
         // nick disappears then reappears — instrument set changes
-        expect(result.rawChanges).toBeGreaterThan(0);
+        expect(result.changes).toBeGreaterThan(0);
+    });
+
+    it("includes songCount in result", () => {
+        const songs = [song("A", "G"), song("B", "G"), song("C", "G")];
+        const result = computeAnxiety(songs, BAND_CONFIG);
+        expect(result.songCount).toBe(3);
     });
 });
 
@@ -559,10 +709,9 @@ describe("computeAnxiety — scaling", () => {
         const short = computeAnxiety(makeAlternating(5), BAND_CONFIG);
         const long = computeAnxiety(makeAlternating(20), BAND_CONFIG);
 
-        // Both have ~100% disrupted transitions, so spread ratio ≈ 1
-        // But longer setlist has more total changes. Scaled should be similar
-        // because baselines also scale with song count.
-        expect(short.rawChanges).toBeLessThan(long.rawChanges);
+        // Both have ~100% disrupted spots, so spread ratio ≈ 1
+        // Longer setlist has more total changes.
+        expect(short.changes).toBeLessThan(long.changes);
         // Scaled should be roughly comparable (both near max for their length)
         expect(Math.abs(short.scaled - long.scaled)).toBeLessThanOrEqual(2);
     });
@@ -574,36 +723,37 @@ describe("computeAnxiety — scaling", () => {
 // ===================================================================
 describe("anxietyLabel", () => {
     it("returns relaxed message for 0 changes", () => {
-        const label = anxietyLabel({ scaled: 0, rawChanges: 0, transitionsDisrupted: 0, totalTransitions: 14 });
+        const label = anxietyLabel({ scaled: 0, changes: 0, spots: 0, songCount: 15 });
         expect(label).toContain("relaxed");
     });
 
     it("returns 'barely notices' for low anxiety", () => {
-        const label = anxietyLabel({ scaled: 1, rawChanges: 2, transitionsDisrupted: 1, totalTransitions: 14 });
+        const label = anxietyLabel({ scaled: 1, changes: 2, spots: 1, songCount: 15 });
         expect(label).toContain("barely notices");
-        expect(label).toContain("1 of 14 transitions");
+        expect(label).toContain("1 spot over 15 songs");
     });
 
     it("returns 'crowd work' for medium anxiety", () => {
-        const label = anxietyLabel({ scaled: 4, rawChanges: 8, transitionsDisrupted: 5, totalTransitions: 14 });
+        const label = anxietyLabel({ scaled: 4, changes: 5, spots: 3, songCount: 15 });
         expect(label).toContain("crowd work");
+        expect(label).toContain("3 spots over 15 songs");
     });
 
     it("returns 'sweating' for high anxiety", () => {
-        const label = anxietyLabel({ scaled: 7, rawChanges: 15, transitionsDisrupted: 10, totalTransitions: 14 });
+        const label = anxietyLabel({ scaled: 7, changes: 10, spots: 7, songCount: 15 });
         expect(label).toContain("sweating");
     });
 
     it("returns 'stand-up set' for extreme anxiety", () => {
-        const label = anxietyLabel({ scaled: 9, rawChanges: 25, transitionsDisrupted: 14, totalTransitions: 14 });
+        const label = anxietyLabel({ scaled: 9, changes: 18, spots: 12, songCount: 15 });
         expect(label).toContain("stand-up set");
     });
 
-    it("pluralizes 'gear change' correctly", () => {
-        expect(anxietyLabel({ scaled: 1, rawChanges: 1, transitionsDisrupted: 1, totalTransitions: 5 }))
-            .toContain("1 gear change ");
-        expect(anxietyLabel({ scaled: 2, rawChanges: 3, transitionsDisrupted: 2, totalTransitions: 5 }))
-            .toContain("3 gear changes");
+    it("pluralizes 'change' correctly", () => {
+        expect(anxietyLabel({ scaled: 1, changes: 1, spots: 1, songCount: 5 }))
+            .toContain("1 change ");
+        expect(anxietyLabel({ scaled: 2, changes: 3, spots: 2, songCount: 5 }))
+            .toContain("3 changes");
     });
 });
 
@@ -630,19 +780,19 @@ describe("transition-by-transition detail verification", () => {
         expect(t.changes.picking.changed).toBe(false);
     });
 
-    it("transition 2→3: instrument + tuning + picking change", () => {
+    it("transition 2→3: instrument + tuning + picking = 1 member at max weight (tuning=4)", () => {
         const result = computeAnxiety(setlist, BAND_CONFIG);
         const t = result.details[1];
         expect(t.changes.instruments.changed).toBe(true);
-        expect(t.changes.instruments.magnitude).toBe(1);
         expect(t.changes.tuning.changed).toBe(true);
         expect(t.changes.picking.changed).toBe(true);
         expect(t.changes.capo.changed).toBe(false);
-        // Score: instrument(3) + tuning(4) + technique(1) = 8
-        expect(t.score).toBe(8);
+        // Per-member: nick changes 3 things, score = max weight (tuning=4)
+        expect(t.score).toBe(4);
+        expect(t.memberChanges).toBe(1);
     });
 
-    it("transition 3→4: capo change only (delta=2)", () => {
+    it("transition 3→4: capo change only = 1 member at capo weight (2)", () => {
         const result = computeAnxiety(setlist, BAND_CONFIG);
         const t = result.details[2];
         expect(t.changes.capo.changed).toBe(true);
@@ -650,31 +800,32 @@ describe("transition-by-transition detail verification", () => {
         expect(t.changes.instruments.changed).toBe(false);
         expect(t.changes.tuning.changed).toBe(false);
         expect(t.changes.picking.changed).toBe(false);
-        // Score: capo magnitude 2 * weight 2 = 4
-        expect(t.score).toBe(4);
+        // Per-member: nick changes capo only, score = capo weight (2)
+        expect(t.score).toBe(2);
+        expect(t.memberChanges).toBe(1);
     });
 
-    it("transition 4→5: everything changes", () => {
+    it("transition 4→5: everything changes = 1 member at max weight (tuning=4)", () => {
         const result = computeAnxiety(setlist, BAND_CONFIG);
         const t = result.details[3];
         expect(t.changes.instruments.changed).toBe(true);
         expect(t.changes.tuning.changed).toBe(true);
         expect(t.changes.capo.changed).toBe(true);
-        expect(t.changes.capo.magnitude).toBe(2); // |2-0|
         expect(t.changes.picking.changed).toBe(true);
-        // instrument(3) + tuning(4) + capo(2*2=4) + technique(1) = 12
-        expect(t.score).toBe(12);
+        // Per-member: nick changes everything, score = max weight (tuning=4)
+        expect(t.score).toBe(4);
+        expect(t.memberChanges).toBe(1);
     });
 
-    it("total rawChanges matches sum of detail rawChanges", () => {
+    it("total changes matches sum of detail memberChanges", () => {
         const result = computeAnxiety(setlist, BAND_CONFIG);
-        const sumFromDetails = result.details.reduce((sum, d) => sum + d.rawChanges, 0);
-        expect(result.rawChanges).toBe(sumFromDetails);
+        const sumFromDetails = result.details.reduce((sum, d) => sum + d.memberChanges, 0);
+        expect(result.changes).toBe(sumFromDetails);
     });
 
-    it("transitionsDisrupted matches count of non-zero detail entries", () => {
+    it("spots matches count of non-zero detail entries", () => {
         const result = computeAnxiety(setlist, BAND_CONFIG);
-        const disrupted = result.details.filter(d => d.rawChanges > 0).length;
-        expect(result.transitionsDisrupted).toBe(disrupted);
+        const spots = result.details.filter(d => d.memberChanges > 0).length;
+        expect(result.spots).toBe(spots);
     });
 });

--- a/src/lib/anxiety.test.js
+++ b/src/lib/anxiety.test.js
@@ -1,0 +1,680 @@
+import { describe, it, expect } from "vitest";
+import { computeAnxiety, anxietyLabel, _internals } from "./anxiety.js";
+
+const { normalizeValue, displayValue, detectInstrumentSetChange, detectFieldChange, scoreTransition } = _internals;
+
+// ---------------------------------------------------------------------------
+// Test config matching the user's real band setup
+// ---------------------------------------------------------------------------
+
+const BAND_CONFIG = {
+    general: {
+        weighting: {
+            tuning: 4,
+            capo: 2,
+            instrument: 3,
+            technique: 1,
+            positionMiss: 8,
+            earlyCover: 2,
+            earlyInstrumental: 2
+        }
+    },
+    props: {
+        tuning: {
+            kind: "instrumentField",
+            field: "tuning",
+            summaryLabel: "tuning changes",
+            minStreak: 2,
+            allowChangeOnLastSong: true
+        },
+        capo: {
+            kind: "instrumentDelta",
+            field: "capo",
+            summaryLabel: "capo steps",
+            minStreak: 2,
+            allowChangeOnLastSong: true
+        },
+        instruments: {
+            kind: "instrumentSet",
+            weightKey: "instrument",
+            summaryLabel: "instrument swaps",
+            minStreak: 2,
+            allowChangeOnLastSong: true,
+            mutuallyExclusive: []
+        },
+        picking: {
+            kind: "instrumentField",
+            field: "picking",
+            weightKey: "technique",
+            summaryLabel: "technique changes",
+            minStreak: 1,
+            allowChangeOnLastSong: true
+        }
+    }
+};
+
+
+// ---------------------------------------------------------------------------
+// Helper: build a song with performance data
+// ---------------------------------------------------------------------------
+function song(name, key, members = {}) {
+    const performance = {};
+    for (const [memberName, setup] of Object.entries(members)) {
+        performance[memberName] = {
+            instrument: setup.instrument || "guitar",
+            tuning: setup.tuning || "Standard",
+            capo: setup.capo || 0,
+            picking: setup.picking || []
+        };
+    }
+    return { id: name.toLowerCase().replace(/\s+/g, "-"), name, key, performance };
+}
+
+
+// ===================================================================
+// normalizeValue
+// ===================================================================
+describe("normalizeValue", () => {
+    it("returns empty string for null/undefined", () => {
+        expect(normalizeValue(null)).toBe("");
+        expect(normalizeValue(undefined)).toBe("");
+    });
+
+    it("stringifies primitives", () => {
+        expect(normalizeValue("Standard")).toBe("Standard");
+        expect(normalizeValue(2)).toBe("2");
+    });
+
+    it("sorts and joins arrays", () => {
+        expect(normalizeValue(["picking", "slide"])).toBe("picking,slide");
+        expect(normalizeValue(["slide", "picking"])).toBe("picking,slide");
+        expect(normalizeValue([])).toBe("");
+    });
+});
+
+
+// ===================================================================
+// detectInstrumentSetChange
+// ===================================================================
+describe("detectInstrumentSetChange", () => {
+    it("detects no change when instruments stay the same", () => {
+        const prev = { nick: { instrument: "banjo" }, mark: { instrument: "guitar" } };
+        const next = { nick: { instrument: "banjo" }, mark: { instrument: "guitar" } };
+        const result = detectInstrumentSetChange(prev, next);
+        expect(result.changed).toBe(false);
+        expect(result.magnitude).toBe(0);
+    });
+
+    it("detects instrument swap for one member", () => {
+        const prev = { nick: { instrument: "banjo" } };
+        const next = { nick: { instrument: "guitar" } };
+        const result = detectInstrumentSetChange(prev, next);
+        expect(result.changed).toBe(true);
+        expect(result.magnitude).toBe(1);
+        expect(result.notes[0]).toContain("nick instrument banjo -> guitar");
+    });
+
+    it("detects member appearing (on/off)", () => {
+        const prev = {};
+        const next = { nick: { instrument: "banjo" } };
+        const result = detectInstrumentSetChange(prev, next);
+        expect(result.changed).toBe(true);
+        expect(result.magnitude).toBe(1);
+    });
+
+    it("detects member disappearing (on/off)", () => {
+        const prev = { nick: { instrument: "banjo" } };
+        const next = {};
+        const result = detectInstrumentSetChange(prev, next);
+        expect(result.changed).toBe(true);
+        expect(result.magnitude).toBe(1);
+    });
+
+    it("counts per-member changes independently", () => {
+        const prev = { nick: { instrument: "banjo" }, mark: { instrument: "guitar" } };
+        const next = { nick: { instrument: "guitar" }, mark: { instrument: "bass" } };
+        const result = detectInstrumentSetChange(prev, next);
+        expect(result.magnitude).toBe(2);
+    });
+});
+
+
+// ===================================================================
+// detectFieldChange
+// ===================================================================
+describe("detectFieldChange", () => {
+    it("detects tuning change for shared member", () => {
+        const prev = { mark: { tuning: "DADDAD" } };
+        const next = { mark: { tuning: "Standard" } };
+        const result = detectFieldChange(prev, next, "tuning", false);
+        expect(result.changed).toBe(true);
+        expect(result.magnitude).toBe(1);
+    });
+
+    it("detects no change when tuning is same", () => {
+        const prev = { mark: { tuning: "Standard" } };
+        const next = { mark: { tuning: "Standard" } };
+        const result = detectFieldChange(prev, next, "tuning", false);
+        expect(result.changed).toBe(false);
+    });
+
+    it("detects capo delta change (scaleByDelta=true)", () => {
+        const prev = { nick: { capo: 0 } };
+        const next = { nick: { capo: 2 } };
+        const result = detectFieldChange(prev, next, "capo", true);
+        expect(result.changed).toBe(true);
+        expect(result.magnitude).toBe(2);
+    });
+
+    it("handles array fields (picking/techniques)", () => {
+        const prev = { nick: { picking: ["picking"] } };
+        const next = { nick: { picking: ["clawhammer"] } };
+        const result = detectFieldChange(prev, next, "picking", false);
+        expect(result.changed).toBe(true);
+        expect(result.magnitude).toBe(1);
+    });
+
+    it("detects change from empty array to populated array", () => {
+        const prev = { nick: { picking: [] } };
+        const next = { nick: { picking: ["slide"] } };
+        const result = detectFieldChange(prev, next, "picking", false);
+        expect(result.changed).toBe(true);
+        expect(result.magnitude).toBe(1);
+    });
+
+    it("detects change between multi-element arrays", () => {
+        const prev = { nick: { picking: ["picking", "slide"] } };
+        const next = { nick: { picking: ["clawhammer"] } };
+        const result = detectFieldChange(prev, next, "picking", false);
+        expect(result.changed).toBe(true);
+        expect(result.magnitude).toBe(1);
+    });
+
+    it("treats same-elements-different-order arrays as identical", () => {
+        const prev = { nick: { picking: ["slide", "picking"] } };
+        const next = { nick: { picking: ["picking", "slide"] } };
+        const result = detectFieldChange(prev, next, "picking", false);
+        expect(result.changed).toBe(false);
+    });
+
+    it("skips members only in one song (instrument set handles that)", () => {
+        const prev = { mark: { tuning: "Standard" } };
+        const next = { nick: { tuning: "Open G" } };
+        const result = detectFieldChange(prev, next, "tuning", false);
+        // Neither member is in both songs — no field comparison possible
+        expect(result.changed).toBe(false);
+    });
+
+    it("counts changes per member independently", () => {
+        const prev = { nick: { capo: 0 }, mark: { capo: 0 } };
+        const next = { nick: { capo: 2 }, mark: { capo: 3 } };
+        const result = detectFieldChange(prev, next, "capo", true);
+        expect(result.magnitude).toBe(5); // |0-2| + |0-3|
+    });
+});
+
+
+// ===================================================================
+// scoreTransition
+// ===================================================================
+describe("scoreTransition", () => {
+    const propNames = ["tuning", "capo", "instruments", "picking"];
+    const propConfig = BAND_CONFIG.props;
+    const weights = BAND_CONFIG.general.weighting;
+
+    it("returns zero for first song (no prev)", () => {
+        const s = song("Test", "G", { nick: { instrument: "banjo" } });
+        const result = scoreTransition(null, s, propNames, propConfig, weights);
+        expect(result.score).toBe(0);
+        for (const p of propNames) {
+            expect(result.changes[p].changed).toBe(false);
+        }
+    });
+
+    it("scores a tuning change correctly", () => {
+        const s1 = song("A", "G", { mark: { tuning: "DADDAD" } });
+        const s2 = song("B", "G", { mark: { tuning: "Standard" } });
+        const result = scoreTransition(s1, s2, propNames, propConfig, weights);
+        expect(result.changes.tuning.changed).toBe(true);
+        expect(result.changes.tuning.magnitude).toBe(1);
+        expect(result.score).toBe(4); // magnitude 1 * weight 4
+    });
+
+    it("scores a capo change with delta", () => {
+        const s1 = song("A", "G", { mark: { capo: 0 } });
+        const s2 = song("B", "G", { mark: { capo: 3 } });
+        const result = scoreTransition(s1, s2, propNames, propConfig, weights);
+        expect(result.changes.capo.changed).toBe(true);
+        expect(result.changes.capo.magnitude).toBe(3);
+        expect(result.score).toBe(6); // magnitude 3 * weight 2
+    });
+
+    it("scores a picking/technique change", () => {
+        const s1 = song("A", "G", { nick: { picking: ["picking"] } });
+        const s2 = song("B", "G", { nick: { picking: ["clawhammer"] } });
+        const result = scoreTransition(s1, s2, propNames, propConfig, weights);
+        expect(result.changes.picking.changed).toBe(true);
+        expect(result.changes.picking.magnitude).toBe(1);
+        expect(result.score).toBe(1); // magnitude 1 * technique weight 1
+    });
+
+    it("scores multiple simultaneous changes", () => {
+        const s1 = song("A", "G", { nick: { instrument: "banjo", tuning: "Open G", picking: ["picking"] } });
+        const s2 = song("B", "G", { nick: { instrument: "guitar", tuning: "Standard", picking: ["clawhammer"] } });
+        const result = scoreTransition(s1, s2, propNames, propConfig, weights);
+        expect(result.changes.instruments.changed).toBe(true);
+        expect(result.changes.tuning.changed).toBe(true);
+        expect(result.changes.picking.changed).toBe(true);
+        // instrument(3) + tuning(4) + technique(1) = 8
+        expect(result.score).toBe(8);
+    });
+});
+
+
+// ===================================================================
+// computeAnxiety — the user's actual setlist
+// ===================================================================
+describe("computeAnxiety — real setlist", () => {
+    // Recreate the user's 15-song setlist from their bug report
+    const realSetlist = [
+        song("O' the Topside", "E", {
+            mark: { instrument: "guitar", tuning: "DADDAD" },
+            nick: { instrument: "banjo", tuning: "Open G", picking: ["picking", "slide"] }
+        }),
+        song("Bob Dylan", "D", {}),  // no members listed
+        song("Tubsies Requiem", "G", {
+            nick: { picking: ["clawhammer"] }
+        }),
+        song("Run Along", "C", {
+            mark: { tuning: "Standard" },
+            nick: { picking: ["picking"] }
+        }),
+        song("In a Station Wagon", "G", {
+            nick: { picking: ["clawhammer"] }
+        }),
+        song("Courtroom Sketch Artist", "G", {
+            nick: { picking: ["picking"] }
+        }),
+        song("Trying to get to the Port", "G", {}),
+        song("Saturn V", "C", {
+            nick: { picking: ["clawhammer"] }
+        }),
+        song("Bottle of Soot", "D", {
+            nick: { picking: ["slide", "picking"] }
+        }),
+        song("Farewell to Cheyenne", "", {
+            nick: { picking: ["picking"] }
+        }),
+        song("Lester Young", "G", {
+            nick: { picking: ["slide", "picking"] }
+        }),
+        song("Bad On Me", "D", {
+            mark: { capo: 2 },
+            nick: { capo: 2, picking: ["picking"] }
+        }),
+        song("Jump Down Turn Around", "E", {}),
+        song("To Rob A Bank", "D", {}),
+        song("Locomotive Smoke", "D", {})
+    ];
+
+    it("detects the correct number of total transitions", () => {
+        const result = computeAnxiety(realSetlist, BAND_CONFIG);
+        expect(result.totalTransitions).toBe(14);
+    });
+
+    it("detects more than 5 raw gear changes", () => {
+        const result = computeAnxiety(realSetlist, BAND_CONFIG);
+        // The user saw "5 gear changes across 2 of 14 transitions" — this was wrong.
+        // Manual count: nick's picking alone changes on nearly every transition.
+        expect(result.rawChanges).toBeGreaterThan(5);
+    });
+
+    it("detects changes on more than 2 transitions", () => {
+        const result = computeAnxiety(realSetlist, BAND_CONFIG);
+        expect(result.transitionsDisrupted).toBeGreaterThan(2);
+    });
+
+    it("scores anxiety higher than 3 for this change-heavy setlist", () => {
+        const result = computeAnxiety(realSetlist, BAND_CONFIG);
+        expect(result.scaled).toBeGreaterThan(3);
+    });
+
+    it("produces a detail entry for each transition", () => {
+        const result = computeAnxiety(realSetlist, BAND_CONFIG);
+        expect(result.details).toHaveLength(14);
+        expect(result.details[0].from).toBe("O' the Topside");
+        expect(result.details[0].to).toBe("Bob Dylan");
+    });
+
+    it("detail entries include per-prop change breakdowns", () => {
+        const result = computeAnxiety(realSetlist, BAND_CONFIG);
+        // Transition from song 1 (O' the Topside) to song 2 (Bob Dylan) —
+        // mark and nick disappear, so instruments should detect on/off.
+        const t1 = result.details[0];
+        expect(t1.changes.instruments).toBeDefined();
+        // Both mark and nick disappear
+        expect(t1.changes.instruments.changed).toBe(true);
+        expect(t1.changes.instruments.magnitude).toBe(2);
+    });
+
+    it("detects nick's picking changes across transitions", () => {
+        const result = computeAnxiety(realSetlist, BAND_CONFIG);
+
+        // Tubsies Requiem (clawhammer) → Run Along (picking)
+        // index 2 → index 3, detail index 2
+        const t_tubsies_to_run = result.details[2];
+        expect(t_tubsies_to_run.from).toBe("Tubsies Requiem");
+        expect(t_tubsies_to_run.to).toBe("Run Along");
+        expect(t_tubsies_to_run.changes.picking.changed).toBe(true);
+
+        // Run Along (picking) → In a Station Wagon (clawhammer)
+        const t_run_to_station = result.details[3];
+        expect(t_run_to_station.from).toBe("Run Along");
+        expect(t_run_to_station.to).toBe("In a Station Wagon");
+        expect(t_run_to_station.changes.picking.changed).toBe(true);
+
+        // In a Station Wagon (clawhammer) → Courtroom Sketch Artist (picking)
+        const t_station_to_court = result.details[4];
+        expect(t_station_to_court.changes.picking.changed).toBe(true);
+    });
+});
+
+
+// ===================================================================
+// computeAnxiety — varying inputs
+// ===================================================================
+describe("computeAnxiety — no changes", () => {
+    it("returns 0 for identical songs", () => {
+        const songs = Array.from({ length: 10 }, (_, i) =>
+            song(`Song ${i + 1}`, "G", { nick: { instrument: "guitar", tuning: "Standard", picking: [] } })
+        );
+        const result = computeAnxiety(songs, BAND_CONFIG);
+        expect(result.scaled).toBe(0);
+        expect(result.rawChanges).toBe(0);
+        expect(result.transitionsDisrupted).toBe(0);
+    });
+});
+
+describe("computeAnxiety — single transition", () => {
+    it("handles a 2-song setlist with one change", () => {
+        const songs = [
+            song("A", "G", { nick: { tuning: "Standard" } }),
+            song("B", "G", { nick: { tuning: "DADGAD" } })
+        ];
+        const result = computeAnxiety(songs, BAND_CONFIG);
+        expect(result.totalTransitions).toBe(1);
+        expect(result.rawChanges).toBe(1);
+        expect(result.transitionsDisrupted).toBe(1);
+        expect(result.details).toHaveLength(1);
+        expect(result.scaled).toBeGreaterThan(0);
+    });
+});
+
+describe("computeAnxiety — every transition has changes", () => {
+    it("returns high anxiety when every song boundary has gear swaps", () => {
+        const songs = [];
+        for (let i = 0; i < 10; i++) {
+            songs.push(song(`Song ${i + 1}`, "G", {
+                nick: { tuning: i % 2 === 0 ? "Standard" : "DADGAD", picking: i % 2 === 0 ? ["picking"] : ["clawhammer"] },
+                mark: { instrument: i % 2 === 0 ? "guitar" : "banjo", capo: i % 3 }
+            }));
+        }
+        const result = computeAnxiety(songs, BAND_CONFIG);
+        expect(result.transitionsDisrupted).toBe(9);
+        expect(result.scaled).toBeGreaterThanOrEqual(7);
+    });
+});
+
+describe("computeAnxiety — grouped vs scattered changes", () => {
+    it("scores scattered changes higher than grouped changes (same total)", () => {
+        // Scattered: change on every other transition
+        const scattered = [];
+        for (let i = 0; i < 10; i++) {
+            scattered.push(song(`S${i + 1}`, "G", {
+                nick: { tuning: i % 2 === 0 ? "Standard" : "DADGAD" }
+            }));
+        }
+
+        // Grouped: all changes in a burst, then stable
+        const grouped = [];
+        for (let i = 0; i < 10; i++) {
+            const tunings = ["Standard", "DADGAD", "Open G", "Drop D", "Standard"];
+            grouped.push(song(`G${i + 1}`, "G", {
+                nick: { tuning: i < 5 ? tunings[i] : "Standard" }
+            }));
+        }
+
+        const scatteredResult = computeAnxiety(scattered, BAND_CONFIG);
+        const groupedResult = computeAnxiety(grouped, BAND_CONFIG);
+
+        // Scattered should have higher anxiety (more transitions disrupted)
+        expect(scatteredResult.transitionsDisrupted).toBeGreaterThan(groupedResult.transitionsDisrupted);
+        // The spread factor should make scattered score higher
+        expect(scatteredResult.weightedScore).toBeGreaterThan(groupedResult.weightedScore);
+    });
+});
+
+
+// ===================================================================
+// computeAnxiety — different weight configurations
+// ===================================================================
+describe("computeAnxiety — weight sensitivity", () => {
+    const baseSongs = [
+        song("A", "G", { nick: { tuning: "Standard", picking: ["picking"] } }),
+        song("B", "G", { nick: { tuning: "DADGAD", picking: ["clawhammer"] } }),
+        song("C", "G", { nick: { tuning: "Open G", picking: ["picking"] } })
+    ];
+
+    it("higher tuning weight increases anxiety for tuning-heavy setlist", () => {
+        const lowWeight = { ...BAND_CONFIG, general: { weighting: { ...BAND_CONFIG.general.weighting, tuning: 1 } } };
+        const highWeight = { ...BAND_CONFIG, general: { weighting: { ...BAND_CONFIG.general.weighting, tuning: 10 } } };
+
+        const lowResult = computeAnxiety(baseSongs, lowWeight);
+        const highResult = computeAnxiety(baseSongs, highWeight);
+
+        expect(highResult.weightedScore).toBeGreaterThan(lowResult.weightedScore);
+    });
+
+    it("zero weight means prop changes don't affect weighted score", () => {
+        const zeroConfig = {
+            general: { weighting: { tuning: 0, capo: 0, instrument: 0, technique: 0 } },
+            props: BAND_CONFIG.props
+        };
+
+        const result = computeAnxiety(baseSongs, zeroConfig);
+        expect(result.weightedScore).toBe(0);
+        expect(result.scaled).toBe(0);
+        // But raw changes should still be counted
+        expect(result.rawChanges).toBeGreaterThan(0);
+    });
+});
+
+
+// ===================================================================
+// computeAnxiety — no props configured
+// ===================================================================
+describe("computeAnxiety — no props", () => {
+    it("returns 0 anxiety when config has no props", () => {
+        const songs = [
+            song("A", "G", { nick: { tuning: "Standard" } }),
+            song("B", "G", { nick: { tuning: "DADGAD" } })
+        ];
+        const result = computeAnxiety(songs, { general: { weighting: {} }, props: {} });
+        expect(result.scaled).toBe(0);
+        expect(result.rawChanges).toBe(0);
+    });
+});
+
+
+// ===================================================================
+// computeAnxiety — edge cases
+// ===================================================================
+describe("computeAnxiety — edge cases", () => {
+    it("handles single song", () => {
+        const result = computeAnxiety([song("Only", "G")], BAND_CONFIG);
+        expect(result.scaled).toBe(0);
+        expect(result.totalTransitions).toBe(1); // Math.max(1, 0)
+        expect(result.details).toHaveLength(0);
+    });
+
+    it("handles empty setlist", () => {
+        const result = computeAnxiety([], BAND_CONFIG);
+        expect(result.scaled).toBe(0);
+        expect(result.details).toHaveLength(0);
+    });
+
+    it("handles songs with no performance data", () => {
+        const songs = [song("A", "G"), song("B", "D"), song("C", "E")];
+        const result = computeAnxiety(songs, BAND_CONFIG);
+        expect(result.rawChanges).toBe(0);
+        expect(result.scaled).toBe(0);
+    });
+
+    it("handles songs where members appear and disappear", () => {
+        const songs = [
+            song("A", "G", { nick: { instrument: "banjo" } }),
+            song("B", "G", {}),
+            song("C", "G", { nick: { instrument: "banjo" } })
+        ];
+        const result = computeAnxiety(songs, BAND_CONFIG);
+        // nick disappears then reappears — instrument set changes
+        expect(result.rawChanges).toBeGreaterThan(0);
+    });
+});
+
+
+// ===================================================================
+// computeAnxiety — large setlists
+// ===================================================================
+describe("computeAnxiety — scaling", () => {
+    it("anxiety scales with setlist length", () => {
+        function makeAlternating(count) {
+            return Array.from({ length: count }, (_, i) =>
+                song(`S${i + 1}`, "G", {
+                    nick: { tuning: i % 2 === 0 ? "Standard" : "DADGAD" }
+                })
+            );
+        }
+
+        const short = computeAnxiety(makeAlternating(5), BAND_CONFIG);
+        const long = computeAnxiety(makeAlternating(20), BAND_CONFIG);
+
+        // Both have ~100% disrupted transitions, so spread ratio ≈ 1
+        // But longer setlist has more total changes. Scaled should be similar
+        // because baselines also scale with song count.
+        expect(short.rawChanges).toBeLessThan(long.rawChanges);
+        // Scaled should be roughly comparable (both near max for their length)
+        expect(Math.abs(short.scaled - long.scaled)).toBeLessThanOrEqual(2);
+    });
+});
+
+
+// ===================================================================
+// anxietyLabel
+// ===================================================================
+describe("anxietyLabel", () => {
+    it("returns relaxed message for 0 changes", () => {
+        const label = anxietyLabel({ scaled: 0, rawChanges: 0, transitionsDisrupted: 0, totalTransitions: 14 });
+        expect(label).toContain("relaxed");
+    });
+
+    it("returns 'barely notices' for low anxiety", () => {
+        const label = anxietyLabel({ scaled: 1, rawChanges: 2, transitionsDisrupted: 1, totalTransitions: 14 });
+        expect(label).toContain("barely notices");
+        expect(label).toContain("1 of 14 transitions");
+    });
+
+    it("returns 'crowd work' for medium anxiety", () => {
+        const label = anxietyLabel({ scaled: 4, rawChanges: 8, transitionsDisrupted: 5, totalTransitions: 14 });
+        expect(label).toContain("crowd work");
+    });
+
+    it("returns 'sweating' for high anxiety", () => {
+        const label = anxietyLabel({ scaled: 7, rawChanges: 15, transitionsDisrupted: 10, totalTransitions: 14 });
+        expect(label).toContain("sweating");
+    });
+
+    it("returns 'stand-up set' for extreme anxiety", () => {
+        const label = anxietyLabel({ scaled: 9, rawChanges: 25, transitionsDisrupted: 14, totalTransitions: 14 });
+        expect(label).toContain("stand-up set");
+    });
+
+    it("pluralizes 'gear change' correctly", () => {
+        expect(anxietyLabel({ scaled: 1, rawChanges: 1, transitionsDisrupted: 1, totalTransitions: 5 }))
+            .toContain("1 gear change ");
+        expect(anxietyLabel({ scaled: 2, rawChanges: 3, transitionsDisrupted: 2, totalTransitions: 5 }))
+            .toContain("3 gear changes");
+    });
+});
+
+
+// ===================================================================
+// Comprehensive transition-by-transition verification
+// ===================================================================
+describe("transition-by-transition detail verification", () => {
+    const setlist = [
+        song("Song 1", "G", { nick: { instrument: "guitar", tuning: "Standard", capo: 0, picking: ["picking"] } }),
+        song("Song 2", "G", { nick: { instrument: "guitar", tuning: "DADGAD", capo: 0, picking: ["picking"] } }),
+        song("Song 3", "G", { nick: { instrument: "banjo", tuning: "Open G", capo: 0, picking: ["clawhammer"] } }),
+        song("Song 4", "G", { nick: { instrument: "banjo", tuning: "Open G", capo: 2, picking: ["clawhammer"] } }),
+        song("Song 5", "G", { nick: { instrument: "guitar", tuning: "Standard", capo: 0, picking: ["picking"] } })
+    ];
+
+    it("transition 1→2: tuning change only", () => {
+        const result = computeAnxiety(setlist, BAND_CONFIG);
+        const t = result.details[0];
+        expect(t.changes.tuning.changed).toBe(true);
+        expect(t.changes.tuning.magnitude).toBe(1);
+        expect(t.changes.instruments.changed).toBe(false);
+        expect(t.changes.capo.changed).toBe(false);
+        expect(t.changes.picking.changed).toBe(false);
+    });
+
+    it("transition 2→3: instrument + tuning + picking change", () => {
+        const result = computeAnxiety(setlist, BAND_CONFIG);
+        const t = result.details[1];
+        expect(t.changes.instruments.changed).toBe(true);
+        expect(t.changes.instruments.magnitude).toBe(1);
+        expect(t.changes.tuning.changed).toBe(true);
+        expect(t.changes.picking.changed).toBe(true);
+        expect(t.changes.capo.changed).toBe(false);
+        // Score: instrument(3) + tuning(4) + technique(1) = 8
+        expect(t.score).toBe(8);
+    });
+
+    it("transition 3→4: capo change only (delta=2)", () => {
+        const result = computeAnxiety(setlist, BAND_CONFIG);
+        const t = result.details[2];
+        expect(t.changes.capo.changed).toBe(true);
+        expect(t.changes.capo.magnitude).toBe(2);
+        expect(t.changes.instruments.changed).toBe(false);
+        expect(t.changes.tuning.changed).toBe(false);
+        expect(t.changes.picking.changed).toBe(false);
+        // Score: capo magnitude 2 * weight 2 = 4
+        expect(t.score).toBe(4);
+    });
+
+    it("transition 4→5: everything changes", () => {
+        const result = computeAnxiety(setlist, BAND_CONFIG);
+        const t = result.details[3];
+        expect(t.changes.instruments.changed).toBe(true);
+        expect(t.changes.tuning.changed).toBe(true);
+        expect(t.changes.capo.changed).toBe(true);
+        expect(t.changes.capo.magnitude).toBe(2); // |2-0|
+        expect(t.changes.picking.changed).toBe(true);
+        // instrument(3) + tuning(4) + capo(2*2=4) + technique(1) = 12
+        expect(t.score).toBe(12);
+    });
+
+    it("total rawChanges matches sum of detail rawChanges", () => {
+        const result = computeAnxiety(setlist, BAND_CONFIG);
+        const sumFromDetails = result.details.reduce((sum, d) => sum + d.rawChanges, 0);
+        expect(result.rawChanges).toBe(sumFromDetails);
+    });
+
+    it("transitionsDisrupted matches count of non-zero detail entries", () => {
+        const result = computeAnxiety(setlist, BAND_CONFIG);
+        const disrupted = result.details.filter(d => d.rawChanges > 0).length;
+        expect(result.transitionsDisrupted).toBe(disrupted);
+    });
+});

--- a/src/lib/anxiety.test.js
+++ b/src/lib/anxiety.test.js
@@ -657,7 +657,7 @@ describe("computeAnxiety — edge cases", () => {
     it("handles single song", () => {
         const result = computeAnxiety([song("Only", "G")], BAND_CONFIG);
         expect(result.scaled).toBe(0);
-        expect(result.totalTransitions).toBe(1); // Math.max(1, 0)
+        expect(result.totalTransitions).toBe(0);
         expect(result.details).toHaveLength(0);
     });
 

--- a/src/lib/components/band/BandScreen.svelte
+++ b/src/lib/components/band/BandScreen.svelte
@@ -345,6 +345,8 @@
             </div>
         </div>
 
+        <hr class="section-divider" />
+
         <!-- Members Section -->
         <div class="section-block">
             <h3 class="section-label">Members</h3>
@@ -352,7 +354,7 @@
             {#if store.bandMemberEntries?.length === 0}
                 <div class="empty-state">
                     <p class="empty-title">No members yet</p>
-                    <p class="empty-sub">Add your first band member below.</p>
+                    <p class="empty-sub">Add members who switch instruments, tunings, or capos between songs. If someone plays the same gear every song, they don't need to be here.</p>
                 </div>
             {/if}
 
@@ -386,11 +388,18 @@
             </div>
         </div>
 
-        <!-- Advanced Config Link -->
-        <button class="card link-card" onclick={() => { store.bandSubView = "advanced"; }}>
-            <span class="link-card-label">Advanced Config</span>
-            <span class="link-card-arrow">&rsaquo;</span>
-        </button>
+        <hr class="section-divider" />
+
+        <!-- Config Section -->
+        <div class="section-block">
+            <h3 class="section-label">Config</h3>
+            <button class="card link-card" onclick={() => { store.bandSubView = "advanced"; }}>
+                <span class="link-card-label">Generation settings, weights, and order rules</span>
+                <span class="link-card-arrow">&rsaquo;</span>
+            </button>
+        </div>
+
+        <hr class="section-divider" />
 
         <!-- Data Section -->
         <div class="section-block">
@@ -419,12 +428,23 @@
                 </div>
             </div>
 
+            <button class="danger-btn" onclick={() => store.deleteAllData()}>Delete All Data</button>
+        </div>
+
+        <hr class="section-divider" />
+
+        <!-- Account Section -->
+        <div class="section-block">
+            <h3 class="section-label">Account</h3>
+
             {#if store.connectAddress}
                 <div class="connect-info">
-                    <span class="field-label">Connected to</span>
+                    <span class="field-label">Connected as</span>
                     <span class="connect-address">{store.connectAddress}</span>
-                    <button class="danger-btn small" onclick={() => store.disconnectStorage()}>Disconnect</button>
                 </div>
+                <button class="danger-btn" onclick={() => store.disconnectStorage()}>Disconnect</button>
+            {:else}
+                <p class="empty-sub">Not connected.</p>
             {/if}
         </div>
     {/if}
@@ -433,7 +453,7 @@
 <style>
     .band-screen {
         display: grid;
-        gap: 0.75rem;
+        gap: 0.85rem;
         padding: 1rem;
         max-width: 640px;
         margin: 0 auto;
@@ -523,10 +543,17 @@
         color: var(--muted, #617086);
     }
 
+    /* Section divider */
+    .section-divider {
+        border: none;
+        border-top: 1px solid var(--line, rgba(27, 49, 80, 0.1));
+        margin: 0.5rem 0;
+    }
+
     /* Section */
     .section-block {
         display: grid;
-        gap: 0.5rem;
+        gap: 0.65rem;
     }
 
     .section-label {
@@ -536,7 +563,7 @@
         letter-spacing: 0.08em;
         color: var(--muted, #617086);
         margin: 0;
-        padding-top: 0.25rem;
+        padding-top: 0;
     }
 
     /* Fields */

--- a/src/lib/components/help/HelpScreen.svelte
+++ b/src/lib/components/help/HelpScreen.svelte
@@ -4,8 +4,8 @@
 </script>
 
 <div class="help-screen">
-    <h1 class="help-title">How Set Roll Works</h1>
-    <p class="help-intro">Set Roll builds setlists that flow well on stage. It looks at tuning changes, instrument swaps, capo moves, and other gear transitions to put your songs in an order that keeps the chaos to a minimum.</p>
+    <h1 class="help-title">How Setlist Roller Works</h1>
+    <p class="help-intro">Setlist Roller builds setlists that flow well on stage. It looks at tuning changes, instrument swaps, capo moves, and other gear transitions to put your songs in an order that keeps the chaos to a minimum.</p>
 
     <section class="help-section">
         <h2>Getting started</h2>
@@ -16,15 +16,15 @@
             </li>
             <li>
                 <strong>Set up their instruments</strong>
-                <p>For each member, add the instruments they play. Then add the tunings for each instrument. If your guitarist plays Standard and DADGAD, add both. This is how Set Roll knows what changes cost time on stage.</p>
+                <p>For each member, add the instruments they play. Then add the tunings for each instrument. If your guitarist plays Standard and DADGAD, add both. This is how Setlist Roller knows what changes cost time on stage.</p>
             </li>
             <li>
                 <strong>Add your songs</strong>
-                <p>Go to the <button class="inline-link" onclick={() => store.navigate("songs")}>Songs</button> tab and add your catalog. For each song, tell Set Roll which instrument and tuning each tracked member uses. The more detail you give, the smarter the setlists.</p>
+                <p>Go to the <button class="inline-link" onclick={() => store.navigate("songs")}>Songs</button> tab and add your catalog. For each song, tell Setlist Roller which instrument and tuning each tracked member uses. The more detail you give, the smarter the setlists.</p>
             </li>
             <li>
                 <strong>Roll a setlist</strong>
-                <p>Go to the <button class="inline-link" onclick={() => store.navigate("roll")}>Roll</button> tab, pick how many songs you want, and hit the dice. Set Roll will crunch the numbers and build you an optimized setlist.</p>
+                <p>Go to the <button class="inline-link" onclick={() => store.navigate("roll")}>Roll</button> tab, pick how many songs you want, and hit the dice. Setlist Roller will crunch the numbers and build you an optimized setlist.</p>
             </li>
         </ol>
     </section>

--- a/src/lib/components/help/HelpScreen.svelte
+++ b/src/lib/components/help/HelpScreen.svelte
@@ -1,0 +1,174 @@
+<script>
+    import { getContext } from "svelte";
+    const store = getContext("app");
+</script>
+
+<div class="help-screen">
+    <h1 class="help-title">How Set Roll Works</h1>
+    <p class="help-intro">Set Roll builds setlists that flow well on stage. It looks at tuning changes, instrument swaps, capo moves, and other gear transitions to put your songs in an order that keeps the chaos to a minimum.</p>
+
+    <section class="help-section">
+        <h2>Getting started</h2>
+        <ol class="steps">
+            <li>
+                <strong>Add members who switch gear</strong>
+                <p>Go to the <button class="inline-link" onclick={() => store.navigate("band")}>Band</button> tab. Only add members who change instruments, tunings, or capos between songs. If your drummer plays the same kit every song, they don't need to be here — this is about tracking transitions, not taking attendance.</p>
+            </li>
+            <li>
+                <strong>Set up their instruments</strong>
+                <p>For each member, add the instruments they play. Then add the tunings for each instrument. If your guitarist plays Standard and DADGAD, add both. This is how Set Roll knows what changes cost time on stage.</p>
+            </li>
+            <li>
+                <strong>Add your songs</strong>
+                <p>Go to the <button class="inline-link" onclick={() => store.navigate("songs")}>Songs</button> tab and add your catalog. For each song, tell Set Roll which instrument and tuning each tracked member uses. The more detail you give, the smarter the setlists.</p>
+            </li>
+            <li>
+                <strong>Roll a setlist</strong>
+                <p>Go to the <button class="inline-link" onclick={() => store.navigate("roll")}>Roll</button> tab, pick how many songs you want, and hit the dice. Set Roll will crunch the numbers and build you an optimized setlist.</p>
+            </li>
+        </ol>
+    </section>
+
+    <section class="help-section">
+        <h2>What "incomplete" means</h2>
+        <p>Songs show an <span class="example-pill">incomplete</span> badge when a tracked band member is missing their instrument setup for that song. The song list shows exactly what's missing — e.g. "nick: needs instrument". Tap the song to fill in the gaps.</p>
+    </section>
+
+    <section class="help-section">
+        <h2>After you roll</h2>
+        <ul class="tips">
+            <li><strong>Drag to reorder</strong> — not happy with a song's position? Grab the handle and move it.</li>
+            <li><strong>Lock it in</strong> — prevents accidental re-rolls. You can still unlock and roll again.</li>
+            <li><strong>Save to Greatest Hits</strong> — stores the setlist so you can view or print it later.</li>
+            <li><strong>Print</strong> — from the <button class="inline-link" onclick={() => store.navigate("saved")}>Saved</button> tab, open a setlist and hit print. Big fonts, clean layout, made for the stage.</li>
+        </ul>
+    </section>
+
+    <section class="help-section">
+        <h2>Tweaking the results</h2>
+        <ul class="tips">
+            <li><strong>Constraints</strong> — if a member has multiple instruments or tunings, you can limit which ones to include in a setlist.</li>
+            <li><strong>Variety slider</strong> — controls how adventurous the algorithm gets. Low = predictable, high = spicy.</li>
+            <li><strong>Max covers / instrumentals</strong> — cap how many of each type end up in the set.</li>
+        </ul>
+    </section>
+
+    <section class="help-section">
+        <h2>Data & backups</h2>
+        <p>Your songs and settings live in remoteStorage. Saved setlists are stored locally on this device. Use <strong>Export</strong> from the <button class="inline-link" onclick={() => store.navigate("band")}>Band</button> tab to download everything as a JSON file — songs, config, and saved setlists. Keep backups!</p>
+    </section>
+</div>
+
+<style>
+    .help-screen {
+        display: grid;
+        gap: 1rem;
+        padding: 0.5rem;
+        max-width: 540px;
+        margin: 0 auto;
+    }
+
+    .help-title {
+        font-size: 1.3rem;
+        font-weight: 800;
+        margin: 0;
+        color: var(--ink, #182230);
+    }
+
+    .help-intro {
+        margin: 0;
+        font-size: 0.88rem;
+        color: var(--muted, #8a95a5);
+        line-height: 1.5;
+    }
+
+    .help-section {
+        border: 1px solid rgba(27, 49, 80, 0.1);
+        border-radius: var(--radius-lg, 16px);
+        background: rgba(255, 255, 255, 0.76);
+        padding: 1rem;
+        display: grid;
+        gap: 0.5rem;
+    }
+
+    .help-section h2 {
+        margin: 0;
+        font-size: 0.95rem;
+        font-weight: 800;
+        color: var(--ink, #182230);
+    }
+
+    .help-section p {
+        margin: 0;
+        font-size: 0.85rem;
+        color: var(--muted, #8a95a5);
+        line-height: 1.55;
+    }
+
+    .help-section p strong {
+        color: var(--ink, #182230);
+    }
+
+    .steps {
+        margin: 0;
+        padding-left: 1.4rem;
+        display: grid;
+        gap: 0.6rem;
+    }
+
+    .steps li {
+        font-size: 0.88rem;
+        font-weight: 700;
+        color: var(--ink, #182230);
+        line-height: 1.4;
+    }
+
+    .steps li p {
+        font-weight: 400;
+        margin: 0.2rem 0 0;
+    }
+
+    .tips {
+        margin: 0;
+        padding-left: 1.4rem;
+        display: grid;
+        gap: 0.4rem;
+    }
+
+    .tips li {
+        font-size: 0.85rem;
+        color: var(--muted, #8a95a5);
+        line-height: 1.5;
+    }
+
+    .tips li strong {
+        color: var(--ink, #182230);
+    }
+
+    .inline-link {
+        background: none;
+        border: none;
+        padding: 0;
+        font: inherit;
+        font-weight: 700;
+        color: var(--accent, #e15b37);
+        cursor: pointer;
+        text-decoration: underline;
+        text-decoration-thickness: 1.5px;
+        text-underline-offset: 2px;
+    }
+
+    .inline-link:hover {
+        color: #c94020;
+    }
+
+    .example-pill {
+        display: inline-block;
+        padding: 0.1rem 0.4rem;
+        border-radius: 999px;
+        background: rgba(255, 160, 40, 0.15);
+        color: #b07020;
+        font-size: 0.75rem;
+        font-weight: 700;
+    }
+</style>

--- a/src/lib/components/layout/BottomNav.svelte
+++ b/src/lib/components/layout/BottomNav.svelte
@@ -4,8 +4,10 @@
 
   const tabs = [
     { id: "roll", label: "Roll", icon: "\u2684" },
+    { id: "saved", label: "Saved", icon: "\u2605" },
     { id: "songs", label: "Songs", icon: "\u266B" },
     { id: "band", label: "Band", icon: "\u2699" },
+    { id: "help", label: "Help", icon: "?" },
   ];
 </script>
 

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -35,15 +35,12 @@
 {/if}
 
 <header class="top-bar">
-  <span class="band-name">{store.appTitle}</span>
+  <div class="title-group">
+    <span class="conn-dot" class:connected={store.connectionStatus === 'connected'} class:syncing={store.syncActivelyRunning}></span>
+    <span class="band-name">{store.appTitle}</span>
+  </div>
 
   <div class="right">
-    {#if store.syncIndicatorVisible}
-      <div class="sync-status">
-        <span class="spinner"></span>
-        <span class="sync-label">{store.syncStatusLabel}</span>
-      </div>
-    {/if}
 
     <div class="menu-wrapper">
       <button class="menu-btn" onclick={toggleMenu} aria-label="Menu">
@@ -81,8 +78,39 @@
     z-index: 200;
   }
 
-  .band-name {
+  .title-group {
     grid-column: 2;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .conn-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--line);
+    flex-shrink: 0;
+    transition: background 300ms ease, box-shadow 300ms ease;
+  }
+
+  .conn-dot.connected {
+    background: #1f8f61;
+    box-shadow: 0 0 4px rgba(31, 143, 97, 0.4);
+  }
+
+  .conn-dot.syncing {
+    background: var(--accent);
+    box-shadow: 0 0 6px rgba(225, 91, 55, 0.4);
+    animation: dot-pulse 1s ease-in-out infinite;
+  }
+
+  @keyframes dot-pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.5; transform: scale(1.4); }
+  }
+
+  .band-name {
     font-size: 16px;
     font-weight: 700;
     color: var(--ink);
@@ -98,33 +126,6 @@
     align-items: center;
     justify-content: flex-end;
     gap: 8px;
-  }
-
-  .sync-status {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 12px;
-    color: var(--muted);
-  }
-
-  .spinner {
-    width: 12px;
-    height: 12px;
-    border: 2px solid var(--line);
-    border-top-color: var(--accent);
-    border-radius: 50%;
-    animation: spin 0.8s linear infinite;
-  }
-
-  @keyframes spin {
-    to {
-      transform: rotate(360deg);
-    }
-  }
-
-  .sync-label {
-    white-space: nowrap;
   }
 
   .menu-wrapper {

--- a/src/lib/components/roll/RollScreen.svelte
+++ b/src/lib/components/roll/RollScreen.svelte
@@ -6,16 +6,50 @@
 
   const store = getContext("app");
 
+  let showConfetti = $state(false);
+  let diceValue = $state(6);
+  let landed = $state(false);
+
+  // Watch for generation completing with a result
+  let prevGenerating = false;
+  $effect(() => {
+    const generating = store.isGenerating;
+    if (prevGenerating && !generating) {
+      diceValue = Math.floor(Math.random() * 6) + 1;
+      if (store.generatedSetlist) {
+        landed = true;
+        showConfetti = true;
+        setTimeout(() => { showConfetti = false; landed = false; }, 1200);
+      }
+    }
+    prevGenerating = generating;
+  });
+
+  // Dice pip layouts: [x, y] positions on a 0-1 grid for each face value
+  const PIP_LAYOUTS = {
+    1: [[0.5, 0.5]],
+    2: [[0.25, 0.25], [0.75, 0.75]],
+    3: [[0.25, 0.25], [0.5, 0.5], [0.75, 0.75]],
+    4: [[0.25, 0.25], [0.75, 0.25], [0.25, 0.75], [0.75, 0.75]],
+    5: [[0.25, 0.25], [0.75, 0.25], [0.5, 0.5], [0.25, 0.75], [0.75, 0.75]],
+    6: [[0.25, 0.22], [0.75, 0.22], [0.25, 0.5], [0.75, 0.5], [0.25, 0.78], [0.75, 0.78]],
+  };
+
+  // New band detection — only songs are required to roll
+  let hasSongs = $derived((store.songs || []).length > 0);
+  let readyToRoll = $derived(hasSongs);
+
   function handleRoll() {
-    store.generate();
+    if (settingsEl) settingsEl.open = false;
+    store.requestRoll();
+  }
+
+  function handleLock() {
+    store.lockSetlist();
   }
 
   function handleSaveSetlist() {
     store.saveCurrentSetlist();
-  }
-
-  function handleRemoveSaved(id) {
-    store.removeSavedSetlist(id);
   }
 
   // Determine which members have multiple instrument/tuning options worth toggling
@@ -47,6 +81,10 @@
   function varietyToTemp(v) { return 0.3 + (v / 100) * 1.7; }
   function tempToVariety(t) { return Math.round(((t - 0.3) / 1.7) * 100); }
   let varietyValue = $derived(tempToVariety(store.generationOptions.randomness?.temperature ?? 0.85));
+
+  let settingsTab = $state("constraints");
+  let hasConstraints = $derived(membersWithChoices().length > 0);
+  let settingsEl = $state(null);
 
   // ---- drag-to-reorder ----
   function handleEditSong(songId) {
@@ -113,15 +151,94 @@
           onchange={(v) => store.updateGenerationField("count", v)}
         />
       </div>
-      <button class="roll-btn" onclick={handleRoll}>Roll</button>
+      <button class="roll-btn" class:rolling={store.isGenerating} class:landed class:disabled={!readyToRoll} disabled={!readyToRoll} onclick={handleRoll} aria-label="Roll setlist">
+        <span class="dice-container" class:rolling={store.isGenerating}>
+          <svg class="dice-svg" viewBox="0 0 56 56" xmlns="http://www.w3.org/2000/svg">
+            <rect x="3" y="3" width="50" height="50" rx="10" ry="10"
+              fill="#fff" stroke="rgba(0,0,0,0.08)" stroke-width="1"/>
+            {#each PIP_LAYOUTS[diceValue] as [px, py]}
+              <circle cx={6 + px * 44} cy={6 + py * 44} r="4.5" fill="#e15b37"/>
+            {/each}
+          </svg>
+        </span>
+        <span class="roll-label">{store.isGenerating ? "Rolling..." : "Roll"}</span>
+        {#if showConfetti}
+          <span class="confetti-burst">
+            {#each Array(12) as _, i}
+              <span class="confetti-dot" style="--i:{i}"></span>
+            {/each}
+          </span>
+        {/if}
+      </button>
     </div>
-  </div>
 
-  <!-- Constraints section -->
-  {#if membersWithChoices().length > 0}
-    <details class="section-details">
-      <summary class="section-summary"><span>Constraints</span><svg class="chevron-down" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg></summary>
-      <div class="section-body">
+    <!-- Settings (inside hero) -->
+    <details class="settings-drawer" bind:this={settingsEl}>
+      <summary class="settings-toggle">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+      <span>Settings</span>
+    </summary>
+    <div class="settings-body">
+      {#if hasConstraints}
+        <div class="settings-tabs">
+          <button class="settings-tab" class:active={settingsTab === "constraints"} onclick={() => { settingsTab = "constraints"; }}>Demands</button>
+          <button class="settings-tab" class:active={settingsTab === "chaos"} onclick={() => { settingsTab = "chaos"; }}>Tweak the Chaos</button>
+        </div>
+      {/if}
+
+      {#if settingsTab === "chaos" || !hasConstraints}
+        <div class="quick-row">
+          <label class="adv-field">
+            <span>Max covers</span>
+            <input
+              type="number"
+              min="0"
+              value={store.generationOptions.maxCovers}
+              oninput={(e) => store.updateGenerationField("maxCovers", Number(e.currentTarget.value))}
+            />
+          </label>
+          <label class="adv-field">
+            <span>Max instrumentals</span>
+            <input
+              type="number"
+              min="0"
+              value={store.generationOptions.maxInstrumentals}
+              oninput={(e) => store.updateGenerationField("maxInstrumentals", Number(e.currentTarget.value))}
+            />
+          </label>
+        </div>
+
+        <div class="variety-field">
+          <div class="variety-header">
+            <span class="variety-label">Variety</span>
+            <span class="variety-hint">{varietyValue >= 100 ? "YOLO 🤘" : varietyValue < 30 ? "Safe pick" : varietyValue > 70 ? "Hold my beer" : "Feels right"}</span>
+          </div>
+          <input
+            class="variety-slider"
+            type="range"
+            min="0"
+            max="100"
+            step="1"
+            value={varietyValue}
+            oninput={(e) => store.updateGenerationField("randomness.temperature", varietyToTemp(Number(e.currentTarget.value)))}
+          />
+          <div class="variety-labels">
+            <span>Safe pick</span>
+            <span>Hold my beer</span>
+          </div>
+        </div>
+
+        <label class="adv-field">
+          <span>Seed <span class="field-hint">(leave 0 for random)</span></span>
+          <input
+            type="number"
+            value={store.generationOptions.seed}
+            oninput={(e) => store.updateGenerationField("seed", Number(e.currentTarget.value))}
+          />
+        </label>
+      {/if}
+
+      {#if settingsTab === "constraints" && hasConstraints}
         {#each membersWithChoices() as memberName}
           <div class="constraint-member">
             <span class="constraint-member-name">{memberName}</span>
@@ -190,76 +307,39 @@
             {/if}
           </div>
         {/each}
-      </div>
-    </details>
-  {/if}
-
-  <!-- Quick Settings -->
-  <details class="section-details">
-    <summary class="section-summary"><span>Quick Settings</span><svg class="chevron-down" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg></summary>
-    <div class="section-body">
-      <div class="quick-row">
-        <label class="adv-field">
-          <span>Max covers</span>
-          <input
-            type="number"
-            min="0"
-            value={store.generationOptions.maxCovers}
-            oninput={(e) => store.updateGenerationField("maxCovers", Number(e.currentTarget.value))}
-          />
-        </label>
-        <label class="adv-field">
-          <span>Max instrumentals</span>
-          <input
-            type="number"
-            min="0"
-            value={store.generationOptions.maxInstrumentals}
-            oninput={(e) => store.updateGenerationField("maxInstrumentals", Number(e.currentTarget.value))}
-          />
-        </label>
-      </div>
-
-      <div class="variety-field">
-        <div class="variety-header">
-          <span class="variety-label">Variety</span>
-          <span class="variety-hint">{varietyValue < 30 ? "Predictable" : varietyValue > 70 ? "Adventurous" : "Balanced"}</span>
-        </div>
-        <input
-          class="variety-slider"
-          type="range"
-          min="0"
-          max="100"
-          step="1"
-          value={varietyValue}
-          oninput={(e) => store.updateGenerationField("randomness.temperature", varietyToTemp(Number(e.currentTarget.value)))}
-        />
-        <div class="variety-labels">
-          <span>Predictable</span>
-          <span>Adventurous</span>
-        </div>
-      </div>
-
-      <label class="adv-field">
-        <span>Seed <span class="field-hint">(leave 0 for random)</span></span>
-        <input
-          type="number"
-          value={store.generationOptions.seed}
-          oninput={(e) => store.updateGenerationField("seed", Number(e.currentTarget.value))}
-        />
-      </label>
+      {/if}
     </div>
   </details>
+  </div>
+
+  <!-- Getting Started -->
+  {#if !readyToRoll}
+    <div class="onboarding-card">
+      <div class="onboarding-illustration">🎸🥁🎤</div>
+      <h2 class="onboarding-title">Almost showtime!</h2>
+      <p class="onboarding-desc">Add some songs to your catalog and Set Roll will build you a setlist.</p>
+      <ol class="onboarding-steps">
+        <li class:done={hasSongs}>
+          <span class="step-icon">{hasSongs ? "✓" : "1"}</span>
+          <span class="step-text">
+            {#if hasSongs}
+              Songs added
+            {:else}
+              <button class="step-link" onclick={() => { store.navigate("songs"); }}>Add some songs</button>
+              <span class="step-hint">Your catalog of tunes. Covers, originals, whatever you play.</span>
+            {/if}
+          </span>
+        </li>
+      </ol>
+      <p class="onboarding-tip">Got members who switch guitars, tunings, or capos between songs? Add them in each song and Set Roll will minimize gear changes.</p>
+      <p class="onboarding-footer">Then come back here and hit Roll.</p>
+      <button class="help-toggle" onclick={() => store.navigate("help")}>How does this work?</button>
+    </div>
+  {/if}
 
   <!-- Setlist result -->
   {#if store.generatedSetlist}
     <section class="result-section">
-      <div class="summary-bar">
-        <div class="stat-pill"><span class="stat-val">{store.generatedSetlist.songs.length}</span><span class="stat-label">songs</span></div>
-        <div class="stat-pill"><span class="stat-val">{store.generatedSetlist.summary.score.toFixed(1)}</span><span class="stat-label">score</span></div>
-        <div class="stat-pill"><span class="stat-val">{store.generatedSetlist.summary.covers}</span><span class="stat-label">covers</span></div>
-        <div class="stat-pill"><span class="stat-val">{store.generatedSetlist.summary.instrumentals}</span><span class="stat-label">inst.</span></div>
-      </div>
-
       <div class="song-list" bind:this={songListEl}>
         {#each store.generatedSetlist.songs as song, i}
           <div class="song-list-item" class:drag-over={dragIndex !== null && dragOverIndex === i && dragIndex !== i}>
@@ -274,44 +354,74 @@
         {/each}
       </div>
 
-      <button class="save-set-btn" onclick={handleSaveSetlist}>Save this set</button>
+      <div class="setlist-actions">
+        {#if store.setlistLocked}
+          <div class="locked-badge">🔒 Locked in</div>
+          {#if store.setlistSaved}
+            <div class="saved-badge">✓ Saved</div>
+          {:else}
+            <button class="save-set-btn secondary" onclick={handleSaveSetlist}>Save to Greatest Hits</button>
+          {/if}
+        {:else}
+          <button class="save-set-btn" onclick={handleLock}>Lock it in 🔒</button>
+        {/if}
+      </div>
+
+      <details class="debug-details">
+        <summary class="debug-summary">Roll stats</summary>
+        <div class="debug-body">
+          <div class="debug-row">
+            <span class="debug-label">Songs</span>
+            <span class="debug-val">{store.generatedSetlist.songs.length}</span>
+          </div>
+          <div class="debug-row">
+            <span class="debug-label">Covers</span>
+            <span class="debug-val">{store.generatedSetlist.summary.covers}</span>
+          </div>
+          <div class="debug-row">
+            <span class="debug-label">Instrumentals</span>
+            <span class="debug-val">{store.generatedSetlist.summary.instrumentals}</span>
+          </div>
+          <div class="debug-row">
+            <span class="debug-label">Score</span>
+            <span class="debug-val">{store.generatedSetlist.summary.score.toFixed(1)}</span>
+          </div>
+          <p class="debug-hint">Score = total penalty points from gear changes, position misses, and constraint violations. Lower is better — 0 means no compromises were made.</p>
+        </div>
+      </details>
     </section>
   {/if}
 
-  <!-- Saved sets -->
-  {#if store.savedSetlists?.length > 0}
-    <section class="saved-section">
-      <h3 class="saved-heading">Saved sets</h3>
-      <div class="saved-scroll">
-        {#each store.savedSetlists as saved}
-          <div class="saved-card">
-            <div class="saved-card-top">
-              <span class="saved-songs">{saved.songs?.length || 0} songs</span>
-              <button class="saved-remove" onclick={() => handleRemoveSaved(saved.id)} aria-label="Remove saved set">&times;</button>
-            </div>
-            {#if saved.summary}
-              <div class="saved-stats">
-                <span>Score {saved.summary.score}</span>
-                <span>{saved.summary.covers}c / {saved.summary.instrumentals}i</span>
-              </div>
-            {/if}
-            {#if saved.seed != null}
-              <span class="saved-seed">seed {saved.seed}</span>
-            {/if}
-          </div>
-        {/each}
+  {#if store.pendingRollConfirm}
+    <div class="confirm-overlay" onclick={store.cancelRoll}>
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div class="confirm-dialog" onclick={(e) => e.stopPropagation()}>
+        <p class="confirm-title">This setlist is locked in.</p>
+        <p class="confirm-desc">Rolling again will wipe it. You sure?</p>
+        <div class="confirm-actions">
+          <button class="confirm-btn cancel" onclick={store.cancelRoll}>Keep it</button>
+          <button class="confirm-btn proceed" onclick={store.confirmRoll}>Roll anyway</button>
+        </div>
       </div>
-    </section>
+    </div>
   {/if}
+
 </div>
 
 <style>
   .roll-screen {
     display: grid;
-    gap: 1rem;
-    padding: 0.75rem;
+    gap: 0.75rem;
+    padding: 0.5rem;
     max-width: 540px;
     margin: 0 auto;
+  }
+
+  @media (min-width: 400px) {
+    .roll-screen {
+      gap: 1rem;
+      padding: 0.75rem;
+    }
   }
 
   /* Hero */
@@ -324,20 +434,28 @@
     -webkit-backdrop-filter: blur(16px);
     border-radius: var(--radius-lg, 16px);
     border: 1px solid rgba(27, 49, 80, 0.1);
-    padding: 0.75rem;
+    padding: 0.6rem;
     display: grid;
-    gap: 0.6rem;
+    gap: 0.5rem;
+  }
+
+  @media (min-width: 400px) {
+    .hero {
+      padding: 0.75rem;
+      gap: 0.6rem;
+    }
   }
 
   .hero-row {
     display: flex;
     align-items: flex-end;
-    gap: 0.75rem;
+    gap: 0.5rem;
   }
 
   .count-control {
     display: grid;
     gap: 0.25rem;
+    flex-shrink: 0;
   }
 
   .field-label {
@@ -348,71 +466,257 @@
     color: var(--muted, #8a95a5);
   }
 
+  /* ---- Roll button ---- */
   .roll-btn {
     flex: 1;
-    min-height: 2.8rem;
+    min-width: 0;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.45rem;
+    height: 2.8rem;
+    margin-bottom: 1px;
+    padding: 0 0.8rem;
     border: none;
-    border-radius: var(--radius-md, 12px);
-    background: var(--accent, #e15b37);
+    border-radius: 14px;
+    background: linear-gradient(140deg, #e15b37 0%, #c94020 100%);
     color: #fff;
-    font-size: 1.05rem;
-    font-weight: 800;
     cursor: pointer;
     touch-action: manipulation;
     -webkit-tap-highlight-color: transparent;
-    transition: background 140ms ease, transform 80ms ease;
-  }
-
-  .roll-btn:hover,
-  .roll-btn:active {
-    background: #c64724;
-  }
-
-  .roll-btn:active {
-    transform: scale(0.97);
-  }
-
-  /* Collapsible sections */
-  .section-details {
-    border: 1px solid rgba(27, 49, 80, 0.1);
-    border-radius: var(--radius-lg, 16px);
-    background: rgba(255, 255, 255, 0.76);
+    box-shadow:
+      0 4px 12px rgba(225, 91, 55, 0.35),
+      inset 0 1px 0 rgba(255, 255, 255, 0.18);
+    transition: transform 120ms ease, box-shadow 120ms ease;
     overflow: hidden;
   }
 
-  .section-summary {
-    padding: 0.7rem 0.85rem;
-    font-weight: 700;
-    font-size: 0.9rem;
-    color: var(--ink, #182230);
+  .roll-btn:hover {
+    transform: translateY(-2px);
+    box-shadow:
+      0 8px 24px rgba(225, 91, 55, 0.4),
+      inset 0 1px 0 rgba(255, 255, 255, 0.18);
+  }
+
+  .roll-btn.disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    pointer-events: none;
+    box-shadow: none;
+  }
+
+  .roll-btn:active:not(.rolling) {
+    transform: scale(0.97);
+    box-shadow:
+      0 2px 6px rgba(225, 91, 55, 0.25),
+      inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  }
+
+  .roll-btn.rolling {
+    pointer-events: none;
+    background: linear-gradient(140deg, #d4502e 0%, #b83818 100%);
+  }
+
+  .roll-btn.landed {
+    animation: btn-land 300ms ease;
+  }
+
+  @keyframes btn-land {
+    0%   { transform: scale(1); }
+    40%  { transform: scale(1.04); }
+    100% { transform: scale(1); }
+  }
+
+  /* ---- Dice graphic ---- */
+  .dice-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    flex-shrink: 0;
+    filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.15));
+    transition: transform 150ms ease;
+  }
+
+  @media (min-width: 400px) {
+    .dice-container {
+      width: 36px;
+      height: 36px;
+    }
+  }
+
+  .roll-btn:hover .dice-container:not(.rolling) {
+    animation: dice-hover 500ms ease;
+  }
+
+  .dice-container.rolling {
+    animation: dice-roll 0.5s cubic-bezier(0.25, 0.1, 0.25, 1) infinite;
+  }
+
+  .dice-svg {
+    width: 100%;
+    height: 100%;
+  }
+
+  .roll-label {
+    font-size: 0.95rem;
+    font-weight: 800;
+    letter-spacing: 0.02em;
+  }
+
+  @media (min-width: 400px) {
+    .roll-label {
+      font-size: 1.1rem;
+    }
+  }
+
+  @keyframes dice-hover {
+    0%, 100% { transform: rotate(0deg); }
+    20%  { transform: rotate(-12deg) scale(1.05); }
+    60%  { transform: rotate(8deg) scale(1.05); }
+    80%  { transform: rotate(-3deg); }
+  }
+
+  @keyframes dice-roll {
+    0%   { transform: rotate(0deg) scale(1) translateY(0); }
+    15%  { transform: rotate(50deg) scale(0.9) translateY(-3px); }
+    30%  { transform: rotate(-30deg) scale(1.05) translateY(1px); }
+    50%  { transform: rotate(180deg) scale(0.92) translateY(-4px); }
+    65%  { transform: rotate(240deg) scale(1.02) translateY(0); }
+    80%  { transform: rotate(310deg) scale(0.95) translateY(-2px); }
+    100% { transform: rotate(360deg) scale(1) translateY(0); }
+  }
+
+  /* ---- Confetti burst ---- */
+  .confetti-burst {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    pointer-events: none;
+    z-index: 10;
+  }
+
+  .confetti-dot {
+    position: absolute;
+    width: 6px;
+    height: 6px;
+    opacity: 0;
+    animation: confetti-fly 800ms ease-out forwards;
+    /* Each dot gets a unique angle from --i */
+    --angle: calc(var(--i) * 30deg);
+    --dist: 55px;
+  }
+
+  /* Shapes: mix circles and squares */
+  .confetti-dot:nth-child(odd) { border-radius: 50%; }
+  .confetti-dot:nth-child(even) { border-radius: 1px; transform: rotate(45deg); }
+
+  .confetti-dot:nth-child(1)  { background: #e15b37; --dist: 50px; }
+  .confetti-dot:nth-child(2)  { background: #4c75f4; --dist: 60px; }
+  .confetti-dot:nth-child(3)  { background: #f4c84c; --dist: 45px; }
+  .confetti-dot:nth-child(4)  { background: #1f8f61; --dist: 65px; }
+  .confetti-dot:nth-child(5)  { background: #e15b37; --dist: 55px; }
+  .confetti-dot:nth-child(6)  { background: #9b59b6; --dist: 50px; }
+  .confetti-dot:nth-child(7)  { background: #f4c84c; --dist: 60px; }
+  .confetti-dot:nth-child(8)  { background: #4c75f4; --dist: 45px; }
+  .confetti-dot:nth-child(9)  { background: #1f8f61; --dist: 65px; }
+  .confetti-dot:nth-child(10) { background: #e15b37; --dist: 55px; }
+  .confetti-dot:nth-child(11) { background: #9b59b6; --dist: 48px; }
+  .confetti-dot:nth-child(12) { background: #f4c84c; --dist: 58px; }
+
+  .confetti-dot:nth-child(2n)   { animation-delay: 40ms; }
+  .confetti-dot:nth-child(3n)   { animation-delay: 80ms; width: 5px; height: 5px; }
+  .confetti-dot:nth-child(4n+1) { animation-delay: 20ms; width: 7px; height: 7px; }
+
+  @keyframes confetti-fly {
+    0% {
+      transform: translate(0, 0) scale(1) rotate(0deg);
+      opacity: 1;
+    }
+    100% {
+      transform:
+        translate(
+          calc(cos(var(--angle)) * var(--dist)),
+          calc(sin(var(--angle)) * var(--dist) - 20px)
+        )
+        scale(0)
+        rotate(180deg);
+      opacity: 0;
+    }
+  }
+
+  /* Fallback for browsers without CSS cos/sin — use fixed positions */
+  @supports not (transform: translate(calc(cos(0deg) * 1px), 0)) {
+    .confetti-dot:nth-child(1)  { --tx:  50px; --ty: -25px; }
+    .confetti-dot:nth-child(2)  { --tx:  35px; --ty: -50px; }
+    .confetti-dot:nth-child(3)  { --tx:   0px; --ty: -55px; }
+    .confetti-dot:nth-child(4)  { --tx: -40px; --ty: -45px; }
+    .confetti-dot:nth-child(5)  { --tx: -55px; --ty: -15px; }
+    .confetti-dot:nth-child(6)  { --tx: -45px; --ty:  20px; }
+    .confetti-dot:nth-child(7)  { --tx: -15px; --ty:  40px; }
+    .confetti-dot:nth-child(8)  { --tx:  25px; --ty:  35px; }
+    .confetti-dot:nth-child(9)  { --tx:  55px; --ty:  10px; }
+    .confetti-dot:nth-child(10) { --tx:  45px; --ty: -40px; }
+    .confetti-dot:nth-child(11) { --tx: -20px; --ty: -58px; }
+    .confetti-dot:nth-child(12) { --tx:  10px; --ty:  45px; }
+
+    @keyframes confetti-fly {
+      0% {
+        transform: translate(0, 0) scale(1) rotate(0deg);
+        opacity: 1;
+      }
+      100% {
+        transform: translate(var(--tx, 40px), var(--ty, -30px)) scale(0) rotate(180deg);
+        opacity: 0;
+      }
+    }
+  }
+
+  /* Settings drawer — minimal, not card-like */
+  .settings-drawer {
+    border: none;
+    background: none;
+  }
+
+  .settings-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.3rem 0;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--muted, #8a95a5);
     cursor: pointer;
     user-select: none;
     list-style: none;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.4rem;
-    min-height: 2.6rem;
+    transition: color 140ms ease;
   }
 
-  .section-summary::-webkit-details-marker {
+  .settings-toggle::-webkit-details-marker {
     display: none;
   }
 
-  .chevron-down {
-    flex-shrink: 0;
-    color: var(--muted, #8a95a5);
-    transition: transform 200ms ease;
+  .settings-toggle:hover,
+  .settings-drawer[open] > .settings-toggle {
+    color: var(--ink, #182230);
   }
 
-  .section-details[open] > .section-summary .chevron-down {
-    transform: rotate(180deg);
+  .settings-toggle svg {
+    transition: transform 300ms ease;
   }
 
-  .section-body {
-    padding: 0 0.85rem 0.85rem;
+  .settings-drawer[open] > .settings-toggle svg {
+    transform: rotate(90deg);
+  }
+
+  .settings-body {
+    margin-top: 0.35rem;
+    padding: 0.55rem 0.1rem 0.1rem;
     display: grid;
     gap: 0.75rem;
+    border-top: 1px solid rgba(27, 49, 80, 0.08);
   }
 
   /* Constraints */
@@ -569,32 +873,95 @@
   .result-section {
     display: grid;
     gap: 0.65rem;
+    animation: pop-in 250ms ease;
   }
 
-  .summary-bar {
-    display: flex;
-    gap: 0.45rem;
-    flex-wrap: wrap;
+  @keyframes pop-in {
+    0% { transform: scale(0.92); opacity: 0; }
+    70% { transform: scale(1.02); }
+    100% { transform: scale(1); opacity: 1; }
   }
 
-  .stat-pill {
+  /* Settings tabs */
+  .settings-tabs {
     display: flex;
-    align-items: baseline;
-    gap: 0.25rem;
-    padding: 0.35rem 0.65rem;
-    border-radius: 999px;
-    background: rgba(255, 255, 255, 0.92);
-    border: 1px solid rgba(27, 49, 80, 0.1);
+    gap: 0;
+    border-radius: var(--radius-md, 12px);
+    overflow: hidden;
+    border: 1px solid rgba(27, 49, 80, 0.12);
+  }
+
+  .settings-tab {
+    flex: 1;
+    padding: 0.45rem 0.5rem;
+    border: none;
+    background: rgba(27, 49, 80, 0.04);
     font-size: 0.78rem;
+    font-weight: 700;
+    color: var(--muted, #8a95a5);
+    cursor: pointer;
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+    transition: background 120ms ease, color 120ms ease;
   }
 
-  .stat-val {
+  .settings-tab + .settings-tab {
+    border-left: 1px solid rgba(27, 49, 80, 0.12);
+  }
+
+  .settings-tab.active {
+    background: var(--accent, #e15b37);
+    color: #fff;
+  }
+
+  /* Debug / roll stats */
+  .debug-details {
+    border: 1px solid rgba(27, 49, 80, 0.08);
+    border-radius: var(--radius-md, 12px);
+    background: rgba(27, 49, 80, 0.03);
+    overflow: hidden;
+  }
+
+  .debug-summary {
+    padding: 0.4rem 0.65rem;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--muted, #8a95a5);
+    cursor: pointer;
+    user-select: none;
+    list-style: none;
+  }
+
+  .debug-summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .debug-body {
+    padding: 0 0.65rem 0.65rem;
+    display: grid;
+    gap: 0.3rem;
+  }
+
+  .debug-row {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.72rem;
+  }
+
+  .debug-label {
+    color: var(--muted, #8a95a5);
+    font-weight: 600;
+  }
+
+  .debug-val {
     font-weight: 800;
     color: var(--ink, #182230);
   }
 
-  .stat-label {
-    font-weight: 600;
+  .debug-hint {
+    margin: 0.25rem 0 0;
+    font-size: 0.68rem;
+    line-height: 1.35;
     color: var(--muted, #8a95a5);
   }
 
@@ -613,7 +980,14 @@
     border-radius: var(--radius-md, 12px);
   }
 
+  .setlist-actions {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
   .save-set-btn {
+    flex: 1;
     min-height: 2.6rem;
     border: 2px solid var(--accent, #e15b37);
     border-radius: var(--radius-md, 12px);
@@ -632,82 +1006,256 @@
     background: rgba(225, 91, 55, 0.12);
   }
 
-  /* Saved sets */
-  .saved-section {
-    display: grid;
-    gap: 0.5rem;
-  }
-
-  .saved-heading {
-    font-size: 0.9rem;
+  .save-set-btn.secondary {
+    flex: 1;
+    border-color: rgba(27, 49, 80, 0.18);
+    background: rgba(27, 49, 80, 0.06);
+    color: var(--ink);
     font-weight: 700;
-    color: var(--ink, #182230);
+    font-size: 0.85rem;
   }
 
-  .saved-scroll {
-    display: flex;
-    gap: 0.5rem;
-    overflow-x: auto;
-    padding-bottom: 0.5rem;
-    -webkit-overflow-scrolling: touch;
-    scroll-snap-type: x mandatory;
+  .save-set-btn.secondary:hover,
+  .save-set-btn.secondary:active {
+    background: rgba(27, 49, 80, 0.12);
   }
 
-  .saved-card {
-    flex: 0 0 auto;
-    width: clamp(120px, 38vw, 160px);
-    padding: 0.65rem;
-    border-radius: var(--radius-md, 12px);
-    background: rgba(255, 255, 255, 0.92);
-    border: 1px solid rgba(27, 49, 80, 0.1);
-    display: grid;
-    gap: 0.3rem;
-    scroll-snap-align: start;
+  .save-set-btn.secondary:active {
+    transform: scale(0.96);
   }
 
-  .saved-card-top {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-
-  .saved-songs {
-    font-weight: 700;
+  .saved-badge {
     font-size: 0.82rem;
+    font-weight: 700;
+    color: #1f8f61;
+    white-space: nowrap;
+    padding: 0.4rem 0.75rem;
+    border: 1.5px solid #1f8f6140;
+    border-radius: var(--radius-md, 12px);
+    background: rgba(31, 143, 97, 0.08);
+  }
+
+  .locked-badge {
+    font-size: 0.82rem;
+    font-weight: 700;
+    color: #1f8f61;
+    white-space: nowrap;
+    padding: 0.4rem 0.75rem;
+    border: 1.5px solid #1f8f6140;
+    border-radius: var(--radius-md, 12px);
+    background: rgba(31, 143, 97, 0.08);
+  }
+
+  /* Confirm dialog */
+  .confirm-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(30, 38, 52, 0.35);
+    backdrop-filter: blur(4px);
+    display: grid;
+    place-items: center;
+    z-index: 60;
+    padding: 1rem;
+    animation: fade-in 150ms ease;
+  }
+
+  .confirm-dialog {
+    width: min(100%, 320px);
+    padding: 1.5rem;
+    background: var(--paper-strong, #fff);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-xl, 16px);
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.15);
+    display: grid;
+    gap: 0.75rem;
+    animation: pop-in 200ms ease;
+  }
+
+  .confirm-title {
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--ink);
+    margin: 0;
+  }
+
+  .confirm-desc {
+    font-size: 0.88rem;
+    color: var(--muted);
+    margin: 0;
+  }
+
+  .confirm-actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.25rem;
+  }
+
+  .confirm-btn {
+    flex: 1;
+    min-height: 2.4rem;
+    border: none;
+    border-radius: var(--radius-md, 12px);
+    font-size: 0.88rem;
+    font-weight: 700;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .confirm-btn.cancel {
+    background: var(--line);
+    color: var(--ink);
+  }
+
+  .confirm-btn.proceed {
+    background: var(--accent, #e15b37);
+    color: #fff;
+  }
+
+  @keyframes fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
+  /* ---- Onboarding card ---- */
+  .onboarding-card {
+    border: 1px solid rgba(27, 49, 80, 0.1);
+    border-radius: var(--radius-lg, 16px);
+    background: rgba(255, 255, 255, 0.85);
+    padding: 1.25rem 1rem;
+    display: grid;
+    gap: 0.65rem;
+    text-align: center;
+    animation: pop-in 300ms ease;
+  }
+
+  .onboarding-illustration {
+    font-size: 2.2rem;
+    line-height: 1;
+    letter-spacing: 0.1em;
+  }
+
+  .onboarding-title {
+    margin: 0;
+    font-size: 1.15rem;
+    font-weight: 800;
     color: var(--ink, #182230);
   }
 
-  .saved-remove {
-    border: none;
-    background: none;
-    cursor: pointer;
-    font-size: 1.1rem;
+  .onboarding-desc {
+    margin: 0;
+    font-size: 0.85rem;
     color: var(--muted, #8a95a5);
+    line-height: 1.4;
+  }
+
+  .onboarding-steps {
+    list-style: none;
     padding: 0;
-    line-height: 1;
-    min-width: 24px;
-    min-height: 24px;
+    margin: 0.25rem 0 0;
+    display: grid;
+    gap: 0.6rem;
+    text-align: left;
+  }
+
+  .onboarding-steps li {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.6rem;
+    padding: 0.55rem 0.7rem;
+    border-radius: var(--radius-md, 12px);
+    background: rgba(27, 49, 80, 0.04);
+    border: 1px solid rgba(27, 49, 80, 0.06);
+  }
+
+  .onboarding-steps li.done {
+    background: rgba(31, 143, 97, 0.06);
+    border-color: rgba(31, 143, 97, 0.15);
+  }
+
+  .step-icon {
     display: flex;
     align-items: center;
     justify-content: center;
+    width: 1.6rem;
+    height: 1.6rem;
+    flex-shrink: 0;
+    border-radius: 50%;
+    background: var(--accent, #e15b37);
+    color: #fff;
+    font-size: 0.75rem;
+    font-weight: 800;
   }
 
-  .saved-remove:hover,
-  .saved-remove:active {
-    color: var(--accent, #e15b37);
+  .onboarding-steps li.done .step-icon {
+    background: #1f8f61;
   }
 
-  .saved-stats {
-    display: flex;
-    gap: 0.4rem;
-    font-size: 0.7rem;
-    color: var(--muted, #8a95a5);
+  .step-text {
+    display: grid;
+    gap: 0.15rem;
+    font-size: 0.85rem;
     font-weight: 600;
+    color: var(--ink, #182230);
+    padding-top: 0.15rem;
   }
 
-  .saved-seed {
-    font-size: 0.65rem;
-    color: var(--muted, #8a95a5);
-    font-family: monospace;
+  .step-link {
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    font-weight: 700;
+    color: var(--accent, #e15b37);
+    cursor: pointer;
+    text-align: left;
+    text-decoration: underline;
+    text-decoration-thickness: 1.5px;
+    text-underline-offset: 2px;
   }
+
+  .step-link:hover {
+    color: #c94020;
+  }
+
+  .step-hint {
+    font-size: 0.78rem;
+    font-weight: 500;
+    color: var(--muted, #8a95a5);
+  }
+
+  .onboarding-tip {
+    margin: 0;
+    font-size: 0.8rem;
+    color: var(--muted, #8a95a5);
+    line-height: 1.4;
+    padding: 0.5rem 0.7rem;
+    background: rgba(27, 49, 80, 0.03);
+    border-radius: var(--radius-md, 12px);
+    border-left: 3px solid var(--accent, #e15b37);
+  }
+
+  .onboarding-footer {
+    margin: 0;
+    font-size: 0.82rem;
+    color: var(--muted, #8a95a5);
+    line-height: 1.4;
+  }
+
+  .help-toggle {
+    background: none;
+    border: none;
+    padding: 0.25rem 0;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--accent, #e15b37);
+    cursor: pointer;
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+  }
+
+  .help-toggle:hover {
+    color: #c94020;
+  }
+
 </style>

--- a/src/lib/components/roll/RollScreen.svelte
+++ b/src/lib/components/roll/RollScreen.svelte
@@ -367,28 +367,11 @@
         {/if}
       </div>
 
-      <details class="debug-details">
-        <summary class="debug-summary">Roll stats</summary>
-        <div class="debug-body">
-          <div class="debug-row">
-            <span class="debug-label">Songs</span>
-            <span class="debug-val">{store.generatedSetlist.songs.length}</span>
-          </div>
-          <div class="debug-row">
-            <span class="debug-label">Covers</span>
-            <span class="debug-val">{store.generatedSetlist.summary.covers}</span>
-          </div>
-          <div class="debug-row">
-            <span class="debug-label">Instrumentals</span>
-            <span class="debug-val">{store.generatedSetlist.summary.instrumentals}</span>
-          </div>
-          <div class="debug-row">
-            <span class="debug-label">Score</span>
-            <span class="debug-val">{store.generatedSetlist.summary.score.toFixed(1)}</span>
-          </div>
-          <p class="debug-hint">Score = total penalty points from gear changes, position misses, and constraint violations. Lower is better — 0 means no compromises were made.</p>
-        </div>
-      </details>
+      <div class="roadie-score">
+        <span class="roadie-label">Bass Player Anxiety</span>
+        <span class="roadie-val">{store.generatedSetlist.summary.score.toFixed(1)}</span>
+        <p class="roadie-hint">{store.generatedSetlist.summary.score === 0 ? "Bass player is relaxed for once. Smooth transitions, zero dead air." : store.generatedSetlist.summary.score < 5 ? "Bass player is calm. Might need one quick joke between songs." : store.generatedSetlist.summary.score < 15 ? "Bass player is rehearsing crowd work. A few gear swaps are going to need covering." : "Bass player is writing crowd work material as we speak. Too many tuning changes — expect nervous rambling about the weather."}</p>
+      </div>
     </section>
   {/if}
 
@@ -914,52 +897,33 @@
     color: #fff;
   }
 
-  /* Debug / roll stats */
-  .debug-details {
-    border: 1px solid rgba(27, 49, 80, 0.08);
+  /* Bass Player Anxiety score */
+  .roadie-score {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    padding: 0.5rem 0.65rem;
     border-radius: var(--radius-md, 12px);
     background: rgba(27, 49, 80, 0.03);
-    overflow: hidden;
+    border: 1px solid rgba(27, 49, 80, 0.06);
   }
 
-  .debug-summary {
-    padding: 0.4rem 0.65rem;
+  .roadie-label {
     font-size: 0.72rem;
-    font-weight: 600;
+    font-weight: 700;
     color: var(--muted, #8a95a5);
-    cursor: pointer;
-    user-select: none;
-    list-style: none;
   }
 
-  .debug-summary::-webkit-details-marker {
-    display: none;
-  }
-
-  .debug-body {
-    padding: 0 0.65rem 0.65rem;
-    display: grid;
-    gap: 0.3rem;
-  }
-
-  .debug-row {
-    display: flex;
-    justify-content: space-between;
-    font-size: 0.72rem;
-  }
-
-  .debug-label {
-    color: var(--muted, #8a95a5);
-    font-weight: 600;
-  }
-
-  .debug-val {
+  .roadie-val {
+    font-size: 0.82rem;
     font-weight: 800;
     color: var(--ink, #182230);
   }
 
-  .debug-hint {
-    margin: 0.25rem 0 0;
+  .roadie-hint {
+    flex-basis: 100%;
+    margin: 0;
     font-size: 0.68rem;
     line-height: 1.35;
     color: var(--muted, #8a95a5);

--- a/src/lib/components/roll/RollScreen.svelte
+++ b/src/lib/components/roll/RollScreen.svelte
@@ -84,6 +84,28 @@
 
   let settingsTab = $state("constraints");
   let hasConstraints = $derived(membersWithChoices().length > 0);
+  // anxietyLevel: read from generator's pre-computed summary (avoids Svelte proxy issues)
+  let anxietyLevel = $derived.by(() => {
+    const setlist = store.generatedSetlist;
+    if (!setlist?.summary?.anxiety) return { scaled: 0, label: "" };
+
+    const { scaled, rawChanges, transitionsDisrupted, totalTransitions } = setlist.summary.anxiety;
+    const spreadNote = transitionsDisrupted > 0 ? ` across ${transitionsDisrupted} of ${totalTransitions} transitions` : "";
+    let label;
+    if (rawChanges === 0) {
+      label = "Bass player is relaxed for once. Zero gear changes — smooth sailing.";
+    } else if (scaled <= 2) {
+      label = `${rawChanges} gear change${rawChanges === 1 ? "" : "s"}${spreadNote}. Bass player barely notices.`;
+    } else if (scaled <= 5) {
+      label = `${rawChanges} gear changes${spreadNote}. Bass player is rehearsing crowd work.`;
+    } else if (scaled <= 7) {
+      label = `${rawChanges} gear changes${spreadNote}. Bass player is visibly sweating.`;
+    } else {
+      label = `${rawChanges} gear changes${spreadNote}. Bass player is writing a stand-up set to fill all the dead air.`;
+    }
+
+    return { scaled, label };
+  });
   let settingsEl = $state(null);
 
   // ---- drag-to-reorder ----
@@ -369,8 +391,8 @@
 
       <div class="roadie-score">
         <span class="roadie-label">Bass Player Anxiety</span>
-        <span class="roadie-val">{store.generatedSetlist.summary.score.toFixed(1)}</span>
-        <p class="roadie-hint">{store.generatedSetlist.summary.score === 0 ? "Bass player is relaxed for once. Smooth transitions, zero dead air." : store.generatedSetlist.summary.score < 5 ? "Bass player is calm. Might need one quick joke between songs." : store.generatedSetlist.summary.score < 15 ? "Bass player is rehearsing crowd work. A few gear swaps are going to need covering." : "Bass player is writing crowd work material as we speak. Too many tuning changes — expect nervous rambling about the weather."}</p>
+        <span class="roadie-val">{anxietyLevel.scaled}/10</span>
+        <p class="roadie-hint">{anxietyLevel.label}</p>
       </div>
     </section>
   {/if}
@@ -420,6 +442,9 @@
     padding: 0.6rem;
     display: grid;
     gap: 0.5rem;
+    max-height: calc(100vh - 48px - var(--bottom-nav-height, 56px) - var(--safe-bottom, 0px) - 1rem);
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
   }
 
   @media (min-width: 400px) {

--- a/src/lib/components/roll/RollScreen.svelte
+++ b/src/lib/components/roll/RollScreen.svelte
@@ -324,7 +324,7 @@
     <div class="onboarding-card">
       <div class="onboarding-illustration">🎸🥁🎤</div>
       <h2 class="onboarding-title">Almost showtime!</h2>
-      <p class="onboarding-desc">Add some songs to your catalog and Set Roll will build you a setlist.</p>
+      <p class="onboarding-desc">Add some songs to your catalog and Setlist Roller will build you a setlist.</p>
       <ol class="onboarding-steps">
         <li class:done={hasSongs}>
           <span class="step-icon">{hasSongs ? "✓" : "1"}</span>
@@ -338,7 +338,7 @@
           </span>
         </li>
       </ol>
-      <p class="onboarding-tip">Got members who switch guitars, tunings, or capos between songs? Add them in each song and Set Roll will minimize gear changes.</p>
+      <p class="onboarding-tip">Got members who switch guitars, tunings, or capos between songs? Add them in each song and Setlist Roller will minimize gear changes.</p>
       <p class="onboarding-footer">Then come back here and hit Roll.</p>
       <button class="help-toggle" onclick={() => store.navigate("help")}>How does this work?</button>
     </div>

--- a/src/lib/components/roll/RollScreen.svelte
+++ b/src/lib/components/roll/RollScreen.svelte
@@ -3,6 +3,7 @@
   import NumberStepper from "../shared/NumberStepper.svelte";
   import ChipToggle from "../shared/ChipToggle.svelte";
   import SetlistSongCard from "./SetlistSongCard.svelte";
+  import { anxietyLabel } from "../../anxiety.js";
 
   const store = getContext("app");
 
@@ -84,27 +85,11 @@
 
   let settingsTab = $state("constraints");
   let hasConstraints = $derived(membersWithChoices().length > 0);
-  // anxietyLevel: read from generator's pre-computed summary (avoids Svelte proxy issues)
+  // anxietyLevel: pre-computed by the generator, label from anxiety lib
   let anxietyLevel = $derived.by(() => {
-    const setlist = store.generatedSetlist;
-    if (!setlist?.summary?.anxiety) return { scaled: 0, label: "" };
-
-    const { scaled, rawChanges, transitionsDisrupted, totalTransitions } = setlist.summary.anxiety;
-    const spreadNote = transitionsDisrupted > 0 ? ` across ${transitionsDisrupted} of ${totalTransitions} transitions` : "";
-    let label;
-    if (rawChanges === 0) {
-      label = "Bass player is relaxed for once. Zero gear changes — smooth sailing.";
-    } else if (scaled <= 2) {
-      label = `${rawChanges} gear change${rawChanges === 1 ? "" : "s"}${spreadNote}. Bass player barely notices.`;
-    } else if (scaled <= 5) {
-      label = `${rawChanges} gear changes${spreadNote}. Bass player is rehearsing crowd work.`;
-    } else if (scaled <= 7) {
-      label = `${rawChanges} gear changes${spreadNote}. Bass player is visibly sweating.`;
-    } else {
-      label = `${rawChanges} gear changes${spreadNote}. Bass player is writing a stand-up set to fill all the dead air.`;
-    }
-
-    return { scaled, label };
+    const anxiety = store.generatedSetlist?.summary?.anxiety;
+    if (!anxiety) return { scaled: 0, label: "" };
+    return { scaled: anxiety.scaled, label: anxietyLabel(anxiety) };
   });
   let settingsEl = $state(null);
 

--- a/src/lib/components/saved/SavedScreen.svelte
+++ b/src/lib/components/saved/SavedScreen.svelte
@@ -62,9 +62,11 @@
     const bandName = (store.appTitle || "").replace(/ — Set Roll$/, "");
     const setName = viewingSet?.name || "Setlist";
     const pdfTitle = `${bandName} - ${setName}`;
+    const esc = (s) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
     const win = window.open("", "_blank", "width=800,height=600");
+    if (!win) { store.addToast("Popup blocked — please allow popups to print.", "warning"); return; }
     win.document.write(`<!DOCTYPE html>
-<html><head><title>${pdfTitle}</title>
+<html><head><title>${esc(pdfTitle)}</title>
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
   @page { margin: 0; }

--- a/src/lib/components/saved/SavedScreen.svelte
+++ b/src/lib/components/saved/SavedScreen.svelte
@@ -59,7 +59,7 @@
     clone.querySelectorAll(".no-print").forEach(el => el.remove());
     const content = clone.innerHTML;
     const appUrl = window.location.origin;
-    const bandName = (store.appTitle || "").replace(/ — Set Roll$/, "");
+    const bandName = (store.appTitle || "").replace(/ — Setlist Roller$/, "");
     const setName = viewingSet?.name || "Setlist";
     const pdfTitle = `${bandName} - ${setName}`;
     const esc = (s) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
@@ -196,7 +196,7 @@
       <div class="print-setlist" bind:this={printEl}>
         <div class="print-top">
           <button class="modal-close no-print" onclick={handleClose} aria-label="Close">&times;</button>
-          <h2 class="print-band">{store.appTitle.replace(/ — Set Roll$/, "")}</h2>
+          <h2 class="print-band">{store.appTitle.replace(/ — Setlist Roller$/, "")}</h2>
           <p class="print-subtitle">{viewingSet.name || "Setlist"} &middot; {formatDate(viewingSet.savedAt)}</p>
         </div>
 

--- a/src/lib/components/saved/SavedScreen.svelte
+++ b/src/lib/components/saved/SavedScreen.svelte
@@ -1,0 +1,604 @@
+<script>
+  import { getContext } from "svelte";
+
+  const store = getContext("app");
+
+  let viewingSet = $state(null);
+  let editingId = $state(null);
+  let editName = $state("");
+  let editDate = $state("");
+
+  function handleView(saved) {
+    if (editingId) return;
+    viewingSet = saved;
+  }
+
+  function startEdit(e, saved) {
+    e.stopPropagation();
+    editingId = saved.id;
+    editName = saved.name || "";
+    // Convert ISO to YYYY-MM-DD for date input
+    editDate = saved.savedAt ? saved.savedAt.slice(0, 10) : "";
+  }
+
+  function saveEdit(e) {
+    if (e) e.stopPropagation();
+    if (!editingId) return;
+    store.updateSavedSetlist(editingId, {
+      name: editName.trim() || "Untitled Set",
+      savedAt: editDate ? new Date(editDate + "T12:00:00").toISOString() : new Date().toISOString(),
+    });
+    editingId = null;
+  }
+
+  function cancelEdit(e) {
+    if (e) e.stopPropagation();
+    editingId = null;
+  }
+
+  function handleClose() {
+    viewingSet = null;
+  }
+
+  function handleLoad(e, id) {
+    e.stopPropagation();
+    store.loadSavedSetlist(id);
+    store.navigate("roll");
+  }
+
+  function handleRemove(e, id) {
+    e.stopPropagation();
+    store.removeSavedSetlist(id);
+  }
+
+  let printEl = $state(null);
+
+  function handlePrint() {
+    if (!printEl) return;
+    const clone = printEl.cloneNode(true);
+    clone.querySelectorAll(".no-print").forEach(el => el.remove());
+    const content = clone.innerHTML;
+    const appUrl = window.location.origin;
+    const bandName = (store.appTitle || "").replace(/ — Set Roll$/, "");
+    const setName = viewingSet?.name || "Setlist";
+    const pdfTitle = `${bandName} - ${setName}`;
+    const win = window.open("", "_blank", "width=800,height=600");
+    win.document.write(`<!DOCTYPE html>
+<html><head><title>${pdfTitle}</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  @page { margin: 0; }
+  body {
+    font-family: "Avenir Next", "Helvetica Neue", "Segoe UI", sans-serif;
+    color: #000;
+    padding: 1.5cm;
+  }
+  .print-top { padding-bottom: 8px; border-bottom: 2px solid #000; margin-bottom: 6px; }
+  .print-band { font-size: 22pt; font-weight: 800; line-height: 1.2; }
+  .print-subtitle { font-size: 11pt; font-weight: 400; color: #555; margin-top: 2px; }
+  .print-songs { list-style: none; }
+  .print-song { padding: 9px 0; border-bottom: 1px solid #ddd; break-inside: avoid; }
+  .print-song-row { display: flex; align-items: baseline; gap: 8px; }
+  .print-num { font-size: 14pt; font-weight: 700; color: #666; min-width: 2rem; text-align: right; flex-shrink: 0; }
+  .print-song-name { font-size: 17pt; font-weight: 600; flex: 1; }
+  .print-song-key { font-size: 13pt; font-weight: 700; color: #444; padding: 1px 6px; border: 1px solid #ccc; border-radius: 3px; flex-shrink: 0; }
+  .print-changes { padding-left: 2.5rem; padding-top: 3px; }
+  .print-change { display: flex; align-items: baseline; gap: 5px; font-size: 12pt; color: #333; }
+  .print-change.setup { color: #666; }
+  .print-change-member { font-weight: 700; }
+  .print-change-detail { font-weight: 500; }
+  .print-footer { position: fixed; bottom: 1cm; right: 1.5cm; font-size: 8pt; color: #999; }
+</style></head><body>${content}<div class="print-footer">${appUrl}</div></body></html>`);
+    win.document.close();
+    win.focus();
+    setTimeout(() => { win.print(); win.close(); }, 150);
+  }
+
+  function formatDate(iso) {
+    if (!iso) return "";
+    const d = new Date(iso);
+    return d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+  }
+
+  // Transition notes — same logic as SetlistSongCard
+  function getChanges(song, prevSong, memberName) {
+    const curr = song.performance?.[memberName];
+    if (!curr) return [];
+    const prev = prevSong?.performance?.[memberName];
+    const changes = [];
+    if (!prev || curr.instrument !== prev.instrument) {
+      if (prev && curr.instrument) changes.push(curr.instrument);
+    }
+    if (!prev || curr.tuning !== prev.tuning) {
+      if (curr.tuning) changes.push(curr.tuning);
+    }
+    if (!prev || curr.capo !== prev.capo) {
+      if (curr.capo) changes.push(`capo ${curr.capo}`);
+      else if (prev?.capo) changes.push("capo off");
+    }
+    const currTech = String(curr.picking || "");
+    const prevTech = prev ? String(prev.picking || "") : "";
+    if (currTech !== prevTech && currTech) {
+      const techDisplay = Array.isArray(curr.picking) ? curr.picking.filter(t => t !== "none").join(", ") : currTech;
+      if (techDisplay) changes.push(techDisplay);
+    }
+    return changes;
+  }
+
+  function allChanges(song, prevSong) {
+    if (!song.performance) return [];
+    const lines = [];
+    for (const [memberName] of Object.entries(song.performance)) {
+      if (prevSong) {
+        const changes = getChanges(song, prevSong, memberName);
+        if (changes.length > 0) lines.push({ member: memberName, changes });
+      } else {
+        // First song: show initial setup
+        const perf = song.performance[memberName];
+        const techStr = Array.isArray(perf.picking) && perf.picking.length ? perf.picking.filter(t => t !== "none").join(", ") || null : null;
+        const parts = [perf.instrument, perf.tuning, perf.capo ? `capo ${perf.capo}` : null, techStr].filter(Boolean);
+        if (parts.length > 0) lines.push({ member: memberName, changes: parts, isSetup: true });
+      }
+    }
+    return lines;
+  }
+</script>
+
+<div class="saved-screen">
+  <h2 class="screen-title">Greatest Hits</h2>
+
+  {#if !store.savedSetlists?.length}
+    <div class="empty-state">
+      <p class="empty-title">Nothing saved yet</p>
+      <p class="empty-sub">Roll a setlist you love, lock it in, then save it here for safekeeping.</p>
+    </div>
+  {:else}
+    <div class="saved-list">
+      {#each store.savedSetlists as saved}
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <div class="saved-card" onclick={() => handleView(saved)} role="button" tabindex="0" onkeydown={(e) => { if (e.key === 'Enter') handleView(saved); }}>
+          {#if editingId === saved.id}
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
+            <div class="edit-form" onclick={(e) => e.stopPropagation()}>
+              <input class="edit-input" type="text" bind:value={editName} placeholder="Setlist name" onkeydown={(e) => { if (e.key === 'Enter') saveEdit(); if (e.key === 'Escape') cancelEdit(); }} />
+              <input class="edit-input date" type="date" bind:value={editDate} />
+              <div class="edit-actions">
+                <button class="card-btn save" onclick={saveEdit}>Save</button>
+                <button class="card-btn cancel" onclick={cancelEdit}>Cancel</button>
+              </div>
+            </div>
+          {:else}
+            <div class="saved-top">
+              <span class="saved-name">{saved.name || `Set #${saved.songCount || "?"}`}</span>
+              <span class="saved-date">{formatDate(saved.savedAt)}</span>
+            </div>
+            <div class="saved-meta">
+              <span>{saved.songCount || saved.songs?.length || 0} songs</span>
+            </div>
+            <div class="saved-card-actions">
+              <button class="card-btn edit" onclick={(e) => startEdit(e, saved)}>Edit</button>
+              <button class="card-btn load" onclick={(e) => handleLoad(e, saved.id)}>Load</button>
+              <button class="card-btn remove" onclick={(e) => handleRemove(e, saved.id)} aria-label="Remove">&times;</button>
+            </div>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+{#if viewingSet}
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div class="modal-backdrop" onclick={handleClose}>
+    <div class="modal-sheet" onclick={(e) => e.stopPropagation()}>
+      <div class="print-setlist" bind:this={printEl}>
+        <div class="print-top">
+          <button class="modal-close no-print" onclick={handleClose} aria-label="Close">&times;</button>
+          <h2 class="print-band">{store.appTitle.replace(/ — Set Roll$/, "")}</h2>
+          <p class="print-subtitle">{viewingSet.name || "Setlist"} &middot; {formatDate(viewingSet.savedAt)}</p>
+        </div>
+
+        <div class="print-songs">
+          {#each viewingSet.songs as song, i}
+            {@const prevSong = i > 0 ? viewingSet.songs[i - 1] : null}
+            {@const changes = allChanges(song, prevSong)}
+            <div class="print-song">
+              <div class="print-song-row">
+                <span class="print-num">{i + 1}.</span>
+                <span class="print-song-name">{song.name || song.title || "Untitled"}</span>
+                {#if song.key}
+                  <span class="print-song-key">{song.key}</span>
+                {/if}
+              </div>
+              {#if changes.length > 0}
+                <div class="print-changes">
+                  {#each changes as line}
+                    <div class="print-change" class:setup={line.isSetup}>
+                      <span class="print-change-member">{line.member}:</span>
+                      <span class="print-change-detail">{line.changes.join(", ")}</span>
+                    </div>
+                  {/each}
+                </div>
+              {/if}
+            </div>
+          {/each}
+        </div>
+
+      </div>
+
+      <div class="modal-actions">
+        <button class="modal-btn" onclick={handlePrint}>Print / Export PDF</button>
+        <button class="modal-btn primary" onclick={(e) => { handleLoad(e, viewingSet.id); viewingSet = null; }}>Load to Roll</button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .saved-screen {
+    display: grid;
+    gap: 1rem;
+    padding: 0.75rem;
+    max-width: 540px;
+    margin: 0 auto;
+  }
+
+  .screen-title {
+    font-size: 1.1rem;
+    font-weight: 800;
+    color: var(--ink, #182230);
+  }
+
+  .empty-state {
+    text-align: center;
+    padding: 3rem 1rem;
+  }
+
+  .empty-title {
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--ink, #182230);
+    margin-bottom: 0.35rem;
+  }
+
+  .empty-sub {
+    font-size: 0.85rem;
+    color: var(--muted, #8a95a5);
+    line-height: 1.5;
+  }
+
+  .saved-list {
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .saved-card {
+    border-radius: var(--radius-lg, 16px);
+    background: rgba(255, 255, 255, 0.92);
+    border: 1px solid rgba(27, 49, 80, 0.1);
+    padding: 0.75rem;
+    display: grid;
+    gap: 0.4rem;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    transition: border-color 140ms ease, box-shadow 140ms ease;
+  }
+
+  .saved-card:hover {
+    border-color: var(--accent, #e15b37);
+    box-shadow: 0 2px 8px rgba(225, 91, 55, 0.1);
+  }
+
+  .saved-card:active {
+    background: rgba(225, 91, 55, 0.04);
+  }
+
+  .saved-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+
+  .saved-name {
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: var(--ink, #182230);
+  }
+
+  .saved-date {
+    font-size: 0.72rem;
+    color: var(--muted, #8a95a5);
+    font-weight: 600;
+  }
+
+  .saved-meta {
+    display: flex;
+    gap: 0.6rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--muted, #8a95a5);
+  }
+
+  .saved-card-actions {
+    display: flex;
+    gap: 0.35rem;
+    margin-top: 0.15rem;
+  }
+
+  .card-btn {
+    border: none;
+    border-radius: var(--radius-md, 12px);
+    font-size: 0.78rem;
+    font-weight: 700;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    padding: 0.35rem 0.7rem;
+    min-height: 1.8rem;
+    transition: background 120ms ease, transform 80ms ease;
+  }
+
+  .card-btn:active {
+    transform: scale(0.96);
+  }
+
+  .card-btn.load {
+    background: linear-gradient(140deg, #e15b37 0%, #c94020 100%);
+    color: #fff;
+  }
+
+  .card-btn.remove {
+    background: none;
+    color: var(--muted, #8a95a5);
+    font-size: 1.1rem;
+    padding: 0.2rem 0.4rem;
+  }
+
+  .card-btn.remove:hover,
+  .card-btn.remove:active {
+    color: var(--accent, #e15b37);
+  }
+
+  .card-btn.edit {
+    background: rgba(27, 49, 80, 0.06);
+    color: var(--ink, #182230);
+    border: 1px solid rgba(27, 49, 80, 0.12);
+  }
+
+  .card-btn.save {
+    background: #1f8f61;
+    color: #fff;
+  }
+
+  .card-btn.cancel {
+    background: rgba(27, 49, 80, 0.06);
+    color: var(--muted, #8a95a5);
+    border: 1px solid rgba(27, 49, 80, 0.1);
+  }
+
+  .edit-form {
+    display: grid;
+    gap: 0.4rem;
+  }
+
+  .edit-input {
+    width: 100%;
+    min-height: 2.2rem;
+    padding: 0.4rem 0.6rem;
+    border: 1px solid rgba(27, 49, 80, 0.18);
+    border-radius: var(--radius-md, 12px);
+    background: #fff;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--ink, #182230);
+  }
+
+  .edit-input:focus {
+    outline: none;
+    border-color: var(--accent, #e15b37);
+    box-shadow: 0 0 0 2px rgba(225, 91, 55, 0.12);
+  }
+
+  .edit-input.date {
+    font-size: 0.8rem;
+    color: var(--muted, #617086);
+  }
+
+  .edit-actions {
+    display: flex;
+    gap: 0.35rem;
+  }
+
+  /* ---- Modal ---- */
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(30, 38, 52, 0.35);
+    backdrop-filter: blur(4px);
+    display: grid;
+    place-items: center;
+    z-index: 300;
+    padding: 1rem;
+    animation: fade-in 150ms ease;
+  }
+
+  .modal-sheet {
+    width: min(100%, 420px);
+    max-height: calc(100vh - 2rem);
+    max-height: calc(100dvh - 2rem);
+    overflow-y: auto;
+    background: #fff;
+    border-radius: var(--radius-xl, 20px);
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.18);
+    display: grid;
+    gap: 0;
+    animation: pop-in 200ms ease;
+  }
+
+  .modal-close {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    border: none;
+    background: rgba(0, 0, 0, 0.05);
+    font-size: 1.3rem;
+    color: #666;
+    cursor: pointer;
+    line-height: 1;
+    padding: 0;
+    width: 1.8rem;
+    height: 1.8rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    z-index: 1;
+  }
+
+  .modal-close:active {
+    background: rgba(0, 0, 0, 0.1);
+  }
+
+  /* ---- Print-friendly setlist (black & white) ---- */
+  .print-setlist {
+    padding: 0.75rem;
+    display: grid;
+    gap: 0;
+    color: #000;
+    position: relative;
+  }
+
+  .print-top {
+    padding-bottom: 0.5rem;
+    border-bottom: 2px solid #000;
+    margin-bottom: 0.35rem;
+  }
+
+  .print-band {
+    font-size: 1.15rem;
+    font-weight: 800;
+    color: #000;
+    margin: 0;
+    line-height: 1.2;
+  }
+
+  .print-subtitle {
+    font-size: 0.78rem;
+    font-weight: 400;
+    color: #555;
+    margin: 0.1rem 0 0;
+  }
+
+  .print-songs {
+    display: grid;
+    gap: 0;
+  }
+
+  .print-song {
+    padding: 0.45rem 0;
+    border-bottom: 1px solid #e0e0e0;
+  }
+
+  .print-song-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.4rem;
+  }
+
+  .print-num {
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: #666;
+    min-width: 1.6rem;
+    text-align: right;
+    flex-shrink: 0;
+  }
+
+  .print-song-name {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #000;
+    flex: 1;
+  }
+
+  .print-song-key {
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: #444;
+    flex-shrink: 0;
+    padding: 0.05rem 0.35rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+  }
+
+  .print-changes {
+    padding-left: 2rem;
+    padding-top: 0.15rem;
+    display: grid;
+    gap: 0.05rem;
+  }
+
+  .print-change {
+    display: flex;
+    align-items: baseline;
+    gap: 0.3rem;
+    font-size: 0.72rem;
+    color: #333;
+  }
+
+  .print-change.setup {
+    color: #666;
+  }
+
+  .print-change-member {
+    font-weight: 700;
+    flex-shrink: 0;
+  }
+
+  .print-change-detail {
+    font-weight: 500;
+  }
+
+
+  .modal-actions {
+    display: flex;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem 0.75rem;
+    border-top: 1px solid rgba(27, 49, 80, 0.08);
+  }
+
+  .modal-btn {
+    flex: 1;
+    min-height: 2.4rem;
+    border: 1.5px solid rgba(27, 49, 80, 0.15);
+    border-radius: var(--radius-md, 12px);
+    background: transparent;
+    color: var(--ink, #182230);
+    font-size: 0.82rem;
+    font-weight: 700;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    transition: background 120ms ease, transform 80ms ease;
+  }
+
+  .modal-btn:active {
+    transform: scale(0.97);
+  }
+
+  .modal-btn.primary {
+    background: linear-gradient(140deg, #e15b37 0%, #c94020 100%);
+    color: #fff;
+    border-color: transparent;
+  }
+
+  @keyframes fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
+  @keyframes pop-in {
+    0% { transform: scale(0.92); opacity: 0; }
+    70% { transform: scale(1.02); }
+    100% { transform: scale(1); opacity: 1; }
+  }
+
+</style>

--- a/src/lib/components/songs/SongEditor.svelte
+++ b/src/lib/components/songs/SongEditor.svelte
@@ -295,7 +295,7 @@
                                             <div class="inline-add">
                                                 <input
                                                     class="field-input"
-                                                    list="inst-{memberName}-{index}"
+                                                    list={`inst-${memberName}-${index}`}
                                                     value={instDraft}
                                                     placeholder="e.g. Guitar, Bass, Keys"
                                                     oninput={(e) => setInstrumentDraft(memberName, index, e.currentTarget.value)}
@@ -307,7 +307,7 @@
                                                 {/if}
                                             </div>
                                             {#if knownInstruments.length > 0}
-                                                <datalist id="inst-{memberName}-{index}">
+                                                <datalist id={`inst-${memberName}-${index}`}>
                                                     {#each knownInstruments as instrument}
                                                         <option value={instrument} />
                                                     {/each}

--- a/src/lib/components/songs/SongEditor.svelte
+++ b/src/lib/components/songs/SongEditor.svelte
@@ -7,6 +7,31 @@
 
     let expandedMember = $state("");
     let confirmingDelete = $state(false);
+    // Track instrument name drafts so we can show sections before committing
+    let instrumentNameDrafts = $state({});
+
+    function draftKey(memberName, index) {
+        return `${memberName}::${index}`;
+    }
+
+    function getInstrumentDraft(memberName, index, currentName) {
+        const key = draftKey(memberName, index);
+        return key in instrumentNameDrafts ? instrumentNameDrafts[key] : currentName;
+    }
+
+    function setInstrumentDraft(memberName, index, value) {
+        instrumentNameDrafts = { ...instrumentNameDrafts, [draftKey(memberName, index)]: value };
+    }
+
+    function commitInstrumentName(memberName, index) {
+        const key = draftKey(memberName, index);
+        const draft = (instrumentNameDrafts[key] || "").trim();
+        if (draft) {
+            store.updateInstrumentOption(memberName, index, "name", draft);
+        }
+        const { [key]: _, ...rest } = instrumentNameDrafts;
+        instrumentNameDrafts = rest;
+    }
 
     function toggleMember(name) {
         expandedMember = expandedMember === name ? "" : name;
@@ -53,6 +78,69 @@
         store.updateInstrumentOption(memberName, index, "tuning", next);
     }
 
+    async function handleAddTuning(memberName, instrumentName, songInstrumentIndex) {
+        const added = await store.addTuningChoice(memberName, instrumentName);
+        if (added) {
+            // Also select it for this song
+            const current = store.editorSong.members[memberName].instruments[songInstrumentIndex].tuning || [];
+            if (!current.includes(added)) {
+                store.updateInstrumentOption(memberName, songInstrumentIndex, "tuning", current.concat(added));
+            }
+        }
+    }
+
+    function handleAddTuningKeydown(e, memberName, instrumentName, songInstrumentIndex) {
+        if (e.key === "Enter") handleAddTuning(memberName, instrumentName, songInstrumentIndex);
+    }
+
+    async function handleAddTechnique(memberName, instrumentName, songInstrumentIndex) {
+        const added = await store.addTechniqueChoice(memberName, instrumentName);
+        if (added) {
+            // Also select it for this song
+            const current = (store.editorSong.members[memberName].instruments[songInstrumentIndex].picking || []).filter(t => t !== "none");
+            if (!current.includes(added)) {
+                store.updateInstrumentOption(memberName, songInstrumentIndex, "picking", current.concat(added));
+            }
+        }
+    }
+
+    function handleAddTechniqueKeydown(e, memberName, instrumentName, songInstrumentIndex) {
+        if (e.key === "Enter") handleAddTechnique(memberName, instrumentName, songInstrumentIndex);
+    }
+
+    function hasDefaultTechnique(memberName, instrumentName) {
+        const memberConfig = store.appConfig?.band?.members?.[memberName];
+        const instConfig = (memberConfig?.instruments || []).find((i) => i.name === instrumentName);
+        return !!(instConfig?.defaultTechnique);
+    }
+
+    function hasTechniques(memberName, instrumentName) {
+        const memberConfig = store.appConfig?.band?.members?.[memberName];
+        const instConfig = (memberConfig?.instruments || []).find((i) => i.name === instrumentName);
+        return (instConfig?.techniques || []).length > 0;
+    }
+
+    function hasDefaultTuning(memberName, instrumentName) {
+        const memberConfig = store.appConfig?.band?.members?.[memberName];
+        const instConfig = (memberConfig?.instruments || []).find((i) => i.name === instrumentName);
+        return !!(instConfig?.defaultTuning);
+    }
+
+    function hasTunings(memberName, instrumentName) {
+        return availableTunings(memberName, { name: instrumentName }).length > 0;
+    }
+
+    function openBandMemberEdit(memberName) {
+        store.editingMemberName = memberName;
+        store.bandSubView = "member-edit";
+        store.navigate("band");
+    }
+
+    function bandMembersNotInSong() {
+        const existing = Object.keys(store.editorSong?.members || {});
+        return (store.bandMemberEntries || []).filter(([name]) => !existing.includes(name));
+    }
+
     function handleSave() {
         store.saveSong();
     }
@@ -68,6 +156,23 @@
 
     function cancelDelete() {
         confirmingDelete = false;
+    }
+
+    function memberIssues(memberName, memberSetup) {
+        const instruments = memberSetup?.instruments || [];
+        if (instruments.length === 0) return null; // no setups = member just listed, that's fine
+        for (const inst of instruments) {
+            if (!inst.name) return "Pick or type an instrument name";
+            const bandMembers = store.appConfig?.band?.members || {};
+            const bandMember = bandMembers[memberName];
+            if (bandMember) {
+                const bandInst = (bandMember.instruments || []).find((i) => i.name === inst.name);
+                if (bandInst && (bandInst.techniques || []).length > 0 && (!Array.isArray(inst.picking) || inst.picking.length === 0)) {
+                    return `${inst.name}: pick a technique`;
+                }
+            }
+        }
+        return null;
     }
 </script>
 
@@ -142,16 +247,22 @@
             <h3 class="section-heading">Members</h3>
 
             {#each Object.entries(store.editorSong.members || {}) as [memberName, memberSetup]}
+                {@const issue = memberIssues(memberName, memberSetup)}
                 <div class="member-card">
                     <button
                         class="member-header"
+                        class:has-issue={issue}
                         onclick={() => toggleMember(memberName)}
                         aria-expanded={expandedMember === memberName}
                     >
                         <span class="member-name">{memberName}</span>
-                        <span class="member-instrument-summary">
-                            {(memberSetup.instruments || []).map((i) => i.name).filter(Boolean).join(", ")}
-                        </span>
+                        {#if issue}
+                            <span class="member-issue">{issue}</span>
+                        {:else}
+                            <span class="member-instrument-summary">
+                                {(memberSetup.instruments || []).map((i) => i.name).filter(Boolean).join(", ")}
+                            </span>
+                        {/if}
                         <svg
                             class="chevron"
                             class:open={expandedMember === memberName}
@@ -175,20 +286,33 @@
                             </label>
 
                             {#each memberSetup.instruments as option, index}
+                                {@const knownInstruments = availableInstruments(memberName, option).filter(Boolean)}
+                                {@const instDraft = getInstrumentDraft(memberName, index, option.name)}
                                 <div class="instrument-card">
                                     <div class="instrument-top">
                                         <label class="field flex-1">
                                             <span class="field-label">Instrument</span>
-                                            <select
-                                                class="field-input"
-                                                value={option.name}
-                                                onchange={(e) => store.updateInstrumentOption(memberName, index, "name", e.currentTarget.value)}
-                                            >
-                                                <option value="">Select instrument</option>
-                                                {#each availableInstruments(memberName, option) as instrument}
-                                                    <option value={instrument}>{instrument}</option>
-                                                {/each}
-                                            </select>
+                                            <div class="inline-add">
+                                                <input
+                                                    class="field-input"
+                                                    list="inst-{memberName}-{index}"
+                                                    value={instDraft}
+                                                    placeholder="e.g. Guitar, Bass, Keys"
+                                                    oninput={(e) => setInstrumentDraft(memberName, index, e.currentTarget.value)}
+                                                    onkeydown={(e) => { if (e.key === "Enter") { e.preventDefault(); commitInstrumentName(memberName, index); } }}
+                                                    onblur={() => commitInstrumentName(memberName, index)}
+                                                />
+                                                {#if instDraft && instDraft !== option.name}
+                                                    <button class="add-sm-btn" onclick={() => commitInstrumentName(memberName, index)}>Set</button>
+                                                {/if}
+                                            </div>
+                                            {#if knownInstruments.length > 0}
+                                                <datalist id="inst-{memberName}-{index}">
+                                                    {#each knownInstruments as instrument}
+                                                        <option value={instrument} />
+                                                    {/each}
+                                                </datalist>
+                                            {/if}
                                         </label>
 
                                         <button
@@ -197,37 +321,54 @@
                                         >Remove</button>
                                     </div>
 
-                                    {#if availableTunings(memberName, option).length > 0}
+                                    {#if option.name || instDraft}
                                         <div class="tuning-section">
                                             <span class="field-label">Tunings</span>
                                             {#if defaultTuning(memberName, option.name)}
                                                 <small class="default-note">Default: {defaultTuning(memberName, option.name)}</small>
                                             {/if}
-                                            <div class="chip-row">
-                                                {#each availableTunings(memberName, option) as tuning}
-                                                    <ChipToggle
-                                                        checked={(option.tuning || []).includes(tuning)}
-                                                        onchange={() => toggleTuning(memberName, index, tuning)}
-                                                    >{tuning}</ChipToggle>
-                                                {/each}
+                                            {#if availableTunings(memberName, option).length > 0}
+                                                <div class="chip-row">
+                                                    {#each availableTunings(memberName, option) as tuning}
+                                                        <ChipToggle
+                                                            checked={(option.tuning || []).includes(tuning)}
+                                                            onchange={() => toggleTuning(memberName, index, tuning)}
+                                                        >{tuning}</ChipToggle>
+                                                    {/each}
+                                                </div>
+                                                {#if !hasDefaultTuning(memberName, option.name)}
+                                                    <button class="defaults-hint" onclick={() => openBandMemberEdit(memberName)}>No default tuning — set one in {memberName}'s config</button>
+                                                {/if}
+                                            {/if}
+                                            <div class="inline-add">
+                                                <input
+                                                    class="field-input small"
+                                                    type="text"
+                                                    placeholder="Add tuning..."
+                                                    value={store.newTuningByInstrument?.[store.tuningDraftKey(memberName, option.name)] || ""}
+                                                    oninput={(e) => { store.newTuningByInstrument = { ...store.newTuningByInstrument, [store.tuningDraftKey(memberName, option.name)]: e.currentTarget.value }; }}
+                                                    onkeydown={(e) => handleAddTuningKeydown(e, memberName, option.name, index)}
+                                                />
+                                                <button class="add-sm-btn" onclick={() => handleAddTuning(memberName, option.name, index)}>Add</button>
                                             </div>
                                         </div>
-                                    {/if}
 
-                                    <div class="instrument-options-row">
-                                        <div class="field">
-                                            <span class="field-label">Capo</span>
-                                            <NumberStepper
-                                                value={option.capo || 0}
-                                                min={0}
-                                                max={12}
-                                                label="Capo"
-                                                onchange={(v) => store.updateInstrumentOption(memberName, index, "capo", v)}
-                                            />
-                                        </div>
-                                        {#if availableTechniques(memberName, option).length > 0}
+                                        <div class="instrument-options-row">
                                             <div class="field">
-                                                <span class="field-label">Technique</span>
+                                                <span class="field-label">Capo</span>
+                                                <NumberStepper
+                                                    value={option.capo || 0}
+                                                    min={0}
+                                                    max={12}
+                                                    label="Capo"
+                                                    onchange={(v) => store.updateInstrumentOption(memberName, index, "capo", v)}
+                                                />
+                                            </div>
+                                        </div>
+
+                                        <div class="tuning-section">
+                                            <span class="field-label">Techniques</span>
+                                            {#if availableTechniques(memberName, option).length > 0}
                                                 <div class="chip-row">
                                                     <ChipToggle
                                                         checked={(option.picking || []).includes("none")}
@@ -241,9 +382,23 @@
                                                         >{technique}</ChipToggle>
                                                     {/each}
                                                 </div>
+                                                {#if !hasDefaultTechnique(memberName, option.name)}
+                                                    <button class="defaults-hint" onclick={() => openBandMemberEdit(memberName)}>No default technique set — set one in {memberName}'s config so new songs auto-pick it</button>
+                                                {/if}
+                                            {/if}
+                                            <div class="inline-add">
+                                                <input
+                                                    class="field-input small"
+                                                    type="text"
+                                                    placeholder="Add technique..."
+                                                    value={store.newTechniqueByInstrument?.[store.techniqueDraftKey(memberName, option.name)] || ""}
+                                                    oninput={(e) => { store.newTechniqueByInstrument = { ...store.newTechniqueByInstrument, [store.techniqueDraftKey(memberName, option.name)]: e.currentTarget.value }; }}
+                                                    onkeydown={(e) => handleAddTechniqueKeydown(e, memberName, option.name, index)}
+                                                />
+                                                <button class="add-sm-btn" onclick={() => handleAddTechnique(memberName, option.name, index)}>Add</button>
                                             </div>
-                                        {/if}
-                                    </div>
+                                        </div>
+                                    {/if}
                                 </div>
                             {/each}
 
@@ -261,7 +416,14 @@
                 </div>
             {/each}
 
-            <button class="secondary-btn" onclick={() => store.addMember()}>+ Add member</button>
+            {#if bandMembersNotInSong().length > 0}
+                <div class="add-member-row">
+                    {#each bandMembersNotInSong() as [name]}
+                        <button class="add-member-btn" onclick={() => store.addMember(name)}>+ {name}</button>
+                    {/each}
+                </div>
+            {/if}
+            <button class="secondary-btn" onclick={() => store.addMember()}>+ New member</button>
         </section>
 
         <!-- Bottom actions -->
@@ -409,16 +571,7 @@
         width: 100%;
     }
 
-    select.field-input {
-        appearance: none;
-        -webkit-appearance: none;
-        background-image: url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='%23666' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
-        background-repeat: no-repeat;
-        background-position: right 0.75rem center;
-        padding-right: 2.2rem;
-    }
-
-    .flex-1 {
+.flex-1 {
         flex: 1 1 0;
     }
 
@@ -465,6 +618,20 @@
         flex: 1;
         font-size: 0.8rem;
         color: var(--muted, #6b7a8d);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .member-header.has-issue {
+        background: rgba(255, 160, 40, 0.06);
+    }
+
+    .member-issue {
+        flex: 1;
+        font-size: 0.78rem;
+        font-weight: 600;
+        color: #b07020;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -523,6 +690,58 @@
         gap: 0.4rem;
     }
 
+    .inline-add {
+        display: flex;
+        gap: 0.4rem;
+        align-items: center;
+    }
+
+    .inline-add .field-input {
+        flex: 1;
+    }
+
+    .field-input.small {
+        min-height: 2.2rem;
+        padding: 0.4rem 0.7rem;
+        font-size: 0.85rem;
+    }
+
+    .add-sm-btn {
+        min-height: 2.2rem;
+        padding: 0.4rem 0.75rem;
+        border-radius: var(--radius-md, 12px);
+        border: none;
+        background: var(--ink, #182230);
+        color: #fff;
+        font-size: 0.78rem;
+        font-weight: 700;
+        cursor: pointer;
+        touch-action: manipulation;
+        flex-shrink: 0;
+    }
+
+    .add-sm-btn:active {
+        opacity: 0.85;
+    }
+
+    .defaults-hint {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: 0.75rem;
+        font-weight: 500;
+        color: var(--accent, #e15b37);
+        cursor: pointer;
+        text-align: left;
+        text-decoration: underline;
+        text-decoration-thickness: 1px;
+        text-underline-offset: 2px;
+    }
+
+    .defaults-hint:hover {
+        color: #c94020;
+    }
+
     .remove-setup-btn {
         min-height: 2.4rem;
         padding: 0.4rem 0.7rem;
@@ -540,6 +759,29 @@
 
     .remove-setup-btn:active {
         background: rgba(200, 40, 40, 0.06);
+    }
+
+    /* Add member row */
+    .add-member-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+    }
+
+    .add-member-btn {
+        padding: 0.45rem 0.85rem;
+        border-radius: var(--radius-md, 12px);
+        border: 1.5px solid var(--accent, #e15b37);
+        background: rgba(225, 91, 55, 0.06);
+        color: var(--accent, #e15b37);
+        font-weight: 700;
+        font-size: 0.82rem;
+        cursor: pointer;
+        touch-action: manipulation;
+    }
+
+    .add-member-btn:active {
+        background: rgba(225, 91, 55, 0.15);
     }
 
     /* Buttons */

--- a/src/lib/components/songs/SongsScreen.svelte
+++ b/src/lib/components/songs/SongsScreen.svelte
@@ -69,13 +69,13 @@
 
     {#if store.emptyCatalog}
         <div class="empty-state">
-            <p class="empty-title">No songs yet</p>
-            <p class="empty-sub">Tap "+ Add" to create your first song.</p>
+            <p class="empty-title">Crickets...</p>
+            <p class="empty-sub">Your song list is lonelier than a drummer's social life. Tap "+ Add" to fix that.</p>
         </div>
     {:else if store.visibleSongs.length === 0}
         <div class="empty-state">
-            <p class="empty-title">No matches</p>
-            <p class="empty-sub">Try adjusting your search or filters.</p>
+            <p class="empty-title">Nope, nothing</p>
+            <p class="empty-sub">Either your search is too picky or your catalog needs more songs.</p>
         </div>
     {:else}
         <ul class="song-list">
@@ -89,7 +89,7 @@
                                     <span class="pill warn">unpracticed</span>
                                 {/if}
                                 {#if store.isSongIncomplete(song)}
-                                    <span class="pill warn">incomplete</span>
+                                    <span class="pill warn" title={store.songIncompleteReasons(song).join(", ")}>incomplete</span>
                                 {/if}
                                 {#if song.cover}
                                     <span class="pill">cover</span>
@@ -100,6 +100,13 @@
                             </div>
                             {#if memberSummary(song)}
                                 <div class="song-members">{memberSummary(song)}</div>
+                            {/if}
+                            {#if store.songIncompleteReasons(song).length > 0}
+                                <div class="incomplete-reasons">
+                                    {#each store.songIncompleteReasons(song) as reason}
+                                        <span class="incomplete-reason">{reason}</span>
+                                    {/each}
+                                </div>
                             {/if}
                             {#if song.key}
                                 <div class="song-key">Key: {song.key}</div>
@@ -331,5 +338,17 @@
     .song-key {
         font-size: 0.78rem;
         color: var(--muted, #6b7a8d);
+    }
+
+    .incomplete-reasons {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.25rem 0.5rem;
+    }
+
+    .incomplete-reason {
+        font-size: 0.75rem;
+        color: #b07020;
+        font-weight: 600;
     }
 </style>

--- a/src/lib/defaults.js
+++ b/src/lib/defaults.js
@@ -26,13 +26,13 @@ const DEFAULT_CONFIG_TEMPLATE = {
             ]
         },
         weighting: {
-            tuning: 5,
+            tuning: 4,
             capo: 2,
             instrument: 3,
             technique: 1,
             positionMiss: 8,
-            earlyCover: 6,
-            earlyInstrumental: 4
+            earlyCover: 2,
+            earlyInstrumental: 2
         },
         randomness: {
             variantJitter: 1.5,
@@ -55,7 +55,7 @@ const DEFAULT_CONFIG_TEMPLATE = {
             kind: "instrumentField",
             field: "tuning",
             summaryLabel: "tuning changes",
-            minStreak: 3,
+            minStreak: 2,
             allowChangeOnLastSong: true
         },
         capo: {
@@ -78,7 +78,7 @@ const DEFAULT_CONFIG_TEMPLATE = {
             field: "picking",
             weightKey: "technique",
             summaryLabel: "technique changes",
-            minStreak: 2,
+            minStreak: 1,
             allowChangeOnLastSong: true
         }
     },

--- a/src/lib/defaults.js
+++ b/src/lib/defaults.js
@@ -105,29 +105,17 @@ function normalizeCatalogConfig(seedConfig = {}) {
 function normalizeBandMembers(seedMembers = {}) {
     return Object.entries(seedMembers || {}).reduce((result, [memberName, memberConfig]) => {
         const instruments = Array.isArray(memberConfig?.instruments)
-            ? memberConfig.instruments.map((instrument) => {
-                if (typeof instrument === "string") {
-                    return {
-                        name: instrument,
-                        tunings: [],
-                        defaultTuning: "",
-                        techniques: [],
-                        defaultTechnique: ""
-                    };
-                }
-
-                return {
-                    name: instrument?.name || instrument?.instrument || "",
-                    tunings: Array.isArray(instrument?.tunings)
-                        ? instrument.tunings.filter(Boolean)
-                        : [],
-                    defaultTuning: instrument?.defaultTuning || "",
-                    techniques: Array.isArray(instrument?.techniques)
-                        ? instrument.techniques.filter(Boolean)
-                        : [],
-                    defaultTechnique: instrument?.defaultTechnique || ""
-                };
-            }).filter((instrument) => instrument.name)
+            ? memberConfig.instruments.map((instrument) => ({
+                name: instrument?.name || "",
+                tunings: Array.isArray(instrument?.tunings)
+                    ? instrument.tunings.filter(Boolean)
+                    : [],
+                defaultTuning: instrument?.defaultTuning || "",
+                techniques: Array.isArray(instrument?.techniques)
+                    ? instrument.techniques.filter(Boolean)
+                    : [],
+                defaultTechnique: instrument?.defaultTechnique || ""
+            })).filter((instrument) => instrument.name)
             : [];
 
         result[memberName] = {
@@ -191,22 +179,8 @@ export function normalizeSongRecord(song) {
         schemaVersion: song.schemaVersion || SCHEMA_VERSION,
         createdAt: song.createdAt || timestamp,
         updatedAt: song.updatedAt || timestamp,
-        members: migrateSongMembers(song.members || {})
+        members: song.members || {}
     };
-}
-
-function migrateSongMembers(members) {
-    const result = clone(members);
-    Object.values(result).forEach((memberSetup) => {
-        (memberSetup.instruments || []).forEach((inst) => {
-            if (typeof inst.picking === "boolean" || typeof inst.picking === "string") {
-                inst.picking = [];
-            } else if (!Array.isArray(inst.picking)) {
-                inst.picking = [];
-            }
-        });
-    });
-    return result;
 }
 
 
@@ -218,25 +192,6 @@ export function normalizeAppConfig(config) {
     const timestamp = config.createdAt || nowIso();
     const bandMembers = normalizeBandMembers(config.band?.members || {});
     const catalog = normalizeCatalogConfig(config);
-
-    // Strip deprecated "energy" rules from order constraints
-    const order = config.general?.order;
-    if (order) {
-        for (const slot of Object.keys(order)) {
-            if (Array.isArray(order[slot])) {
-                order[slot] = order[slot].filter(([name]) => name !== "energy");
-            }
-        }
-    }
-
-    // Strip deprecated energy-related weighting keys
-    const weighting = config.general?.weighting;
-    if (weighting) {
-        delete weighting.energyTarget;
-        delete weighting.repeatEnergy;
-        delete weighting.energyStreak;
-        delete weighting.bigEnergyJump;
-    }
 
     return deepMerge(createDefaultAppConfig({ bandName: config.bandName || "" }), {
         ...clone(config),

--- a/src/lib/defaults.js
+++ b/src/lib/defaults.js
@@ -182,7 +182,6 @@ export function normalizeSongRecord(song) {
     return {
         id: String(song.id),
         name: song.name || "",
-        energy: Number(song.energy || 2),
         cover: Boolean(song.cover),
         instrumental: Boolean(song.instrumental),
         notGoodOpener: Boolean(song.notGoodOpener),
@@ -219,6 +218,26 @@ export function normalizeAppConfig(config) {
     const timestamp = config.createdAt || nowIso();
     const bandMembers = normalizeBandMembers(config.band?.members || {});
     const catalog = normalizeCatalogConfig(config);
+
+    // Strip deprecated "energy" rules from order constraints
+    const order = config.general?.order;
+    if (order) {
+        for (const slot of Object.keys(order)) {
+            if (Array.isArray(order[slot])) {
+                order[slot] = order[slot].filter(([name]) => name !== "energy");
+            }
+        }
+    }
+
+    // Strip deprecated energy-related weighting keys
+    const weighting = config.general?.weighting;
+    if (weighting) {
+        delete weighting.energyTarget;
+        delete weighting.repeatEnergy;
+        delete weighting.energyStreak;
+        delete weighting.bigEnergyJump;
+    }
+
     return deepMerge(createDefaultAppConfig({ bandName: config.bandName || "" }), {
         ...clone(config),
         bandName: config.bandName || "",

--- a/src/lib/detection.js
+++ b/src/lib/detection.js
@@ -1,0 +1,171 @@
+/**
+ * Shared change detection for setlist transitions.
+ *
+ * Single source of truth used by both the generator (beam search + finalization)
+ * and the anxiety scoring module.
+ */
+
+// ---------------------------------------------------------------------------
+// Value normalization
+// ---------------------------------------------------------------------------
+
+export function normalizeValue(value) {
+    if (value === undefined || value === null) return "";
+    if (Array.isArray(value)) return value.slice().sort().join(",");
+    return String(value);
+}
+
+export function displayValue(value) {
+    if (value === undefined || value === null || value === "") return "default";
+    if (Array.isArray(value)) return value.length === 0 ? "default" : value.join(", ");
+    return String(value);
+}
+
+
+// ---------------------------------------------------------------------------
+// Full detection (with notes — used for finalization / display)
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect instrument set changes (member's instrument itself changed,
+ * or member appeared/disappeared).
+ *
+ * @param {object} prevPerf - previous song's performance map
+ * @param {object} nextPerf - next song's performance map
+ * @returns {{ changed: boolean, magnitude: number, notes: string[] }}
+ */
+export function detectInstrumentSetChange(prevPerf, nextPerf) {
+    const members = new Set([
+        ...Object.keys(prevPerf),
+        ...Object.keys(nextPerf)
+    ]);
+    const notes = [];
+    let magnitude = 0;
+
+    for (const member of Array.from(members).sort()) {
+        const prev = prevPerf[member];
+        const next = nextPerf[member];
+
+        if (!prev || !next) {
+            magnitude += 1;
+            notes.push(`${member} instrument on/off`);
+            continue;
+        }
+        if (prev.instrument !== next.instrument) {
+            magnitude += 1;
+            notes.push(`${member} instrument ${prev.instrument} -> ${next.instrument}`);
+        }
+    }
+
+    return { changed: magnitude > 0, magnitude, notes };
+}
+
+/**
+ * Detect value changes for a given field across all members present in
+ * EITHER song. Members only in one song are skipped (instrument set
+ * change handles the on/off transition).
+ *
+ * @param {object} prevPerf - previous song's performance map
+ * @param {object} nextPerf - next song's performance map
+ * @param {string} field - the field to compare (e.g. "tuning", "capo", "picking")
+ * @param {boolean} scaleByDelta - if true, magnitude = numeric difference; else 1 per change
+ * @returns {{ changed: boolean, magnitude: number, notes: string[] }}
+ */
+export function detectFieldChange(prevPerf, nextPerf, field, scaleByDelta) {
+    const allMembers = new Set([
+        ...Object.keys(prevPerf),
+        ...Object.keys(nextPerf)
+    ]);
+    const notes = [];
+    let magnitude = 0;
+
+    for (const member of Array.from(allMembers).sort()) {
+        const prev = prevPerf[member];
+        const next = nextPerf[member];
+
+        // Member only in one song — skip field comparison
+        if (!prev || !next) continue;
+
+        const prevValue = prev[field];
+        const nextValue = next[field];
+
+        const left = normalizeValue(prevValue);
+        const right = normalizeValue(nextValue);
+
+        if (left === right) continue;
+
+        const amount = scaleByDelta
+            ? Math.abs((Number(prevValue) || 0) - (Number(nextValue) || 0))
+            : 1;
+        if (!amount) continue;
+
+        magnitude += amount;
+        notes.push(`${member} ${field} ${displayValue(prevValue)} -> ${displayValue(nextValue)}`);
+    }
+
+    return { changed: magnitude > 0, magnitude, notes };
+}
+
+
+// ---------------------------------------------------------------------------
+// Lite detection (no notes — used during beam search for speed)
+// ---------------------------------------------------------------------------
+
+/**
+ * Lite version of detectInstrumentSetChange — returns { changed, magnitude } only.
+ */
+export function detectInstrumentSetChangeLite(prevPerf, nextPerf) {
+    let magnitude = 0;
+    const prevKeys = Object.keys(prevPerf);
+    const nextKeys = Object.keys(nextPerf);
+
+    for (let i = 0; i < prevKeys.length; i++) {
+        const m = prevKeys[i];
+        if (!nextPerf[m]) { magnitude += 1; continue; }
+        if (prevPerf[m].instrument !== nextPerf[m].instrument) { magnitude += 1; }
+    }
+    for (let i = 0; i < nextKeys.length; i++) {
+        if (!prevPerf[nextKeys[i]]) { magnitude += 1; }
+    }
+
+    return { changed: magnitude > 0, magnitude };
+}
+
+/**
+ * Lite version of detectFieldChange — returns { changed, magnitude } only.
+ */
+export function detectFieldChangeLite(prevPerf, nextPerf, field, scaleByDelta) {
+    let magnitude = 0;
+    const prevKeys = Object.keys(prevPerf);
+    const nextKeys = Object.keys(nextPerf);
+
+    // Check members in prev
+    for (let i = 0; i < prevKeys.length; i++) {
+        const member = prevKeys[i];
+        if (!nextPerf[member]) continue; // member only in prev — skip
+        const prevValue = prevPerf[member][field];
+        const nextValue = nextPerf[member][field];
+        const left = normalizeValue(prevValue);
+        const right = normalizeValue(nextValue);
+        if (left === right) continue;
+        const amount = scaleByDelta ? Math.abs((Number(prevValue) || 0) - (Number(nextValue) || 0)) : 1;
+        if (!amount) continue;
+        magnitude += amount;
+    }
+
+    // Check members only in next (not in prev) — skip for field change
+    // (instrument set change handles on/off)
+
+    return { changed: magnitude > 0, magnitude };
+}
+
+
+// ---------------------------------------------------------------------------
+// Prop kind inference
+// ---------------------------------------------------------------------------
+
+export function inferPropKind(propName) {
+    if (propName === "instruments") return "instrumentSet";
+    if (propName === "capo") return "instrumentDelta";
+    return "instrumentField";
+}

--- a/src/lib/detection.test.js
+++ b/src/lib/detection.test.js
@@ -1,0 +1,301 @@
+import { describe, it, expect } from "vitest";
+import {
+    normalizeValue,
+    displayValue,
+    detectInstrumentSetChange,
+    detectFieldChange,
+    detectInstrumentSetChangeLite,
+    detectFieldChangeLite,
+    inferPropKind
+} from "./detection.js";
+
+
+// ===================================================================
+// normalizeValue
+// ===================================================================
+describe("normalizeValue", () => {
+    it("returns empty string for null/undefined", () => {
+        expect(normalizeValue(null)).toBe("");
+        expect(normalizeValue(undefined)).toBe("");
+    });
+
+    it("stringifies primitives", () => {
+        expect(normalizeValue("Standard")).toBe("Standard");
+        expect(normalizeValue(2)).toBe("2");
+        expect(normalizeValue(0)).toBe("0");
+    });
+
+    it("sorts and joins arrays", () => {
+        expect(normalizeValue(["picking", "slide"])).toBe("picking,slide");
+        expect(normalizeValue(["slide", "picking"])).toBe("picking,slide");
+    });
+
+    it("returns empty string for empty array", () => {
+        expect(normalizeValue([])).toBe("");
+    });
+
+    it("handles single-element arrays", () => {
+        expect(normalizeValue(["clawhammer"])).toBe("clawhammer");
+    });
+});
+
+
+// ===================================================================
+// displayValue
+// ===================================================================
+describe("displayValue", () => {
+    it("returns 'default' for null/undefined/empty", () => {
+        expect(displayValue(null)).toBe("default");
+        expect(displayValue(undefined)).toBe("default");
+        expect(displayValue("")).toBe("default");
+    });
+
+    it("returns 'default' for empty array", () => {
+        expect(displayValue([])).toBe("default");
+    });
+
+    it("joins arrays with comma-space", () => {
+        expect(displayValue(["picking", "slide"])).toBe("picking, slide");
+    });
+
+    it("returns string for primitives", () => {
+        expect(displayValue("Standard")).toBe("Standard");
+        expect(displayValue(2)).toBe("2");
+    });
+});
+
+
+// ===================================================================
+// detectInstrumentSetChange (full)
+// ===================================================================
+describe("detectInstrumentSetChange", () => {
+    it("no change when instruments stay the same", () => {
+        const prev = { nick: { instrument: "banjo" }, mark: { instrument: "guitar" } };
+        const next = { nick: { instrument: "banjo" }, mark: { instrument: "guitar" } };
+        const r = detectInstrumentSetChange(prev, next);
+        expect(r.changed).toBe(false);
+        expect(r.magnitude).toBe(0);
+        expect(r.notes).toHaveLength(0);
+    });
+
+    it("detects instrument swap", () => {
+        const prev = { nick: { instrument: "banjo" } };
+        const next = { nick: { instrument: "guitar" } };
+        const r = detectInstrumentSetChange(prev, next);
+        expect(r.changed).toBe(true);
+        expect(r.magnitude).toBe(1);
+        expect(r.notes[0]).toContain("banjo -> guitar");
+    });
+
+    it("detects member appearing", () => {
+        const r = detectInstrumentSetChange({}, { nick: { instrument: "banjo" } });
+        expect(r.changed).toBe(true);
+        expect(r.magnitude).toBe(1);
+        expect(r.notes[0]).toContain("on/off");
+    });
+
+    it("detects member disappearing", () => {
+        const r = detectInstrumentSetChange({ nick: { instrument: "banjo" } }, {});
+        expect(r.changed).toBe(true);
+        expect(r.magnitude).toBe(1);
+    });
+
+    it("counts each member independently", () => {
+        const prev = { nick: { instrument: "banjo" }, mark: { instrument: "guitar" } };
+        const next = { nick: { instrument: "guitar" }, mark: { instrument: "bass" } };
+        const r = detectInstrumentSetChange(prev, next);
+        expect(r.magnitude).toBe(2);
+    });
+
+    it("detects simultaneous appear + disappear", () => {
+        const prev = { nick: { instrument: "banjo" } };
+        const next = { mark: { instrument: "guitar" } };
+        const r = detectInstrumentSetChange(prev, next);
+        expect(r.magnitude).toBe(2); // nick disappears, mark appears
+    });
+});
+
+
+// ===================================================================
+// detectInstrumentSetChangeLite
+// ===================================================================
+describe("detectInstrumentSetChangeLite", () => {
+    it("no change when same", () => {
+        const prev = { nick: { instrument: "banjo" } };
+        const next = { nick: { instrument: "banjo" } };
+        const r = detectInstrumentSetChangeLite(prev, next);
+        expect(r.changed).toBe(false);
+        expect(r.magnitude).toBe(0);
+        expect(r).not.toHaveProperty("notes");
+    });
+
+    it("detects instrument swap", () => {
+        const r = detectInstrumentSetChangeLite(
+            { nick: { instrument: "banjo" } },
+            { nick: { instrument: "guitar" } }
+        );
+        expect(r.magnitude).toBe(1);
+    });
+
+    it("detects member appearing", () => {
+        const r = detectInstrumentSetChangeLite({}, { nick: { instrument: "banjo" } });
+        expect(r.magnitude).toBe(1);
+    });
+
+    it("detects member disappearing", () => {
+        const r = detectInstrumentSetChangeLite({ nick: { instrument: "banjo" } }, {});
+        expect(r.magnitude).toBe(1);
+    });
+
+    it("counts both directions", () => {
+        const r = detectInstrumentSetChangeLite(
+            { nick: { instrument: "banjo" } },
+            { mark: { instrument: "guitar" } }
+        );
+        expect(r.magnitude).toBe(2);
+    });
+});
+
+
+// ===================================================================
+// detectFieldChange (full)
+// ===================================================================
+describe("detectFieldChange", () => {
+    it("detects tuning change for shared member", () => {
+        const prev = { mark: { tuning: "DADDAD" } };
+        const next = { mark: { tuning: "Standard" } };
+        const r = detectFieldChange(prev, next, "tuning", false);
+        expect(r.changed).toBe(true);
+        expect(r.magnitude).toBe(1);
+        expect(r.notes[0]).toContain("DADDAD -> Standard");
+    });
+
+    it("no change when values match", () => {
+        const prev = { mark: { tuning: "Standard" } };
+        const next = { mark: { tuning: "Standard" } };
+        const r = detectFieldChange(prev, next, "tuning", false);
+        expect(r.changed).toBe(false);
+    });
+
+    it("capo delta scaling", () => {
+        const prev = { nick: { capo: 0 } };
+        const next = { nick: { capo: 3 } };
+        const r = detectFieldChange(prev, next, "capo", true);
+        expect(r.magnitude).toBe(3);
+    });
+
+    it("handles array fields — order independent", () => {
+        const prev = { nick: { picking: ["slide", "picking"] } };
+        const next = { nick: { picking: ["picking", "slide"] } };
+        const r = detectFieldChange(prev, next, "picking", false);
+        expect(r.changed).toBe(false); // same elements, different order
+    });
+
+    it("detects array content change", () => {
+        const prev = { nick: { picking: ["picking"] } };
+        const next = { nick: { picking: ["clawhammer"] } };
+        const r = detectFieldChange(prev, next, "picking", false);
+        expect(r.changed).toBe(true);
+        expect(r.magnitude).toBe(1);
+    });
+
+    it("detects empty array to populated array", () => {
+        const prev = { nick: { picking: [] } };
+        const next = { nick: { picking: ["slide"] } };
+        const r = detectFieldChange(prev, next, "picking", false);
+        expect(r.changed).toBe(true);
+    });
+
+    it("skips members only in one song", () => {
+        const prev = { mark: { tuning: "Standard" } };
+        const next = { nick: { tuning: "Open G" } };
+        const r = detectFieldChange(prev, next, "tuning", false);
+        expect(r.changed).toBe(false); // no shared members for field comparison
+    });
+
+    it("counts changes per member independently", () => {
+        const prev = { nick: { capo: 0 }, mark: { capo: 0 } };
+        const next = { nick: { capo: 2 }, mark: { capo: 3 } };
+        const r = detectFieldChange(prev, next, "capo", true);
+        expect(r.magnitude).toBe(5); // 2 + 3
+    });
+});
+
+
+// ===================================================================
+// detectFieldChangeLite
+// ===================================================================
+describe("detectFieldChangeLite", () => {
+    it("detects tuning change", () => {
+        const r = detectFieldChangeLite(
+            { mark: { tuning: "DADDAD" } },
+            { mark: { tuning: "Standard" } },
+            "tuning", false
+        );
+        expect(r.changed).toBe(true);
+        expect(r.magnitude).toBe(1);
+        expect(r).not.toHaveProperty("notes");
+    });
+
+    it("no change when values match", () => {
+        const r = detectFieldChangeLite(
+            { mark: { tuning: "Standard" } },
+            { mark: { tuning: "Standard" } },
+            "tuning", false
+        );
+        expect(r.changed).toBe(false);
+    });
+
+    it("handles array fields — order independent", () => {
+        const r = detectFieldChangeLite(
+            { nick: { picking: ["slide", "picking"] } },
+            { nick: { picking: ["picking", "slide"] } },
+            "picking", false
+        );
+        expect(r.changed).toBe(false);
+    });
+
+    it("capo delta", () => {
+        const r = detectFieldChangeLite(
+            { nick: { capo: 0 } },
+            { nick: { capo: 4 } },
+            "capo", true
+        );
+        expect(r.magnitude).toBe(4);
+    });
+
+    it("skips members only in one song", () => {
+        const r = detectFieldChangeLite(
+            { mark: { tuning: "Standard" } },
+            { nick: { tuning: "Open G" } },
+            "tuning", false
+        );
+        expect(r.changed).toBe(false);
+    });
+});
+
+
+// ===================================================================
+// inferPropKind
+// ===================================================================
+describe("inferPropKind", () => {
+    it("instruments -> instrumentSet", () => {
+        expect(inferPropKind("instruments")).toBe("instrumentSet");
+    });
+
+    it("capo -> instrumentDelta", () => {
+        expect(inferPropKind("capo")).toBe("instrumentDelta");
+    });
+
+    it("tuning -> instrumentField", () => {
+        expect(inferPropKind("tuning")).toBe("instrumentField");
+    });
+
+    it("picking -> instrumentField (NOT instrumentBoolean)", () => {
+        expect(inferPropKind("picking")).toBe("instrumentField");
+    });
+
+    it("unknown -> instrumentField", () => {
+        expect(inferPropKind("foo")).toBe("instrumentField");
+    });
+});

--- a/src/lib/generator.js
+++ b/src/lib/generator.js
@@ -1,4 +1,5 @@
 import { deepMerge, toArray } from "./utils.js";
+import { computeAnxiety } from "./anxiety.js";
 
 function clampInteger(value, fallback, minimum) {
     const parsed = Number.parseInt(value, 10);
@@ -576,54 +577,7 @@ class SetList {
             };
         });
 
-        // Compute anxiety: weighted gear changes with spread factor
-        const songCount = finalizedItems.length;
-        const totalTransitions = Math.max(1, songCount - 1);
-        let totalWeighted = 0;
-        let totalRawChanges = 0;
-        let transitionsWithChanges = 0;
-
-        for (let idx = 1; idx < finalizedItems.length; idx++) {
-            const song = finalizedItems[idx];
-            const changes = song.propChanges || {};
-            let hasChange = false;
-
-            for (const propName of this._propNames) {
-                const change = changes[propName];
-                if (!change || !change.changed) continue;
-                const w = this._getPropWeight(propName);
-                totalWeighted += change.magnitude * w;
-                totalRawChanges += change.magnitude;
-                hasChange = true;
-            }
-            if (hasChange) transitionsWithChanges++;
-        }
-
-        // Spread factor: scattered changes (more disrupted transitions) = more anxiety
-        const spreadRatio = transitionsWithChanges / totalTransitions;
-        const adjustedWeighted = totalWeighted * (0.5 + spreadRatio * 0.5);
-
-        // Dynamic scale based on this band's weights
-        let avgWeight = 0;
-        if (this._propNames.length > 0) {
-            let sumW = 0;
-            for (const propName of this._propNames) {
-                sumW += this._getPropWeight(propName);
-            }
-            avgWeight = sumW / this._propNames.length;
-        }
-        const mediumBaseline = totalTransitions * 0.3 * avgWeight;
-        const maxBaseline = totalTransitions * avgWeight * 2;
-
-        let anxietyScaled;
-        if (maxBaseline <= 0) {
-            anxietyScaled = 0;
-        } else if (adjustedWeighted <= mediumBaseline) {
-            anxietyScaled = Math.round((adjustedWeighted / mediumBaseline) * 5);
-        } else {
-            anxietyScaled = 5 + Math.round(((adjustedWeighted - mediumBaseline) / (maxBaseline - mediumBaseline)) * 5);
-        }
-        anxietyScaled = Math.max(0, Math.min(10, anxietyScaled));
+        const anxiety = computeAnxiety(finalizedItems, this._config);
 
         return {
             items: finalizedItems,
@@ -632,13 +586,7 @@ class SetList {
                 covers: state.coverCount,
                 instrumentals: state.instrumentalCount,
                 changes: state.changeTotals,
-                anxiety: {
-                    scaled: anxietyScaled,
-                    rawChanges: totalRawChanges,
-                    weightedScore: Math.round(adjustedWeighted * 10) / 10,
-                    transitionsDisrupted: transitionsWithChanges,
-                    totalTransitions
-                }
+                anxiety
             }
         };
     }
@@ -1223,46 +1171,7 @@ export function scoreFixedOrder(fixedSongs, config) {
         });
     });
 
-    // Compute anxiety for reordered setlist
-    const totalTransitions = Math.max(1, count - 1);
-    let totalWeighted = 0;
-    let totalRawChanges = 0;
-    let transitionsWithChanges = 0;
-
-    for (let idx = 1; idx < items.length; idx++) {
-        const changes = items[idx].propChanges || {};
-        let hasChange = false;
-        for (const pn of propNames) {
-            const change = changes[pn];
-            if (!change || !change.changed) continue;
-            totalWeighted += change.magnitude * getPropWeight(pn);
-            totalRawChanges += change.magnitude;
-            hasChange = true;
-        }
-        if (hasChange) transitionsWithChanges++;
-    }
-
-    const spreadRatio = transitionsWithChanges / totalTransitions;
-    const adjustedWeighted = totalWeighted * (0.5 + spreadRatio * 0.5);
-
-    let avgWeight = 0;
-    if (propNames.length > 0) {
-        let sumW = 0;
-        for (const pn of propNames) sumW += getPropWeight(pn);
-        avgWeight = sumW / propNames.length;
-    }
-    const mediumBaseline = totalTransitions * 0.3 * avgWeight;
-    const maxBaseline = totalTransitions * avgWeight * 2;
-
-    let anxietyScaled;
-    if (maxBaseline <= 0) {
-        anxietyScaled = 0;
-    } else if (adjustedWeighted <= mediumBaseline) {
-        anxietyScaled = Math.round((adjustedWeighted / mediumBaseline) * 5);
-    } else {
-        anxietyScaled = 5 + Math.round(((adjustedWeighted - mediumBaseline) / (maxBaseline - mediumBaseline)) * 5);
-    }
-    anxietyScaled = Math.max(0, Math.min(10, anxietyScaled));
+    const anxiety = computeAnxiety(items, config);
 
     return {
         songs: items,
@@ -1270,13 +1179,7 @@ export function scoreFixedOrder(fixedSongs, config) {
             score: totalScore,
             covers: coverCount,
             instrumentals: instrumentalCount,
-            anxiety: {
-                scaled: anxietyScaled,
-                rawChanges: totalRawChanges,
-                weightedScore: Math.round(adjustedWeighted * 10) / 10,
-                transitionsDisrupted: transitionsWithChanges,
-                totalTransitions
-            }
+            anxiety
         }
     };
 }

--- a/src/lib/generator.js
+++ b/src/lib/generator.js
@@ -1,5 +1,14 @@
 import { deepMerge, toArray } from "./utils.js";
 import { computeAnxiety } from "./anxiety.js";
+import {
+    normalizeValue,
+    displayValue,
+    detectInstrumentSetChange,
+    detectFieldChange,
+    detectInstrumentSetChangeLite,
+    detectFieldChangeLite,
+    inferPropKind
+} from "./detection.js";
 
 function clampInteger(value, fallback, minimum) {
     const parsed = Number.parseInt(value, 10);
@@ -212,6 +221,7 @@ class SetList {
         });
         this._songBiasById = this._buildSongBiases(this._catalog);
         this._count = Math.min(this._options.count, this._catalog.length);
+        this._minConstraints = this._buildMinConstraints();
         this._list = [];
         this._summary = {
             score: 0,
@@ -290,6 +300,95 @@ class SetList {
         return this._songBiasById[songId] || 0;
     }
 
+    /**
+     * Pre-compute minimum instrument/tuning constraints from show config.
+     * Returns { instruments: [{member, instrument, min}], tunings: [{member, instrument, tuning, min}] }
+     */
+    _buildMinConstraints() {
+        const constraints = { instruments: [], tunings: [] };
+        const showMembers = this._show.members || {};
+
+        for (const [memberName, memberShow] of Object.entries(showMembers)) {
+            const allowed = memberShow.allowedInstruments || [];
+            if (allowed.length >= 2) {
+                const min = memberShow.minSongsPerInstrument ?? 2;
+                for (const inst of allowed) {
+                    constraints.instruments.push({ member: memberName, instrument: inst, min });
+                }
+            }
+
+            const allowedTunings = memberShow.allowedTunings || {};
+            const minPerTuning = memberShow.minSongsPerTuning || {};
+            for (const [instName, tunings] of Object.entries(allowedTunings)) {
+                if (tunings.length >= 2) {
+                    const min = minPerTuning[instName] ?? 2;
+                    for (const tuning of tunings) {
+                        constraints.tunings.push({ member: memberName, instrument: instName, tuning, min });
+                    }
+                }
+            }
+        }
+
+        return constraints;
+    }
+
+    /**
+     * Count instrument/tuning usage from a variant's performance.
+     */
+    _updateUsageCounts(counts, variant) {
+        const next = {
+            instruments: { ...counts.instruments },
+            tunings: { ...counts.tunings }
+        };
+        const perf = variant.performance || {};
+        for (const [member, setup] of Object.entries(perf)) {
+            const instKey = `${member}:${setup.instrument}`;
+            next.instruments[instKey] = (next.instruments[instKey] || 0) + 1;
+            if (setup.tuning) {
+                const tuningKey = `${member}:${setup.instrument}:${setup.tuning}`;
+                next.tunings[tuningKey] = (next.tunings[tuningKey] || 0) + 1;
+            }
+        }
+        return next;
+    }
+
+    /**
+     * Score penalty for unmet minimum constraints. Returns a positive number
+     * when we're falling behind on meeting minimums.
+     * Returns Infinity if it's mathematically impossible to meet them.
+     */
+    _scoreMinimumPenalty(usageCounts, position) {
+        const remaining = this._count - position;
+        let penalty = 0;
+
+        for (const c of this._minConstraints.instruments) {
+            const key = `${c.member}:${c.instrument}`;
+            const have = usageCounts.instruments[key] || 0;
+            const deficit = c.min - have;
+            if (deficit > 0 && deficit > remaining) {
+                return Infinity; // impossible to meet
+            }
+            if (deficit > 0) {
+                // Proportional penalty: higher when deadline is closer
+                penalty += deficit * (this._weights.instrument || 3) * (1 + (1 / (remaining + 1)));
+            }
+        }
+
+        for (const c of this._minConstraints.tunings) {
+            const key = `${c.member}:${c.instrument}:${c.tuning}`;
+            const have = usageCounts.tunings[key] || 0;
+            const deficit = c.min - have;
+            if (deficit > 0 && deficit > remaining) {
+                return Infinity;
+            }
+            if (deficit > 0) {
+                penalty += deficit * (this._weights.tuning || 4) * (1 + (1 / (remaining + 1)));
+            }
+        }
+
+        return penalty;
+    }
+
     _initialState() {
         return {
             // Linked list: head points to { item, prev } chain
@@ -304,7 +403,8 @@ class SetList {
             _tiebreaker: 0,
             propChangeCounts: zeroMap(this._propNames),
             propStreaks: zeroMap(this._propNames),
-            changeTotals: zeroMap(this._propNames)
+            changeTotals: zeroMap(this._propNames),
+            usageCounts: { instruments: {}, tunings: {} }
         };
     }
 
@@ -623,7 +723,8 @@ class SetList {
             _tiebreaker: this._rng(),
             propChangeCounts: bestVariant.propChangeCounts,
             propStreaks: bestVariant.propStreaks,
-            changeTotals: bestVariant.changeTotals
+            changeTotals: bestVariant.changeTotals,
+            usageCounts: bestVariant.usageCounts
         };
     }
 
@@ -631,6 +732,9 @@ class SetList {
         const prevItem = state.lastItem;
         let best = null;
         let bestScore = Infinity;
+        // Fallback: track best variant even if minimums are impossible
+        let fallback = null;
+        let fallbackScore = Infinity;
 
         const variants = this._variantCache.get(song.id);
         for (let vi = 0; vi < variants.length; vi++) {
@@ -641,9 +745,30 @@ class SetList {
             }
 
             const nextPropState = this._advancePropState(state, propTransition.changes, prevItem);
+            const nextUsageCounts = this._updateUsageCounts(state.usageCounts, variant);
+            const minimumPenalty = this._scoreMinimumPenalty(nextUsageCounts, position);
+
             const positionScore = this._scorePositionLite(variant, position);
             const transitionScore = propTransition.score;
-            const incrementalScore = transitionScore + positionScore + this._songBias(variant.id);
+
+            if (minimumPenalty === Infinity) {
+                // Track as fallback in case all variants are impossible
+                const fbScore = transitionScore + positionScore + this._songBias(variant.id);
+                if (fbScore < fallbackScore) {
+                    fallbackScore = fbScore;
+                    fallback = {
+                        propChangeCounts: nextPropState.propChangeCounts,
+                        propStreaks: nextPropState.propStreaks,
+                        changeTotals: nextPropState.changeTotals,
+                        usageCounts: nextUsageCounts,
+                        incrementalScore: fbScore,
+                        item: variant
+                    };
+                }
+                continue;
+            }
+
+            const incrementalScore = transitionScore + positionScore + this._songBias(variant.id) + minimumPenalty;
             const exploratoryScore = incrementalScore + this._randomJitter(this._randomness.variantJitter);
 
             if (exploratoryScore < bestScore) {
@@ -652,13 +777,14 @@ class SetList {
                     propChangeCounts: nextPropState.propChangeCounts,
                     propStreaks: nextPropState.propStreaks,
                     changeTotals: nextPropState.changeTotals,
+                    usageCounts: nextUsageCounts,
                     incrementalScore,
                     item: variant
                 };
             }
         }
 
-        return best;
+        return best || fallback;
     }
 
     // Lite version: returns { score, changes } without building notes arrays
@@ -682,59 +808,16 @@ class SetList {
         if (!prevItem) {
             return { changed: false, magnitude: 0 };
         }
-        const kind = rule.kind || this._inferPropKind(propName);
+        const prevPerf = prevItem.performance;
+        const nextPerf = nextVariant.performance;
+        const kind = rule.kind || inferPropKind(propName);
         if (kind === "instrumentSet") {
-            return this._detectInstrumentSetChangeLite(prevItem, nextVariant);
+            return detectInstrumentSetChangeLite(prevPerf, nextPerf);
         }
         if (kind === "instrumentDelta") {
-            return this._detectInstrumentValueChangeLite(prevItem, nextVariant, rule, true, false);
+            return detectFieldChangeLite(prevPerf, nextPerf, rule.field || propName, true);
         }
-        if (kind === "instrumentBoolean") {
-            return this._detectInstrumentValueChangeLite(prevItem, nextVariant, rule, false, true);
-        }
-        return this._detectInstrumentValueChangeLite(prevItem, nextVariant, rule, false, false);
-    }
-
-    _detectInstrumentSetChangeLite(prevItem, nextVariant) {
-        const prevPerf = prevItem.performance;
-        const nextPerf = nextVariant.performance;
-        let magnitude = 0;
-        const prevKeys = Object.keys(prevPerf);
-        const nextKeys = Object.keys(nextPerf);
-        for (let i = 0; i < prevKeys.length; i++) {
-            const m = prevKeys[i];
-            if (!nextPerf[m]) { magnitude += 1; continue; }
-            if (prevPerf[m].instrument !== nextPerf[m].instrument) { magnitude += 1; }
-        }
-        for (let i = 0; i < nextKeys.length; i++) {
-            if (!prevPerf[nextKeys[i]]) { magnitude += 1; }
-        }
-        return { changed: magnitude > 0, magnitude };
-    }
-
-    _detectInstrumentValueChangeLite(prevItem, nextVariant, rule, scaleByDelta, coerceBoolean) {
-        const field = rule.field;
-        let magnitude = 0;
-        const prevPerf = prevItem.performance;
-        const nextPerf = nextVariant.performance;
-        const prevKeys = Object.keys(prevPerf);
-        for (let i = 0; i < prevKeys.length; i++) {
-            const member = prevKeys[i];
-            if (!nextPerf[member]) continue;
-            const prevValue = prevPerf[member][field];
-            const nextValue = nextPerf[member][field];
-            if (coerceBoolean) {
-                if (Boolean(prevValue) === Boolean(nextValue)) continue;
-            } else {
-                const left = (prevValue === undefined || prevValue === null) ? "" : String(prevValue);
-                const right = (nextValue === undefined || nextValue === null) ? "" : String(nextValue);
-                if (left === right) continue;
-            }
-            const amount = scaleByDelta ? Math.abs((prevValue || 0) - (nextValue || 0)) : 1;
-            if (!amount) continue;
-            magnitude += amount;
-        }
-        return { changed: magnitude > 0, magnitude };
+        return detectFieldChangeLite(prevPerf, nextPerf, rule.field || propName, false);
     }
 
     // Lite position scoring: returns just the numeric score
@@ -780,116 +863,20 @@ class SetList {
 
     _detectPropChange(prevItem, nextVariant, propName, rule) {
         if (!prevItem) {
-            return {
-                changed: false,
-                magnitude: 0,
-                notes: []
-            };
+            return { changed: false, magnitude: 0, notes: [] };
         }
 
-        const kind = rule.kind || this._inferPropKind(propName);
+        const prevPerf = prevItem.performance;
+        const nextPerf = nextVariant.performance;
+        const kind = rule.kind || inferPropKind(propName);
+
         if (kind === "instrumentSet") {
-            return this._detectInstrumentSetChange(prevItem, nextVariant);
+            return detectInstrumentSetChange(prevPerf, nextPerf);
         }
         if (kind === "instrumentDelta") {
-            return this._detectInstrumentValueChange(prevItem, nextVariant, rule, true);
+            return detectFieldChange(prevPerf, nextPerf, rule.field || propName, true);
         }
-        if (kind === "instrumentBoolean") {
-            return this._detectInstrumentValueChange(prevItem, nextVariant, rule, false, true);
-        }
-        return this._detectInstrumentValueChange(prevItem, nextVariant, rule, false, false);
-    }
-
-    _inferPropKind(propName) {
-        if (propName === "instruments") {
-            return "instrumentSet";
-        }
-        if (propName === "capo") {
-            return "instrumentDelta";
-        }
-        if (propName === "picking") {
-            return "instrumentBoolean";
-        }
-        return "instrumentField";
-    }
-
-    _detectInstrumentValueChange(prevItem, nextVariant, rule, scaleByDelta, coerceBoolean) {
-        const field = rule.field;
-        const notes = [];
-        let magnitude = 0;
-        const sharedMembers = Object.keys(prevItem.performance).filter((member) => {
-            return Object.prototype.hasOwnProperty.call(nextVariant.performance, member);
-        }).sort();
-
-        sharedMembers.forEach((member) => {
-            const prevValue = prevItem.performance[member][field];
-            const nextValue = nextVariant.performance[member][field];
-            const left = coerceBoolean ? Boolean(prevValue) : this._normalizeValue(prevValue);
-            const right = coerceBoolean ? Boolean(nextValue) : this._normalizeValue(nextValue);
-
-            if (left === right) {
-                return;
-            }
-
-            const amount = scaleByDelta ? Math.abs((prevValue || 0) - (nextValue || 0)) : 1;
-            if (!amount) {
-                return;
-            }
-
-            magnitude += amount;
-            notes.push(`${member} ${field} ${this._displayValue(prevValue)} -> ${this._displayValue(nextValue)}`);
-        });
-
-        return {
-            changed: magnitude > 0,
-            magnitude,
-            notes
-        };
-    }
-
-    _detectInstrumentSetChange(prevItem, nextVariant) {
-        const members = new Set([
-            ...Object.keys(prevItem.performance),
-            ...Object.keys(nextVariant.performance)
-        ]);
-        const notes = [];
-        let magnitude = 0;
-
-        Array.from(members).sort().forEach((member) => {
-            const previous = prevItem.performance[member];
-            const next = nextVariant.performance[member];
-
-            if (!previous || !next) {
-                magnitude += 1;
-                notes.push(`${member} instrument on/off`);
-                return;
-            }
-
-            if (previous.instrument !== next.instrument) {
-                magnitude += 1;
-                notes.push(`${member} instrument ${previous.instrument} -> ${next.instrument}`);
-            }
-        });
-
-        return {
-            changed: magnitude > 0,
-            magnitude,
-            notes
-        };
-    }
-
-    _normalizeValue(value) {
-        if (value === undefined || value === null) {
-            return "";
-        }
-        return String(value);
-    }
-
-    _displayValue(value) {
-        if (value === undefined || value === null || value === "") {
-            return "default";
-        }
-        return String(value);
+        return detectFieldChange(prevPerf, nextPerf, rule.field || propName, false);
     }
 
     _getPropWeight(propName) {
@@ -909,9 +896,11 @@ class SetList {
             if (!change.changed || !prevItem) {
                 continue;
             }
+            // maxChanges is always enforced, even on the last song
             if (rule.maxChanges !== undefined && state.propChangeCounts[propName] >= rule.maxChanges) {
                 return false;
             }
+            // allowChangeOnLastSong only bypasses minStreak, not maxChanges
             if (isLastSong && rule.allowChangeOnLastSong) {
                 continue;
             }
@@ -1000,21 +989,6 @@ class SetList {
         return undefined;
     }
 
-    _variantSignature(variant) {
-        const parts = [variant.name];
-        Object.keys(variant.performance).sort().forEach((member) => {
-            const setup = variant.performance[member];
-            parts.push([
-                member,
-                setup.instrument || "",
-                setup.tuning || "",
-                String(setup.capo || 0),
-                String(setup.picking || "")
-            ].join("|"));
-        });
-        return parts.join("|");
-    }
-
     toJSON() {
         return {
             options: this._options,
@@ -1062,92 +1036,50 @@ export function scoreFixedOrder(fixedSongs, config) {
         return weights[weightKey] || 0;
     }
 
-    function normalizeValue(value) {
-        if (value === undefined || value === null) return "";
-        return String(value);
-    }
+    function scorePropTransition(prevItem, nextItem) {
+        if (!prevItem) {
+            const changes = {};
+            for (const p of propNames) changes[p] = { changed: false, magnitude: 0, notes: [] };
+            return { score: 0, notes: [], changes };
+        }
 
-    function displayValue(value) {
-        if (value === undefined || value === null || value === "") return "default";
-        return String(value);
-    }
-
-    function detectInstrumentSetChange(prevItem, nextVariant) {
-        const members = new Set([
-            ...Object.keys(prevItem.performance || {}),
-            ...Object.keys(nextVariant.performance || {})
-        ]);
-        const notes = [];
-        let magnitude = 0;
-        Array.from(members).sort().forEach((member) => {
-            const previous = (prevItem.performance || {})[member];
-            const next = (nextVariant.performance || {})[member];
-            if (!previous || !next) { magnitude += 1; notes.push(`${member} instrument on/off`); return; }
-            if (previous.instrument !== next.instrument) { magnitude += 1; notes.push(`${member} instrument ${previous.instrument} -> ${next.instrument}`); }
-        });
-        return { changed: magnitude > 0, magnitude, notes };
-    }
-
-    function detectInstrumentValueChange(prevItem, nextVariant, rule, scaleByDelta, coerceBoolean) {
-        const field = rule.field;
-        const notes = [];
-        let magnitude = 0;
-        const sharedMembers = Object.keys(prevItem.performance || {}).filter((m) => Object.prototype.hasOwnProperty.call(nextVariant.performance || {}, m)).sort();
-        sharedMembers.forEach((member) => {
-            const prevValue = (prevItem.performance || {})[member]?.[field];
-            const nextValue = (nextVariant.performance || {})[member]?.[field];
-            const left = coerceBoolean ? Boolean(prevValue) : normalizeValue(prevValue);
-            const right = coerceBoolean ? Boolean(nextValue) : normalizeValue(nextValue);
-            if (left === right) return;
-            const amount = scaleByDelta ? Math.abs((prevValue || 0) - (nextValue || 0)) : 1;
-            if (!amount) return;
-            magnitude += amount;
-            notes.push(`${member} ${field} ${displayValue(prevValue)} -> ${displayValue(nextValue)}`);
-        });
-        return { changed: magnitude > 0, magnitude, notes };
-    }
-
-    function inferPropKind(propName) {
-        if (propName === "instruments") return "instrumentSet";
-        if (propName === "capo") return "instrumentDelta";
-        if (propName === "picking") return "instrumentBoolean";
-        return "instrumentField";
-    }
-
-    function detectPropChange(prevItem, nextVariant, propName, rule) {
-        if (!prevItem) return { changed: false, magnitude: 0, notes: [] };
-        const kind = rule.kind || inferPropKind(propName);
-        if (kind === "instrumentSet") return detectInstrumentSetChange(prevItem, nextVariant);
-        if (kind === "instrumentDelta") return detectInstrumentValueChange(prevItem, nextVariant, rule, true, false);
-        if (kind === "instrumentBoolean") return detectInstrumentValueChange(prevItem, nextVariant, rule, false, true);
-        return detectInstrumentValueChange(prevItem, nextVariant, rule, false, false);
-    }
-
-    function scoreConfiguredProps(prevItem, nextVariant) {
+        const prevPerf = prevItem.performance || {};
+        const nextPerf = nextItem.performance || {};
         const changes = {};
         const notes = [];
         let score = 0;
-        propNames.forEach((propName) => {
-            const change = detectPropChange(prevItem, nextVariant, propName, propConfig[propName]);
+
+        for (const propName of propNames) {
+            const rule = propConfig[propName] || {};
+            const kind = rule.kind || inferPropKind(propName);
+            let change;
+
+            if (kind === "instrumentSet") {
+                change = detectInstrumentSetChange(prevPerf, nextPerf);
+            } else if (kind === "instrumentDelta") {
+                change = detectFieldChange(prevPerf, nextPerf, rule.field || propName, true);
+            } else {
+                change = detectFieldChange(prevPerf, nextPerf, rule.field || propName, false);
+            }
+
             changes[propName] = change;
             if (change.changed) {
                 score += change.magnitude * getPropWeight(propName);
-                Array.prototype.push.apply(notes, change.notes);
+                notes.push(...change.notes);
             }
-        });
+        }
+
         return { score, notes, changes };
     }
 
-    const count = fixedSongs.length;
     const items = [];
     let totalScore = 0;
     let coverCount = 0;
     let instrumentalCount = 0;
 
     fixedSongs.forEach((song, index) => {
-        const position = index + 1;
         const prevItem = items[items.length - 1] || null;
-        const propTransition = scoreConfiguredProps(prevItem, song);
+        const propTransition = scorePropTransition(prevItem, song);
 
         const incrementalScore = propTransition.score;
         totalScore += incrementalScore;
@@ -1161,7 +1093,7 @@ export function scoreFixedOrder(fixedSongs, config) {
             instrumental: song.instrumental,
             key: song.key,
             performance: song.performance,
-            position,
+            position: index + 1,
             incrementalScore,
             cumulativeScore: totalScore,
             transitionNotes: propTransition.notes,

--- a/src/lib/generator.js
+++ b/src/lib/generator.js
@@ -1,4 +1,4 @@
-import { clone, deepMerge, toArray } from "./utils.js";
+import { deepMerge, toArray } from "./utils.js";
 
 function clampInteger(value, fallback, minimum) {
     const parsed = Number.parseInt(value, 10);
@@ -68,19 +68,18 @@ function compareStates(left, right) {
     if (left.instrumentalCount !== right.instrumentalCount) {
         return left.instrumentalCount - right.instrumentalCount;
     }
-    const leftNames = left.items.map((item) => item.name).join("|");
-    const rightNames = right.items.map((item) => item.name).join("|");
-    return leftNames.localeCompare(rightNames);
+    // Use numeric tiebreaker instead of expensive string join + localeCompare
+    return (left._tiebreaker || 0) - (right._tiebreaker || 0);
 }
 
 
 class SongsCatalog {
     constructor(list = []) {
-        this._songs = clone(list);
+        this._songs = list;
     }
 
     all() {
-        return clone(this._songs);
+        return this._songs;
     }
 
     expandVariants(song, showConstraints = {}) {
@@ -163,7 +162,7 @@ class SongsCatalog {
             return optionTunings.some((tuning) => validTunings.indexOf(tuning) >= 0);
         }).map((option) => {
             const instrumentName = option.name || option.instrument;
-            const constrainedOption = clone(option);
+            const constrainedOption = { ...option };
 
             if (allowedTunings[instrumentName]) {
                 const validTunings = toArray(allowedTunings[instrumentName]);
@@ -183,7 +182,6 @@ class SongsCatalog {
         return {
             id: String(song.id),
             name: song.name,
-            energy: song.energy || 2,
             cover: Boolean(song.cover),
             instrumental: Boolean(song.instrumental),
             notGoodOpener: Boolean(song.notGoodOpener),
@@ -231,13 +229,13 @@ class SetList {
         const limits = this._config.general?.limits || {};
         const normalized = merge({
             count: this._config.general?.count || 15,
-            beamWidth: this._config.general?.beamWidth || 64,
+            beamWidth: this._config.general?.beamWidth || 20,
             maxCovers: limits.covers || 2,
             maxInstrumentals: limits.instrumentals || 2
         }, options || {});
 
         normalized.count = clampInteger(normalized.count, this._config.general?.count || 15, 1);
-        normalized.beamWidth = clampInteger(normalized.beamWidth, this._config.general?.beamWidth || 64, 1);
+        normalized.beamWidth = clampInteger(normalized.beamWidth, this._config.general?.beamWidth || 20, 1);
         normalized.maxCovers = clampInteger(normalized.maxCovers, limits.covers || 2, 0);
         normalized.maxInstrumentals = clampInteger(normalized.maxInstrumentals, limits.instrumentals || 2, 0);
         normalized.show = deepMerge(this._config.show || {}, normalized.show || {});
@@ -293,39 +291,61 @@ class SetList {
 
     _initialState() {
         return {
-            items: [],
-            usedIds: {},
+            // Linked list: head points to { item, prev } chain
+            head: null,
+            length: 0,
+            usedIds: Object.create(null),
             score: 0,
             coverCount: 0,
             instrumentalCount: 0,
-            energyStreak: 0,
-            lastEnergy: null,
+            lastItem: null,
             rankScore: 0,
+            _tiebreaker: 0,
             propChangeCounts: zeroMap(this._propNames),
             propStreaks: zeroMap(this._propNames),
             changeTotals: zeroMap(this._propNames)
         };
     }
 
+    // Reconstruct items array from linked list
+    _collectItems(state) {
+        const items = new Array(state.length);
+        let node = state.head;
+        for (let i = state.length - 1; i >= 0; i--) {
+            items[i] = node.item;
+            node = node.prev;
+        }
+        return items;
+    }
+
     _build() {
         let states = [this._initialState()];
         const catalog = this._randomness.shuffleCatalog ? this._shuffle(this._catalog) : this._catalog.slice();
 
+        // Pre-expand and cache all variants once
+        const variantCache = new Map();
+        for (let i = 0; i < catalog.length; i++) {
+            variantCache.set(catalog[i].id, this._songs.expandVariants(catalog[i], this._show));
+        }
+        this._variantCache = variantCache;
+
         for (let position = 1; position <= this._count; position += 1) {
             const nextStates = [];
 
-            states.forEach((state) => {
-                catalog.forEach((song) => {
+            for (let si = 0; si < states.length; si++) {
+                const state = states[si];
+                for (let ci = 0; ci < catalog.length; ci++) {
+                    const song = catalog[ci];
                     if (state.usedIds[song.id]) {
-                        return;
+                        continue;
                     }
 
                     const nextState = this._buildNextState(state, song, position);
                     if (nextState) {
                         nextStates.push(nextState);
                     }
-                });
-            });
+                }
+            }
 
             if (!nextStates.length) {
                 break;
@@ -336,7 +356,8 @@ class SetList {
         }
 
         const best = this._pickFinalState(states);
-        const diversifiedItems = this._diversifyCompatibleRuns(best.items);
+        const bestItems = this._collectItems(best);
+        const diversifiedItems = this._diversifyCompatibleRuns(bestItems);
         const finalized = this._finalizeItems(diversifiedItems);
         this._list = finalized.items;
         this._summary = finalized.summary;
@@ -374,8 +395,7 @@ class SetList {
             }
 
             const chosen = pool.splice(chosenIndex, 1)[0];
-            const lastItem = chosen.items[chosen.items.length - 1];
-            const lastSongId = lastItem ? lastItem.id : "none";
+            const lastSongId = chosen.lastItem ? chosen.lastItem.id : "none";
             const used = lastSongCounts[lastSongId] || 0;
 
             if (used >= maxStatesPerLastSong) {
@@ -387,9 +407,11 @@ class SetList {
         }
 
         if (selected.length < this._options.beamWidth) {
-            const fallback = nextStates.filter((state) => selected.indexOf(state) < 0);
-            while (fallback.length && selected.length < this._options.beamWidth) {
-                selected.push(fallback.shift());
+            const selectedSet = new Set(selected);
+            for (let i = 0; i < nextStates.length && selected.length < this._options.beamWidth; i++) {
+                if (!selectedSet.has(nextStates[i])) {
+                    selected.push(nextStates[i]);
+                }
             }
         }
 
@@ -464,8 +486,7 @@ class SetList {
         for (let offset = 0; offset < runItems.length; offset += 1) {
             const position = startPosition + offset;
             const ranked = remaining.map((item) => {
-                const distance = Math.abs(item.energy - this._targetEnergy(position)) * this._weights.energyTarget;
-                const score = distance + this._songBias(item.id);
+                const score = this._songBias(item.id);
                 return { item, score };
             }).sort((left, right) => left.score - right.score);
 
@@ -513,7 +534,6 @@ class SetList {
             const variant = {
                 id: item.id,
                 name: item.name,
-                energy: item.energy,
                 cover: item.cover,
                 instrumental: item.instrumental,
                 key: item.key,
@@ -523,14 +543,12 @@ class SetList {
             const propTransition = this._scoreConfiguredProps(prevItem, variant);
             const nextPropState = this._advancePropState(state, propTransition.changes, prevItem);
             const positionScore = this._scorePosition(variant, position);
-            const context = this._scoreContext(state, variant);
-            const transitionScore = propTransition.score + this._scoreEnergyJump(prevItem, variant);
-            const incrementalScore = transitionScore + positionScore.score + context.score + this._songBias(variant.id);
+            const transitionScore = propTransition.score;
+            const incrementalScore = transitionScore + positionScore.score + this._songBias(variant.id);
 
             const finalized = {
                 id: variant.id,
                 name: variant.name,
-                energy: variant.energy,
                 cover: variant.cover,
                 instrumental: variant.instrumental,
                 key: variant.key,
@@ -538,9 +556,9 @@ class SetList {
                 position,
                 incrementalScore,
                 cumulativeScore: state.score + incrementalScore,
-                transitionNotes: propTransition.notes.concat(this._energyJumpNotes(prevItem, variant)),
+                transitionNotes: propTransition.notes,
                 positionNotes: positionScore.notes,
-                contextNotes: context.notes,
+                contextNotes: [],
                 propChanges: propTransition.changes
             };
 
@@ -552,8 +570,6 @@ class SetList {
                 rankScore: state.score + incrementalScore,
                 coverCount: state.coverCount + Number(Boolean(variant.cover)),
                 instrumentalCount: state.instrumentalCount + Number(Boolean(variant.instrumental)),
-                energyStreak: context.energyStreak,
-                lastEnergy: variant.energy,
                 propChangeCounts: nextPropState.propChangeCounts,
                 propStreaks: nextPropState.propStreaks,
                 changeTotals: nextPropState.changeTotals
@@ -572,8 +588,8 @@ class SetList {
     }
 
     _buildNextState(state, song, position) {
-        const nextCoverCount = state.coverCount + Number(Boolean(song.cover));
-        const nextInstrumentalCount = state.instrumentalCount + Number(Boolean(song.instrumental));
+        const nextCoverCount = state.coverCount + (song.cover ? 1 : 0);
+        const nextInstrumentalCount = state.instrumentalCount + (song.instrumental ? 1 : 0);
 
         if (nextCoverCount > this._options.maxCovers) {
             return null;
@@ -587,15 +603,20 @@ class SetList {
             return null;
         }
 
+        const newScore = state.score + bestVariant.incrementalScore;
+        const usedIds = Object.create(state.usedIds);
+        usedIds[song.id] = true;
+
         return {
-            items: state.items.concat(bestVariant.item),
-            usedIds: merge(state.usedIds, { [song.id]: true }),
-            score: state.score + bestVariant.item.incrementalScore,
-            rankScore: state.score + bestVariant.item.incrementalScore + this._randomJitter(this._randomness.stateJitter),
+            head: { item: bestVariant.item, prev: state.head },
+            length: state.length + 1,
+            usedIds,
+            score: newScore,
             coverCount: nextCoverCount,
             instrumentalCount: nextInstrumentalCount,
-            energyStreak: bestVariant.energyStreak,
-            lastEnergy: bestVariant.item.energy,
+            lastItem: bestVariant.item,
+            rankScore: newScore + this._randomJitter(this._randomness.stateJitter),
+            _tiebreaker: this._rng(),
             propChangeCounts: bestVariant.propChangeCounts,
             propStreaks: bestVariant.propStreaks,
             changeTotals: bestVariant.changeTotals
@@ -603,54 +624,137 @@ class SetList {
     }
 
     _findBestVariant(state, song, position) {
-        const prevItem = state.items[state.items.length - 1] || null;
+        const prevItem = state.lastItem;
         let best = null;
+        let bestScore = Infinity;
 
-        this._songs.expandVariants(song, this._show).forEach((variant) => {
-            const propTransition = this._scoreConfiguredProps(prevItem, variant);
+        const variants = this._variantCache.get(song.id);
+        for (let vi = 0; vi < variants.length; vi++) {
+            const variant = variants[vi];
+            const propTransition = this._scoreConfiguredPropsLite(prevItem, variant);
             if (!this._isAllowedByPropRules(state, propTransition.changes, prevItem, position)) {
-                return;
+                continue;
             }
 
             const nextPropState = this._advancePropState(state, propTransition.changes, prevItem);
-            const positionScore = this._scorePosition(variant, position);
-            const context = this._scoreContext(state, variant);
-            const transitionScore = propTransition.score + this._scoreEnergyJump(prevItem, variant);
-            const incrementalScore = transitionScore + positionScore.score + context.score + this._songBias(variant.id);
+            const positionScore = this._scorePositionLite(variant, position);
+            const transitionScore = propTransition.score;
+            const incrementalScore = transitionScore + positionScore + this._songBias(variant.id);
             const exploratoryScore = incrementalScore + this._randomJitter(this._randomness.variantJitter);
-            const signature = this._variantSignature(variant);
 
-            if (!best || exploratoryScore < best.explorationScore || (
-                exploratoryScore === best.explorationScore && signature < best.signature
-            )) {
+            if (exploratoryScore < bestScore) {
+                bestScore = exploratoryScore;
                 best = {
-                    signature,
-                    explorationScore: exploratoryScore,
-                    energyStreak: context.energyStreak,
                     propChangeCounts: nextPropState.propChangeCounts,
                     propStreaks: nextPropState.propStreaks,
                     changeTotals: nextPropState.changeTotals,
-                    item: {
-                        id: variant.id,
-                        name: variant.name,
-                        energy: variant.energy,
-                        cover: variant.cover,
-                        instrumental: variant.instrumental,
-                        key: variant.key,
-                        performance: variant.performance,
-                        position,
-                        incrementalScore,
-                        cumulativeScore: state.score + incrementalScore,
-                        transitionNotes: propTransition.notes.concat(this._energyJumpNotes(prevItem, variant)),
-                        positionNotes: positionScore.notes,
-                        contextNotes: context.notes,
-                        propChanges: propTransition.changes
-                    }
+                    incrementalScore,
+                    item: variant
                 };
             }
-        });
+        }
 
         return best;
+    }
+
+    // Lite version: returns { score, changes } without building notes arrays
+    _scoreConfiguredPropsLite(prevItem, nextVariant) {
+        const changes = {};
+        let score = 0;
+
+        for (let i = 0; i < this._propNames.length; i++) {
+            const propName = this._propNames[i];
+            const change = this._detectPropChangeLite(prevItem, nextVariant, propName, this._propConfig[propName]);
+            changes[propName] = change;
+            if (change.changed) {
+                score += change.magnitude * this._getPropWeight(propName);
+            }
+        }
+
+        return { score, changes };
+    }
+
+    _detectPropChangeLite(prevItem, nextVariant, propName, rule) {
+        if (!prevItem) {
+            return { changed: false, magnitude: 0 };
+        }
+        const kind = rule.kind || this._inferPropKind(propName);
+        if (kind === "instrumentSet") {
+            return this._detectInstrumentSetChangeLite(prevItem, nextVariant);
+        }
+        if (kind === "instrumentDelta") {
+            return this._detectInstrumentValueChangeLite(prevItem, nextVariant, rule, true, false);
+        }
+        if (kind === "instrumentBoolean") {
+            return this._detectInstrumentValueChangeLite(prevItem, nextVariant, rule, false, true);
+        }
+        return this._detectInstrumentValueChangeLite(prevItem, nextVariant, rule, false, false);
+    }
+
+    _detectInstrumentSetChangeLite(prevItem, nextVariant) {
+        const prevPerf = prevItem.performance;
+        const nextPerf = nextVariant.performance;
+        let magnitude = 0;
+        const prevKeys = Object.keys(prevPerf);
+        const nextKeys = Object.keys(nextPerf);
+        for (let i = 0; i < prevKeys.length; i++) {
+            const m = prevKeys[i];
+            if (!nextPerf[m]) { magnitude += 1; continue; }
+            if (prevPerf[m].instrument !== nextPerf[m].instrument) { magnitude += 1; }
+        }
+        for (let i = 0; i < nextKeys.length; i++) {
+            if (!prevPerf[nextKeys[i]]) { magnitude += 1; }
+        }
+        return { changed: magnitude > 0, magnitude };
+    }
+
+    _detectInstrumentValueChangeLite(prevItem, nextVariant, rule, scaleByDelta, coerceBoolean) {
+        const field = rule.field;
+        let magnitude = 0;
+        const prevPerf = prevItem.performance;
+        const nextPerf = nextVariant.performance;
+        const prevKeys = Object.keys(prevPerf);
+        for (let i = 0; i < prevKeys.length; i++) {
+            const member = prevKeys[i];
+            if (!nextPerf[member]) continue;
+            const prevValue = prevPerf[member][field];
+            const nextValue = nextPerf[member][field];
+            if (coerceBoolean) {
+                if (Boolean(prevValue) === Boolean(nextValue)) continue;
+            } else {
+                const left = (prevValue === undefined || prevValue === null) ? "" : String(prevValue);
+                const right = (nextValue === undefined || nextValue === null) ? "" : String(nextValue);
+                if (left === right) continue;
+            }
+            const amount = scaleByDelta ? Math.abs((prevValue || 0) - (nextValue || 0)) : 1;
+            if (!amount) continue;
+            magnitude += amount;
+        }
+        return { changed: magnitude > 0, magnitude };
+    }
+
+    // Lite position scoring: returns just the numeric score
+    _scorePositionLite(song, position) {
+        let score = 0;
+        const orderLabel = this._findOrderLabel(position);
+        const orderRules = (this._config.general?.order && this._config.general.order[orderLabel]) || [];
+
+        for (let i = 0; i < orderRules.length; i++) {
+            const [name, expected] = orderRules[i];
+            const accepted = Array.isArray(expected) ? expected : [expected];
+            const actual = song[name] === undefined ? false : song[name];
+            if (accepted.indexOf(actual) < 0) {
+                score += this._weights.positionMiss;
+            }
+        }
+
+        if (song.cover && position <= 2) {
+            score += this._weights.earlyCover;
+        }
+        if (song.instrumental && position <= 2) {
+            score += this._weights.earlyInstrumental;
+        }
+        return score;
     }
 
     _scoreConfiguredProps(prevItem, nextVariant) {
@@ -816,26 +920,27 @@ class SetList {
     }
 
     _advancePropState(state, propChanges, prevItem) {
-        const propChangeCounts = clone(state.propChangeCounts);
-        const propStreaks = clone(state.propStreaks);
-        const changeTotals = clone(state.changeTotals);
+        const propChangeCounts = { ...state.propChangeCounts };
+        const propStreaks = { ...state.propStreaks };
+        const changeTotals = { ...state.changeTotals };
 
-        this._propNames.forEach((propName) => {
+        for (let i = 0; i < this._propNames.length; i++) {
+            const propName = this._propNames[i];
             const change = propChanges[propName];
             if (!prevItem) {
                 propStreaks[propName] = 1;
-                return;
+                continue;
             }
 
             if (change.changed) {
                 propChangeCounts[propName] += 1;
                 propStreaks[propName] = 1;
                 changeTotals[propName] += change.magnitude;
-                return;
+                continue;
             }
 
             propStreaks[propName] += 1;
-        });
+        }
 
         return {
             propChangeCounts,
@@ -844,35 +949,12 @@ class SetList {
         };
     }
 
-    _scoreEnergyJump(prevItem, nextVariant) {
-        if (!prevItem) {
-            return 0;
-        }
-        if (Math.abs(prevItem.energy - nextVariant.energy) > 1) {
-            return this._weights.bigEnergyJump;
-        }
-        return 0;
-    }
-
-    _energyJumpNotes(prevItem, nextVariant) {
-        if (!prevItem) {
-            return [];
-        }
-        if (Math.abs(prevItem.energy - nextVariant.energy) > 1) {
-            return [`energy jump ${prevItem.energy} -> ${nextVariant.energy}`];
-        }
-        return [];
-    }
 
     _scorePosition(song, position) {
         const notes = [];
-        let score = Math.abs(song.energy - this._targetEnergy(position)) * this._weights.energyTarget;
+        let score = 0;
         const orderLabel = this._findOrderLabel(position);
         const orderRules = (this._config.general?.order && this._config.general.order[orderLabel]) || [];
-
-        if (score > 0) {
-            notes.push(`energy target ${this._targetEnergy(position).toFixed(1)}`);
-        }
 
         orderRules.forEach(([name, expected]) => {
             const accepted = Array.isArray(expected) ? expected : [expected];
@@ -897,38 +979,6 @@ class SetList {
         return { score, notes };
     }
 
-    _scoreContext(state, variant) {
-        const notes = [];
-        let score = 0;
-        let energyStreak = 1;
-
-        if (state.lastEnergy === variant.energy) {
-            score += this._weights.repeatEnergy;
-            energyStreak = state.energyStreak + 1;
-            notes.push(`repeat energy ${variant.energy}`);
-        }
-
-        if (energyStreak >= 3) {
-            score += (energyStreak - 2) * this._weights.energyStreak;
-            notes.push(`energy streak ${energyStreak}`);
-        }
-
-        return { score, notes, energyStreak };
-    }
-
-    _targetEnergy(position) {
-        const ratio = position / this._count;
-        if (ratio <= 0.2) {
-            return 1.5;
-        }
-        if (ratio <= 0.5) {
-            return 2;
-        }
-        if (ratio <= 0.75) {
-            return 2.5;
-        }
-        return 3;
-    }
 
     _findOrderLabel(position) {
         if (position === 1) {
@@ -974,10 +1024,6 @@ class SetList {
 
 const DEFAULT_WEIGHTS = {
     positionMiss: 8,
-    energyTarget: 3,
-    repeatEnergy: 2,
-    energyStreak: 4,
-    bigEnergyJump: 3,
     earlyCover: 6,
     earlyInstrumental: 4
 };
@@ -989,9 +1035,9 @@ const DEFAULT_RANDOMNESS = {
     temperature: 0.85,
     shuffleCatalog: true,
     songBias: 3,
-    beamChoicePoolMultiplier: 6,
+    beamChoicePoolMultiplier: 4,
     beamTemperature: 1.1,
-    maxStatesPerLastSong: 24,
+    maxStatesPerLastSong: 8,
     blockShuffleTemperature: 1.4
 };
 
@@ -1088,67 +1134,25 @@ export function scoreFixedOrder(fixedSongs, config) {
         return { score, notes, changes };
     }
 
-    function targetEnergy(position, count) {
-        const ratio = position / count;
-        if (ratio <= 0.2) return 1.5;
-        if (ratio <= 0.5) return 2;
-        if (ratio <= 0.75) return 2.5;
-        return 3;
-    }
-
-    function scoreEnergyJump(prevItem, nextVariant) {
-        if (!prevItem) return 0;
-        if (Math.abs(prevItem.energy - nextVariant.energy) > 1) return weights.bigEnergyJump;
-        return 0;
-    }
-
-    function energyJumpNotes(prevItem, nextVariant) {
-        if (!prevItem) return [];
-        if (Math.abs(prevItem.energy - nextVariant.energy) > 1) return [`energy jump ${prevItem.energy} -> ${nextVariant.energy}`];
-        return [];
-    }
-
     const count = fixedSongs.length;
     const items = [];
     let totalScore = 0;
     let coverCount = 0;
     let instrumentalCount = 0;
-    let lastEnergy = null;
-    let energyStreak = 0;
 
     fixedSongs.forEach((song, index) => {
         const position = index + 1;
         const prevItem = items[items.length - 1] || null;
         const propTransition = scoreConfiguredProps(prevItem, song);
-        const ejScore = scoreEnergyJump(prevItem, song);
-        const te = targetEnergy(position, count);
-        const posScore = Math.abs(song.energy - te) * weights.energyTarget;
-        const posNotes = posScore > 0 ? [`energy target ${te.toFixed(1)}`] : [];
 
-        let contextScore = 0;
-        const contextNotes = [];
-        let newStreak = 1;
-        if (lastEnergy === song.energy) {
-            contextScore += weights.repeatEnergy;
-            newStreak = energyStreak + 1;
-            contextNotes.push(`repeat energy ${song.energy}`);
-        }
-        if (newStreak >= 3) {
-            contextScore += (newStreak - 2) * weights.energyStreak;
-            contextNotes.push(`energy streak ${newStreak}`);
-        }
-
-        const incrementalScore = propTransition.score + ejScore + posScore + contextScore;
+        const incrementalScore = propTransition.score;
         totalScore += incrementalScore;
         coverCount += Number(Boolean(song.cover));
         instrumentalCount += Number(Boolean(song.instrumental));
-        lastEnergy = song.energy;
-        energyStreak = newStreak;
 
         items.push({
             id: song.id,
             name: song.name,
-            energy: song.energy,
             cover: song.cover,
             instrumental: song.instrumental,
             key: song.key,
@@ -1156,9 +1160,9 @@ export function scoreFixedOrder(fixedSongs, config) {
             position,
             incrementalScore,
             cumulativeScore: totalScore,
-            transitionNotes: propTransition.notes.concat(energyJumpNotes(prevItem, song)),
-            positionNotes: posNotes,
-            contextNotes,
+            transitionNotes: propTransition.notes,
+            positionNotes: [],
+            contextNotes: [],
             propChanges: propTransition.changes
         });
     });

--- a/src/lib/generator.js
+++ b/src/lib/generator.js
@@ -576,13 +576,69 @@ class SetList {
             };
         });
 
+        // Compute anxiety: weighted gear changes with spread factor
+        const songCount = finalizedItems.length;
+        const totalTransitions = Math.max(1, songCount - 1);
+        let totalWeighted = 0;
+        let totalRawChanges = 0;
+        let transitionsWithChanges = 0;
+
+        for (let idx = 1; idx < finalizedItems.length; idx++) {
+            const song = finalizedItems[idx];
+            const changes = song.propChanges || {};
+            let hasChange = false;
+
+            for (const propName of this._propNames) {
+                const change = changes[propName];
+                if (!change || !change.changed) continue;
+                const w = this._getPropWeight(propName);
+                totalWeighted += change.magnitude * w;
+                totalRawChanges += change.magnitude;
+                hasChange = true;
+            }
+            if (hasChange) transitionsWithChanges++;
+        }
+
+        // Spread factor: scattered changes (more disrupted transitions) = more anxiety
+        const spreadRatio = transitionsWithChanges / totalTransitions;
+        const adjustedWeighted = totalWeighted * (0.5 + spreadRatio * 0.5);
+
+        // Dynamic scale based on this band's weights
+        let avgWeight = 0;
+        if (this._propNames.length > 0) {
+            let sumW = 0;
+            for (const propName of this._propNames) {
+                sumW += this._getPropWeight(propName);
+            }
+            avgWeight = sumW / this._propNames.length;
+        }
+        const mediumBaseline = totalTransitions * 0.3 * avgWeight;
+        const maxBaseline = totalTransitions * avgWeight * 2;
+
+        let anxietyScaled;
+        if (maxBaseline <= 0) {
+            anxietyScaled = 0;
+        } else if (adjustedWeighted <= mediumBaseline) {
+            anxietyScaled = Math.round((adjustedWeighted / mediumBaseline) * 5);
+        } else {
+            anxietyScaled = 5 + Math.round(((adjustedWeighted - mediumBaseline) / (maxBaseline - mediumBaseline)) * 5);
+        }
+        anxietyScaled = Math.max(0, Math.min(10, anxietyScaled));
+
         return {
             items: finalizedItems,
             summary: {
                 score: state.score,
                 covers: state.coverCount,
                 instrumentals: state.instrumentalCount,
-                changes: state.changeTotals
+                changes: state.changeTotals,
+                anxiety: {
+                    scaled: anxietyScaled,
+                    rawChanges: totalRawChanges,
+                    weightedScore: Math.round(adjustedWeighted * 10) / 10,
+                    transitionsDisrupted: transitionsWithChanges,
+                    totalTransitions
+                }
             }
         };
     }
@@ -1167,12 +1223,60 @@ export function scoreFixedOrder(fixedSongs, config) {
         });
     });
 
+    // Compute anxiety for reordered setlist
+    const totalTransitions = Math.max(1, count - 1);
+    let totalWeighted = 0;
+    let totalRawChanges = 0;
+    let transitionsWithChanges = 0;
+
+    for (let idx = 1; idx < items.length; idx++) {
+        const changes = items[idx].propChanges || {};
+        let hasChange = false;
+        for (const pn of propNames) {
+            const change = changes[pn];
+            if (!change || !change.changed) continue;
+            totalWeighted += change.magnitude * getPropWeight(pn);
+            totalRawChanges += change.magnitude;
+            hasChange = true;
+        }
+        if (hasChange) transitionsWithChanges++;
+    }
+
+    const spreadRatio = transitionsWithChanges / totalTransitions;
+    const adjustedWeighted = totalWeighted * (0.5 + spreadRatio * 0.5);
+
+    let avgWeight = 0;
+    if (propNames.length > 0) {
+        let sumW = 0;
+        for (const pn of propNames) sumW += getPropWeight(pn);
+        avgWeight = sumW / propNames.length;
+    }
+    const mediumBaseline = totalTransitions * 0.3 * avgWeight;
+    const maxBaseline = totalTransitions * avgWeight * 2;
+
+    let anxietyScaled;
+    if (maxBaseline <= 0) {
+        anxietyScaled = 0;
+    } else if (adjustedWeighted <= mediumBaseline) {
+        anxietyScaled = Math.round((adjustedWeighted / mediumBaseline) * 5);
+    } else {
+        anxietyScaled = 5 + Math.round(((adjustedWeighted - mediumBaseline) / (maxBaseline - mediumBaseline)) * 5);
+    }
+    anxietyScaled = Math.max(0, Math.min(10, anxietyScaled));
+
     return {
         songs: items,
         summary: {
             score: totalScore,
             covers: coverCount,
-            instrumentals: instrumentalCount
+            instrumentals: instrumentalCount,
+            anxiety: {
+                scaled: anxietyScaled,
+                rawChanges: totalRawChanges,
+                weightedScore: Math.round(adjustedWeighted * 10) / 10,
+                transitionsDisrupted: transitionsWithChanges,
+                totalTransitions
+            }
         }
     };
 }

--- a/src/lib/generator.test.js
+++ b/src/lib/generator.test.js
@@ -1,0 +1,711 @@
+import { describe, it, expect } from "vitest";
+import { generateSetlist, scoreFixedOrder } from "./generator.js";
+
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeSong(name, opts = {}) {
+    return {
+        id: opts.id || name.toLowerCase().replace(/\s+/g, "-"),
+        name,
+        cover: opts.cover || false,
+        instrumental: opts.instrumental || false,
+        notGoodOpener: opts.notGoodOpener || false,
+        notGoodCloser: opts.notGoodCloser || false,
+        unpracticed: false,
+        key: opts.key || "G",
+        schemaVersion: 1,
+        createdAt: "2025-01-01T00:00:00Z",
+        updatedAt: "2025-01-01T00:00:00Z",
+        members: opts.members || {}
+    };
+}
+
+function makeConfig(overrides = {}) {
+    return {
+        general: {
+            count: 15,
+            beamWidth: 512,
+            limits: { covers: 2, instrumentals: 2 },
+            order: {
+                first: [["notGoodOpener", false], ["cover", false], ["instrumental", false]],
+                second: [["cover", false], ["instrumental", false]],
+                penultimate: [],
+                last: [["notGoodCloser", false]]
+            },
+            weighting: {
+                tuning: 4,
+                capo: 2,
+                instrument: 3,
+                technique: 1,
+                positionMiss: 8,
+                earlyCover: 2,
+                earlyInstrumental: 2
+            },
+            randomness: {
+                variantJitter: 1.5,
+                stateJitter: 1,
+                finalChoicePool: 12,
+                temperature: 0.85,
+                shuffleCatalog: true,
+                songBias: 3,
+                beamChoicePoolMultiplier: 6,
+                beamTemperature: 1.1,
+                maxStatesPerLastSong: 24,
+                blockShuffleTemperature: 1.4
+            },
+            ...overrides.general
+        },
+        props: overrides.props || {
+            tuning: {
+                kind: "instrumentField",
+                field: "tuning",
+                summaryLabel: "tuning changes",
+                minStreak: 2,
+                allowChangeOnLastSong: true
+            },
+            capo: {
+                kind: "instrumentDelta",
+                field: "capo",
+                summaryLabel: "capo steps",
+                minStreak: 2,
+                allowChangeOnLastSong: true
+            },
+            instruments: {
+                kind: "instrumentSet",
+                weightKey: "instrument",
+                summaryLabel: "instrument swaps",
+                minStreak: 2,
+                allowChangeOnLastSong: true,
+                mutuallyExclusive: []
+            },
+            picking: {
+                kind: "instrumentField",
+                field: "picking",
+                weightKey: "technique",
+                summaryLabel: "technique changes",
+                minStreak: 1,
+                allowChangeOnLastSong: true
+            }
+        },
+        show: overrides.show || { members: {} },
+        band: overrides.band || { members: {} },
+        catalog: overrides.catalog || { tunings: [], tuningsByInstrument: {} }
+    };
+}
+
+/** Fixed-seed deterministic options for reproducible tests */
+function deterministicOptions(overrides = {}) {
+    return {
+        count: overrides.count || 10,
+        seed: overrides.seed || 42,
+        beamWidth: overrides.beamWidth || 64,
+        randomness: {
+            shuffleCatalog: false,
+            songBias: 0,
+            variantJitter: 0,
+            stateJitter: 0,
+            temperature: 0.85,
+            finalChoicePool: 1,
+            ...overrides.randomness
+        },
+        show: overrides.show || {},
+        ...overrides
+    };
+}
+
+/** Generate a catalog of simple songs (no members) */
+function simpleCatalog(count) {
+    return Array.from({ length: count }, (_, i) => makeSong(`Song ${i + 1}`));
+}
+
+/** Generate songs where a member alternates instruments */
+function twoInstrumentCatalog(count, memberName = "nick") {
+    return Array.from({ length: count }, (_, i) => {
+        const instruments = [
+            { name: "guitar", tuning: ["Standard"], capo: 0, picking: [] },
+            { name: "banjo", tuning: ["Open G"], capo: 0, picking: [] }
+        ];
+        return makeSong(`Song ${i + 1}`, {
+            members: {
+                [memberName]: { instruments }
+            }
+        });
+    });
+}
+
+/** Generate songs where a member has two tunings on one instrument */
+function twoTuningCatalog(count, memberName = "nick") {
+    return Array.from({ length: count }, (_, i) =>
+        makeSong(`Song ${i + 1}`, {
+            members: {
+                [memberName]: {
+                    instruments: [
+                        { name: "guitar", tuning: ["Standard", "DADGAD"], capo: 0, picking: [] }
+                    ]
+                }
+            }
+        })
+    );
+}
+
+
+// ===================================================================
+// Basic generation
+// ===================================================================
+describe("generateSetlist — basics", () => {
+    it("returns the correct number of songs", () => {
+        const songs = simpleCatalog(20);
+        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 10 }));
+        expect(result.songs).toHaveLength(10);
+    });
+
+    it("clamps to catalog size when count exceeds available songs", () => {
+        const songs = simpleCatalog(5);
+        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 15 }));
+        expect(result.songs).toHaveLength(5);
+    });
+
+    it("handles empty catalog", () => {
+        const result = generateSetlist([], makeConfig(), deterministicOptions({ count: 10 }));
+        expect(result.songs).toHaveLength(0);
+    });
+
+    it("handles single song", () => {
+        const result = generateSetlist([makeSong("Only")], makeConfig(), deterministicOptions({ count: 1 }));
+        expect(result.songs).toHaveLength(1);
+        expect(result.songs[0].name).toBe("Only");
+    });
+
+    it("each song appears at most once", () => {
+        const songs = simpleCatalog(15);
+        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 15 }));
+        const ids = result.songs.map(s => s.id);
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it("includes summary with score, covers, instrumentals, anxiety", () => {
+        const songs = simpleCatalog(10);
+        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 5 }));
+        expect(result.summary).toBeDefined();
+        expect(typeof result.summary.score).toBe("number");
+        expect(typeof result.summary.covers).toBe("number");
+        expect(typeof result.summary.instrumentals).toBe("number");
+        expect(result.summary.anxiety).toBeDefined();
+        expect(typeof result.summary.anxiety.scaled).toBe("number");
+    });
+});
+
+
+// ===================================================================
+// Determinism
+// ===================================================================
+describe("generateSetlist — determinism", () => {
+    it("same seed produces identical output", () => {
+        const songs = simpleCatalog(20);
+        const config = makeConfig();
+        const opts = deterministicOptions({ count: 10, seed: 777 });
+        const r1 = generateSetlist(songs, config, opts);
+        const r2 = generateSetlist(songs, config, opts);
+        expect(r1.songs.map(s => s.id)).toEqual(r2.songs.map(s => s.id));
+    });
+
+    it("different seeds produce different output (high probability)", () => {
+        const songs = simpleCatalog(20);
+        const config = makeConfig();
+        const r1 = generateSetlist(songs, config, deterministicOptions({ count: 10, seed: 1 }));
+        const r2 = generateSetlist(songs, config, deterministicOptions({ count: 10, seed: 2 }));
+        // With 20 songs picking 10, different seeds should almost certainly differ
+        const ids1 = r1.songs.map(s => s.id).join(",");
+        const ids2 = r2.songs.map(s => s.id).join(",");
+        expect(ids1).not.toBe(ids2);
+    });
+});
+
+
+// ===================================================================
+// Cover / Instrumental limits
+// ===================================================================
+describe("generateSetlist — cover and instrumental limits", () => {
+    it("respects maxCovers", () => {
+        const songs = Array.from({ length: 10 }, (_, i) =>
+            makeSong(`Song ${i + 1}`, { cover: true })
+        );
+        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 10, maxCovers: 2 }));
+        const covers = result.songs.filter(s => s.cover);
+        expect(covers.length).toBeLessThanOrEqual(2);
+    });
+
+    it("respects maxInstrumentals", () => {
+        const songs = Array.from({ length: 10 }, (_, i) =>
+            makeSong(`Song ${i + 1}`, { instrumental: true })
+        );
+        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 10, maxInstrumentals: 1 }));
+        const instrumentals = result.songs.filter(s => s.instrumental);
+        expect(instrumentals.length).toBeLessThanOrEqual(1);
+    });
+
+    it("all covers with maxCovers=1 produces exactly 1 song", () => {
+        const songs = Array.from({ length: 5 }, (_, i) =>
+            makeSong(`Cover ${i + 1}`, { cover: true })
+        );
+        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 5, maxCovers: 1 }));
+        expect(result.songs.length).toBe(1);
+    });
+});
+
+
+// ===================================================================
+// Position rules
+// ===================================================================
+describe("generateSetlist — position rules", () => {
+    it("avoids notGoodOpener in first position (across seeds)", () => {
+        const songs = [
+            makeSong("Opener", { notGoodOpener: true }),
+            ...simpleCatalog(14).map((s, i) => ({ ...s, id: `other-${i}`, name: `Other ${i + 1}` }))
+        ];
+        const config = makeConfig();
+        let openerFirst = 0;
+        for (let seed = 1; seed <= 20; seed++) {
+            const result = generateSetlist(songs, config, deterministicOptions({ count: 10, seed }));
+            if (result.songs[0]?.name === "Opener") openerFirst++;
+        }
+        // Should very rarely be first (position penalty makes it expensive)
+        expect(openerFirst).toBeLessThanOrEqual(2);
+    });
+
+    it("avoids notGoodCloser in last position (across seeds)", () => {
+        const songs = [
+            makeSong("Closer", { notGoodCloser: true }),
+            ...simpleCatalog(14).map((s, i) => ({ ...s, id: `other-${i}`, name: `Other ${i + 1}` }))
+        ];
+        const config = makeConfig();
+        let closerLast = 0;
+        for (let seed = 1; seed <= 20; seed++) {
+            const result = generateSetlist(songs, config, deterministicOptions({ count: 10, seed }));
+            const last = result.songs[result.songs.length - 1];
+            if (last?.name === "Closer") closerLast++;
+        }
+        expect(closerLast).toBeLessThanOrEqual(2);
+    });
+
+    it("avoids covers in first two positions", () => {
+        const songs = [
+            makeSong("Cover 1", { cover: true }),
+            makeSong("Cover 2", { cover: true }),
+            ...simpleCatalog(13).map((s, i) => ({ ...s, id: `other-${i}`, name: `Other ${i + 1}` }))
+        ];
+        const config = makeConfig();
+        let coverEarly = 0;
+        for (let seed = 1; seed <= 20; seed++) {
+            const result = generateSetlist(songs, config, deterministicOptions({ count: 10, seed }));
+            if (result.songs[0]?.cover || result.songs[1]?.cover) coverEarly++;
+        }
+        expect(coverEarly).toBeLessThanOrEqual(3);
+    });
+});
+
+
+// ===================================================================
+// Variant expansion
+// ===================================================================
+describe("generateSetlist — variant expansion", () => {
+    it("song with no members has one variant (empty performance)", () => {
+        const result = generateSetlist([makeSong("Simple")], makeConfig(), deterministicOptions({ count: 1 }));
+        expect(result.songs[0].performance).toEqual({});
+    });
+
+    it("song with one member and one instrument gets that performance", () => {
+        const songs = [makeSong("Tune", {
+            members: {
+                nick: {
+                    instruments: [{ name: "banjo", tuning: ["Open G"], capo: 0, picking: ["clawhammer"] }]
+                }
+            }
+        })];
+        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 1 }));
+        const perf = result.songs[0].performance;
+        expect(perf.nick).toBeDefined();
+        expect(perf.nick.instrument).toBe("banjo");
+        expect(perf.nick.tuning).toBe("Open G");
+    });
+
+    it("filters variants by allowedInstruments", () => {
+        const songs = twoInstrumentCatalog(5);
+        const config = makeConfig({
+            show: {
+                members: {
+                    nick: { allowedInstruments: ["guitar"] }
+                }
+            }
+        });
+        const result = generateSetlist(songs, config, deterministicOptions({ count: 5 }));
+        // All songs should use guitar since banjo is filtered out
+        for (const song of result.songs) {
+            expect(song.performance.nick.instrument).toBe("guitar");
+        }
+    });
+
+    it("song with all instruments filtered out is excluded from catalog", () => {
+        const songs = [
+            makeSong("Only Banjo", {
+                members: {
+                    nick: { instruments: [{ name: "banjo", tuning: ["Open G"], capo: 0, picking: [] }] }
+                }
+            }),
+            makeSong("Filler")
+        ];
+        const config = makeConfig({
+            show: {
+                members: {
+                    nick: { allowedInstruments: ["guitar"] } // banjo not allowed
+                }
+            }
+        });
+        const result = generateSetlist(songs, config, deterministicOptions({ count: 2 }));
+        // Only Banjo should be excluded since its only instrument is filtered
+        expect(result.songs.map(s => s.name)).not.toContain("Only Banjo");
+    });
+});
+
+
+// ===================================================================
+// Detection correctness (via generator output)
+// ===================================================================
+describe("generateSetlist — change detection", () => {
+    it("detects tuning changes in transition notes", () => {
+        const songs = [
+            makeSong("Song A", {
+                members: { nick: { instruments: [{ name: "guitar", tuning: ["Standard"], capo: 0, picking: [] }] } }
+            }),
+            makeSong("Song B", {
+                members: { nick: { instruments: [{ name: "guitar", tuning: ["DADGAD"], capo: 0, picking: [] }] } }
+            })
+        ];
+        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 2 }));
+        // One of the songs should have tuning in transition notes
+        const allNotes = result.songs.flatMap(s => s.transitionNotes);
+        expect(allNotes.some(n => n.includes("tuning"))).toBe(true);
+    });
+
+    it("array picking order does NOT cause false change detection", () => {
+        // Both songs have same techniques, just different array ordering
+        const songs = [
+            makeSong("Song A", {
+                members: { nick: { instruments: [{ name: "guitar", tuning: ["Standard"], capo: 0, picking: ["slide", "picking"] }] } }
+            }),
+            makeSong("Song B", {
+                members: { nick: { instruments: [{ name: "guitar", tuning: ["Standard"], capo: 0, picking: ["picking", "slide"] }] } }
+            })
+        ];
+        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 2 }));
+        // Second song should have no picking change
+        const song2 = result.songs[1];
+        expect(song2.propChanges.picking.changed).toBe(false);
+    });
+
+    it("detects member appearing as instrument set change", () => {
+        const songs = [
+            makeSong("Song A", { members: {} }),
+            makeSong("Song B", {
+                members: { nick: { instruments: [{ name: "banjo", tuning: ["Open G"], capo: 0, picking: [] }] } }
+            })
+        ];
+        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 2 }));
+        const song2 = result.songs[1];
+        expect(song2.propChanges.instruments.changed).toBe(true);
+    });
+
+    it("detects member disappearing as instrument set change", () => {
+        const songs = [
+            makeSong("Song A", {
+                members: { nick: { instruments: [{ name: "banjo", tuning: ["Open G"], capo: 0, picking: [] }] } }
+            }),
+            makeSong("Song B", { members: {} })
+        ];
+        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 2 }));
+        const song2 = result.songs[1];
+        expect(song2.propChanges.instruments.changed).toBe(true);
+    });
+
+    it("capo change magnitude reflects numeric delta", () => {
+        const songs = [
+            makeSong("Song A", {
+                members: { nick: { instruments: [{ name: "guitar", tuning: ["Standard"], capo: 0, picking: [] }] } }
+            }),
+            makeSong("Song B", {
+                members: { nick: { instruments: [{ name: "guitar", tuning: ["Standard"], capo: 3, picking: [] }] } }
+            })
+        ];
+        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 2 }));
+        const song2 = result.songs[1];
+        expect(song2.propChanges.capo.changed).toBe(true);
+        expect(song2.propChanges.capo.magnitude).toBe(3);
+    });
+});
+
+
+// ===================================================================
+// Constraint enforcement — minStreak
+// ===================================================================
+describe("generateSetlist — minStreak enforcement", () => {
+    it("respects tuning minStreak=2 (no back-to-back tuning changes)", () => {
+        const songs = twoTuningCatalog(15);
+        const config = makeConfig();
+        // Run across multiple seeds
+        for (let seed = 1; seed <= 5; seed++) {
+            const result = generateSetlist(songs, config, deterministicOptions({ count: 10, seed }));
+            let consecutive = 0;
+            for (let i = 1; i < result.songs.length; i++) {
+                if (result.songs[i].propChanges.tuning?.changed) {
+                    consecutive++;
+                    // With minStreak=2, two consecutive changes should not happen
+                    expect(consecutive).toBeLessThanOrEqual(1);
+                } else {
+                    consecutive = 0;
+                }
+            }
+        }
+    });
+});
+
+
+// ===================================================================
+// Bug #6 regression: maxChanges enforced on last song
+// ===================================================================
+describe("generateSetlist — maxChanges on last song", () => {
+    it("maxChanges is enforced even when allowChangeOnLastSong is true", () => {
+        const songs = twoTuningCatalog(10);
+        const config = makeConfig({
+            props: {
+                tuning: {
+                    kind: "instrumentField",
+                    field: "tuning",
+                    minStreak: 1,
+                    maxChanges: 1,
+                    allowChangeOnLastSong: true
+                }
+            }
+        });
+
+        for (let seed = 1; seed <= 10; seed++) {
+            const result = generateSetlist(songs, config, deterministicOptions({ count: 5, seed }));
+            const tuningChanges = result.songs.filter(s => s.propChanges.tuning?.changed).length;
+            expect(tuningChanges).toBeLessThanOrEqual(1);
+        }
+    });
+});
+
+
+// ===================================================================
+// minSongsPerInstrument enforcement
+// ===================================================================
+describe("generateSetlist — minSongsPerInstrument", () => {
+    it("both instruments appear at least min times with sufficient catalog", () => {
+        const songs = twoInstrumentCatalog(15);
+        const config = makeConfig();
+        const opts = deterministicOptions({
+            count: 10,
+            show: {
+                members: {
+                    nick: {
+                        allowedInstruments: ["guitar", "banjo"],
+                        minSongsPerInstrument: 2
+                    }
+                }
+            }
+        });
+
+        let bothMet = 0;
+        for (let seed = 1; seed <= 10; seed++) {
+            const result = generateSetlist(songs, config, { ...opts, seed });
+            const guitarCount = result.songs.filter(s => s.performance.nick?.instrument === "guitar").length;
+            const banjoCount = result.songs.filter(s => s.performance.nick?.instrument === "banjo").length;
+            if (guitarCount >= 2 && banjoCount >= 2) bothMet++;
+        }
+        // Should meet minimums most of the time
+        expect(bothMet).toBeGreaterThanOrEqual(7);
+    });
+
+    it("still produces a result when minimums are impossible", () => {
+        // Only 3 songs but min=5 per instrument
+        const songs = twoInstrumentCatalog(3);
+        const config = makeConfig();
+        const opts = deterministicOptions({
+            count: 3,
+            show: {
+                members: {
+                    nick: {
+                        allowedInstruments: ["guitar", "banjo"],
+                        minSongsPerInstrument: 5
+                    }
+                }
+            }
+        });
+        const result = generateSetlist(songs, config, opts);
+        // Should still produce some result even if minimums can't be met
+        expect(result.songs.length).toBeGreaterThan(0);
+    });
+
+    it("instrument switch actually happens in the setlist", () => {
+        const songs = twoInstrumentCatalog(10);
+        const config = makeConfig();
+        const opts = deterministicOptions({
+            count: 8,
+            show: {
+                members: {
+                    nick: {
+                        allowedInstruments: ["guitar", "banjo"],
+                        minSongsPerInstrument: 3
+                    }
+                }
+            }
+        });
+
+        let hasBoth = 0;
+        for (let seed = 1; seed <= 10; seed++) {
+            const result = generateSetlist(songs, config, { ...opts, seed });
+            const instruments = new Set(result.songs.map(s => s.performance.nick?.instrument));
+            if (instruments.has("guitar") && instruments.has("banjo")) hasBoth++;
+        }
+        expect(hasBoth).toBeGreaterThanOrEqual(8);
+    });
+});
+
+
+// ===================================================================
+// minSongsPerTuning enforcement
+// ===================================================================
+describe("generateSetlist — minSongsPerTuning", () => {
+    it("both tunings appear at least min times with sufficient catalog", () => {
+        const songs = twoTuningCatalog(15);
+        const config = makeConfig();
+        const opts = deterministicOptions({
+            count: 10,
+            show: {
+                members: {
+                    nick: {
+                        allowedTunings: { guitar: ["Standard", "DADGAD"] },
+                        minSongsPerTuning: { guitar: 2 }
+                    }
+                }
+            }
+        });
+
+        let bothMet = 0;
+        for (let seed = 1; seed <= 10; seed++) {
+            const result = generateSetlist(songs, config, { ...opts, seed });
+            const standardCount = result.songs.filter(s => s.performance.nick?.tuning === "Standard").length;
+            const dadgadCount = result.songs.filter(s => s.performance.nick?.tuning === "DADGAD").length;
+            if (standardCount >= 2 && dadgadCount >= 2) bothMet++;
+        }
+        expect(bothMet).toBeGreaterThanOrEqual(7);
+    });
+});
+
+
+// ===================================================================
+// scoreFixedOrder
+// ===================================================================
+describe("scoreFixedOrder", () => {
+    const config = makeConfig();
+
+    it("returns correct structure", () => {
+        const songs = [
+            { id: "1", name: "A", performance: { nick: { instrument: "guitar", tuning: "Standard", capo: 0, picking: [] } } },
+            { id: "2", name: "B", performance: { nick: { instrument: "guitar", tuning: "DADGAD", capo: 0, picking: [] } } }
+        ];
+        const result = scoreFixedOrder(songs, config);
+        expect(result.songs).toHaveLength(2);
+        expect(result.summary).toBeDefined();
+        expect(result.summary.anxiety).toBeDefined();
+    });
+
+    it("scores identical songs as 0", () => {
+        const perf = { nick: { instrument: "guitar", tuning: "Standard", capo: 0, picking: [] } };
+        const songs = [
+            { id: "1", name: "A", performance: perf },
+            { id: "2", name: "B", performance: perf },
+            { id: "3", name: "C", performance: perf }
+        ];
+        const result = scoreFixedOrder(songs, config);
+        expect(result.summary.score).toBe(0);
+    });
+
+    it("detects tuning change with correct weight", () => {
+        const songs = [
+            { id: "1", name: "A", performance: { nick: { instrument: "guitar", tuning: "Standard", capo: 0, picking: [] } } },
+            { id: "2", name: "B", performance: { nick: { instrument: "guitar", tuning: "DADGAD", capo: 0, picking: [] } } }
+        ];
+        const result = scoreFixedOrder(songs, config);
+        expect(result.songs[1].propChanges.tuning.changed).toBe(true);
+        expect(result.songs[1].incrementalScore).toBe(4); // weight 4
+    });
+
+    it("uses shared detection (array order independence)", () => {
+        const songs = [
+            { id: "1", name: "A", performance: { nick: { instrument: "guitar", tuning: "Standard", capo: 0, picking: ["slide", "picking"] } } },
+            { id: "2", name: "B", performance: { nick: { instrument: "guitar", tuning: "Standard", capo: 0, picking: ["picking", "slide"] } } }
+        ];
+        const result = scoreFixedOrder(songs, config);
+        expect(result.songs[1].propChanges.picking.changed).toBe(false);
+    });
+
+    it("includes anxiety in summary", () => {
+        const songs = [
+            { id: "1", name: "A", performance: { nick: { instrument: "guitar", tuning: "Standard", capo: 0, picking: [] } } },
+            { id: "2", name: "B", performance: { nick: { instrument: "banjo", tuning: "Open G", capo: 0, picking: ["clawhammer"] } } }
+        ];
+        const result = scoreFixedOrder(songs, config);
+        expect(result.summary.anxiety.scaled).toBeGreaterThan(0);
+    });
+
+    it("detects member appearing/disappearing", () => {
+        const songs = [
+            { id: "1", name: "A", performance: { nick: { instrument: "banjo", tuning: "Open G", capo: 0, picking: [] } } },
+            { id: "2", name: "B", performance: {} },
+            { id: "3", name: "C", performance: { nick: { instrument: "banjo", tuning: "Open G", capo: 0, picking: [] } } }
+        ];
+        const result = scoreFixedOrder(songs, config);
+        // nick disappears in song 2
+        expect(result.songs[1].propChanges.instruments.changed).toBe(true);
+        // nick reappears in song 3
+        expect(result.songs[2].propChanges.instruments.changed).toBe(true);
+    });
+});
+
+
+// ===================================================================
+// Edge cases
+// ===================================================================
+describe("generateSetlist — edge cases", () => {
+    it("generates with no props configured", () => {
+        const songs = simpleCatalog(10);
+        const config = makeConfig({ props: {} });
+        const result = generateSetlist(songs, config, deterministicOptions({ count: 5 }));
+        expect(result.songs).toHaveLength(5);
+        expect(result.summary.score).toBe(0);
+    });
+
+    it("handles songs where every song has cover=true and instrumental=true", () => {
+        const songs = Array.from({ length: 5 }, (_, i) =>
+            makeSong(`Song ${i + 1}`, { cover: true, instrumental: true })
+        );
+        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 5, maxCovers: 5, maxInstrumentals: 5 }));
+        expect(result.songs.length).toBeGreaterThan(0);
+    });
+
+    it("handles mixed catalog — some songs with members, some without", () => {
+        const songs = [
+            makeSong("With Members", {
+                members: { nick: { instruments: [{ name: "guitar", tuning: ["Standard"], capo: 0, picking: [] }] } }
+            }),
+            makeSong("Without Members"),
+            makeSong("Also Without"),
+        ];
+        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 3 }));
+        expect(result.songs).toHaveLength(3);
+    });
+});

--- a/src/lib/generator.worker.js
+++ b/src/lib/generator.worker.js
@@ -1,0 +1,17 @@
+import { generateSetlist } from "./generator.js";
+
+self.onmessage = function (event) {
+    const { songs, config, optionsList } = event.data;
+    let best = null;
+
+    for (let i = 0; i < optionsList.length; i++) {
+        const result = generateSetlist(songs, config, optionsList[i]);
+        if (!best || result.summary.score < best.summary.score) {
+            best = result;
+        }
+        // Post progress so the UI knows we're still working
+        self.postMessage({ type: "progress", attempt: i + 1, total: optionsList.length });
+    }
+
+    self.postMessage({ type: "done", result: best });
+};

--- a/src/lib/remotestorage.js
+++ b/src/lib/remotestorage.js
@@ -110,6 +110,10 @@ export function createRemoteStorageRepository() {
             await client.remove(`songs/${songId}`);
         },
 
+        async deleteConfig() {
+            await client.remove("settings/app-config");
+        },
+
         async getConfig() {
             const result = await client.getObject("settings/app-config");
             return normalizeAppConfig(result);

--- a/src/lib/remotestorage.js
+++ b/src/lib/remotestorage.js
@@ -46,10 +46,14 @@ export function createRemoteStorageRepository() {
         client,
 
         connect(userAddress) {
+            // Re-enable caching in case it was reset by a previous disconnect
+            remoteStorage.caching.enable(`/${APP_SCOPE}/`);
             remoteStorage.connect(userAddress);
         },
 
         disconnect() {
+            // Reset the local cache before disconnecting to prevent data leaking to the next account
+            remoteStorage.caching.reset();
             remoteStorage.disconnect();
         },
 

--- a/src/lib/remotestorage.js
+++ b/src/lib/remotestorage.js
@@ -7,12 +7,12 @@ import {
 } from "./defaults.js";
 import { clone, nowIso } from "./utils.js";
 
-const APP_SCOPE = "setlist-generator";
+const APP_SCOPE = "setlist-roller";
 const TYPES = {
-    song: "setlist-song",
-    preset: "setlist-preset",
-    config: "setlist-config",
-    meta: "setlist-meta"
+    song: "setlist-roller-song",
+    preset: "setlist-roller-preset",
+    config: "setlist-roller-config",
+    meta: "setlist-roller-meta"
 };
 
 const OBJECT_SCHEMA = {

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -1,19 +1,40 @@
 import { DEFAULT_APP_CONFIG, blankSong, normalizeAppConfig, normalizeSongRecord } from "../defaults.js";
 import { CONFIG_SECTIONS } from "../config-meta.js";
-import { generateSetlist, scoreFixedOrder } from "../generator.js";
+import { scoreFixedOrder } from "../generator.js";
 import { clone, deepMerge, formatDelimitedList, getByPath, nowIso, parseDelimitedList, setByPath, titleForBand, tryParseJson, uid } from "../utils.js";
+import GeneratorWorker from "../generator.worker.js?worker";
 
-const STORAGE_KEY = "setlist-generator-ui-options";
-const SAVED_SETS_KEY = "setlist-generator-saved-sets";
+const STORAGE_PREFIX = "setlist-generator";
 const MAX_SAVED_SETS = 5;
 
+// Scope localStorage keys per user so accounts don't leak data
+function scopedKey(base, userAddress) {
+    if (!userAddress) return `${STORAGE_PREFIX}-${base}`;
+    // Simple hash to keep the key short
+    let h = 0;
+    for (let i = 0; i < userAddress.length; i++) {
+        h = ((h << 5) - h + userAddress.charCodeAt(i)) | 0;
+    }
+    return `${STORAGE_PREFIX}-${base}-${(h >>> 0).toString(36)}`;
+}
+
+function randomFrom(arr) { return arr[Math.floor(Math.random() * arr.length)]; }
+
 export function createAppStore(repo) {
+    // ---- per-user localStorage scoping ----
+    let currentUserAddress = "";
+    function storageKey(base) { return scopedKey(base, currentUserAddress); }
+
     // ---- core state ----
     let songs = $state([]);
     let appConfig = $state(null);
     let bootstrapMeta = $state(null);
     let generatedSetlist = $state(null);
-    let savedSetlists = $state(loadSavedSetlists());
+    let isGenerating = $state(false);
+    let setlistLocked = $state(false);
+    let setlistSaved = $state(false);
+    let pendingRollConfirm = $state(false);
+    let savedSetlists = $state([]);
 
     // ---- connection ----
     let connectionStatus = $state("disconnected");
@@ -33,8 +54,8 @@ export function createAppStore(repo) {
     let syncActiveCount = 0;
     let syncIndicatorTimer = null;
 
-    // ---- generation options ----
-    let generationOptions = $state(loadStoredGenerationOptions());
+    // ---- generation options (loaded properly on connect via loadUserLocalData) ----
+    let generationOptions = $state(defaultGenerationOptions(DEFAULT_APP_CONFIG));
 
     // ---- song editor ----
     let editorSong = $state(null);
@@ -79,7 +100,7 @@ export function createAppStore(repo) {
         const source = config || DEFAULT_APP_CONFIG;
         return {
             count: source.general?.count || 15,
-            beamWidth: source.general?.beamWidth || 512,
+            beamWidth: source.general?.beamWidth || 20,
             maxCovers: source.general?.limits?.covers || 0,
             maxInstrumentals: source.general?.limits?.instrumentals || 0,
             seed: "",
@@ -145,23 +166,30 @@ export function createAppStore(repo) {
         return Array.from(names).sort();
     }
 
-    function isSongIncomplete(song) {
+    function songIncompleteReasons(song) {
         const bandMembers = appConfig?.band?.members || {};
         const memberNames = Object.keys(bandMembers);
-        if (memberNames.length === 0) return false;
+        if (memberNames.length === 0) return [];
         const songMembers = song.members || {};
+        const reasons = [];
         for (const name of memberNames) {
             const memberSetup = songMembers[name];
-            if (!memberSetup) return true;
+            if (!memberSetup) { reasons.push(`${name}: not set up`); continue; }
             const instruments = memberSetup.instruments || [];
-            if (instruments.length === 0) return true;
+            if (instruments.length === 0) { reasons.push(`${name}: needs instrument`); continue; }
             for (const inst of instruments) {
-                if (!inst.name) return true;
+                if (!inst.name) { reasons.push(`${name}: instrument not selected`); continue; }
                 const bandInst = (bandMembers[name].instruments || []).find((i) => i.name === inst.name);
-                if (bandInst && (bandInst.techniques || []).length > 0 && (!Array.isArray(inst.picking) || inst.picking.length === 0)) return true;
+                if (bandInst && (bandInst.techniques || []).length > 0 && (!Array.isArray(inst.picking) || inst.picking.length === 0)) {
+                    reasons.push(`${name}: ${inst.name} needs technique`);
+                }
             }
         }
-        return false;
+        return reasons;
+    }
+
+    function isSongIncomplete(song) {
+        return songIncompleteReasons(song).length > 0;
     }
 
     function computeVisibleSongs() {
@@ -181,32 +209,97 @@ export function createAppStore(repo) {
     function loadStoredGenerationOptions() {
         const fallback = defaultGenerationOptions(DEFAULT_APP_CONFIG);
         if (typeof localStorage === "undefined") return fallback;
-        const stored = tryParseJson(localStorage.getItem(STORAGE_KEY), null);
+        const stored = tryParseJson(localStorage.getItem(storageKey("ui-options")), null);
         return stored ? deepMerge(fallback, stored) : fallback;
     }
 
     function persistGenerationOptions() {
         if (typeof localStorage === "undefined") return;
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(generationOptions));
+        localStorage.setItem(storageKey("ui-options"), JSON.stringify(generationOptions));
+    }
+
+    // Strip deprecated "energy" field and energy-related notes from saved setlist songs
+    function stripEnergy(sets) {
+        if (!Array.isArray(sets)) return sets;
+        return sets.map((s) => ({
+            ...s,
+            songs: (s.songs || []).map((song) => {
+                const { energy, ...rest } = song;
+                return {
+                    ...rest,
+                    transitionNotes: (rest.transitionNotes || []).filter((n) => !/energy/i.test(n)),
+                    contextNotes: (rest.contextNotes || []).filter((n) => !/energy/i.test(n)),
+                };
+            }),
+        }));
     }
 
     function loadSavedSetlists() {
         if (typeof localStorage === "undefined") return [];
-        return tryParseJson(localStorage.getItem(SAVED_SETS_KEY), []);
+        return stripEnergy(tryParseJson(localStorage.getItem(storageKey("saved-sets")), []) || []);
     }
 
     function persistSavedSetlists() {
         if (typeof localStorage === "undefined") return;
-        localStorage.setItem(SAVED_SETS_KEY, JSON.stringify(savedSetlists));
+        localStorage.setItem(storageKey("saved-sets"), JSON.stringify(savedSetlists));
+    }
+
+    function loadCurrentSetlist() {
+        if (typeof localStorage === "undefined") return null;
+        return tryParseJson(localStorage.getItem(storageKey("current-set")), null);
+    }
+
+    function loadCurrentSetlistLocked() {
+        if (typeof localStorage === "undefined") return false;
+        const data = tryParseJson(localStorage.getItem(storageKey("current-set")), null);
+        return data?._locked || false;
+    }
+
+    function persistCurrentSetlist() {
+        if (typeof localStorage === "undefined") return;
+        if (generatedSetlist) {
+            localStorage.setItem(storageKey("current-set"), JSON.stringify({ ...generatedSetlist, _locked: setlistLocked }));
+        } else {
+            localStorage.removeItem(storageKey("current-set"));
+        }
+    }
+
+    // Remove any un-scoped legacy localStorage keys so they can't leak between accounts
+    function clearUnscopedLocalStorage() {
+        if (typeof localStorage === "undefined") return;
+        localStorage.removeItem("setlist-generator-ui-options");
+        localStorage.removeItem("setlist-generator-saved-sets");
+        localStorage.removeItem("setlist-generator-current-set");
+    }
+
+    // Clear the current user's scoped localStorage keys (called on disconnect)
+    function clearUserLocalStorage() {
+        if (typeof localStorage === "undefined" || !currentUserAddress) return;
+        localStorage.removeItem(storageKey("ui-options"));
+        localStorage.removeItem(storageKey("saved-sets"));
+        localStorage.removeItem(storageKey("current-set"));
+    }
+
+    // Load all per-user localStorage data (called on connect when we know the user)
+    function loadUserLocalData() {
+        clearUnscopedLocalStorage();
+        savedSetlists = loadSavedSetlists();
+        const current = loadCurrentSetlist();
+        const locked = current?._locked || false;
+        generatedSetlist = locked ? current : null;
+        setlistLocked = locked;
+        setlistSaved = false;
+        generationOptions = loadStoredGenerationOptions();
     }
 
     // ---- toast ----
     function addToast(message, tone = "info") {
         const id = uid("toast");
         toastMessages = [...toastMessages, { id, message, tone }];
+        const duration = tone === "danger" ? 8000 : 6000;
         setTimeout(() => {
             toastMessages = toastMessages.filter((t) => t.id !== id);
-        }, 4200);
+        }, duration);
     }
 
     // ---- sync indicators ----
@@ -243,7 +336,7 @@ export function createAppStore(repo) {
     // ---- navigation ----
     function syncRouteFromHash() {
         const next = window.location.hash.replace(/^#\/?/, "") || "roll";
-        const allowed = ["roll", "songs", "band"];
+        const allowed = ["roll", "saved", "songs", "band", "help"];
         activeView = allowed.includes(next) ? next : "roll";
     }
 
@@ -272,14 +365,14 @@ export function createAppStore(repo) {
             busyMessage = quiet ? "" : "Loading your songs...";
             loadError = "";
             const data = await repo.loadAll();
-            songs = data.songs;
+            songs = data.songs.map(normalizeSongRecord);
             bootstrapMeta = data.bootstrap;
             appConfig = data.config ? normalizeAppConfig(data.config) : null;
 
             if (!appConfig) {
                 showFirstRunPrompt = true;
                 firstRunBandName = "";
-                navigate("songs");
+                navigate("roll");
                 generationOptions = defaultGenerationOptions(DEFAULT_APP_CONFIG);
                 persistGenerationOptions();
                 return;
@@ -288,10 +381,6 @@ export function createAppStore(repo) {
             showFirstRunPrompt = false;
             generationOptions = deepMerge(defaultGenerationOptions(appConfig), generationOptions || {});
             persistGenerationOptions();
-
-            if (songs.length === 0) {
-                navigate("songs");
-            }
         } catch (error) {
             loadError = error?.message || "Could not load remote data.";
             addToast(loadError, "danger");
@@ -353,54 +442,149 @@ export function createAppStore(repo) {
         return true;
     }
 
+    function requestRoll() {
+        if (isGenerating) return;
+        if (setlistLocked) {
+            pendingRollConfirm = true;
+            return;
+        }
+        generate();
+    }
+
+    function confirmRoll() {
+        pendingRollConfirm = false;
+        setlistLocked = false;
+        generate();
+    }
+
+    function cancelRoll() {
+        pendingRollConfirm = false;
+    }
+
     function generate() {
+        if (isGenerating) return;
         if (!songs.length) {
-            addToast("Add a few songs first.", "danger");
+            addToast("Can't roll with no songs! Add a few first.", "danger");
             navigate("songs");
             return;
         }
-        try {
-            const eligibleSongs = songs.filter((s) => !s.unpracticed);
-            if (!eligibleSongs.length) {
-                addToast("All songs are marked unpracticed.", "danger");
+        const eligibleSongs = songs.filter((s) => !s.unpracticed);
+        if (!eligibleSongs.length) {
+            addToast("Every song is unpracticed. Time to rehearse!", "danger");
+            return;
+        }
+
+        isGenerating = true;
+        const optionsList = [clone(generationOptions)];
+
+        const worker = new GeneratorWorker();
+        worker.postMessage({
+            songs: clone(eligibleSongs),
+            config: clone(appConfig || DEFAULT_APP_CONFIG),
+            optionsList
+        });
+        worker.onmessage = (event) => {
+            const { type, result } = event.data;
+            if (type !== "done") return;
+            worker.terminate();
+            isGenerating = false;
+            if (!result) {
+                addToast(randomFrom([
+                    "The generator tripped over a cable.",
+                    "Something went sideways. Blame the bassist.",
+                    "Critical fumble — try again?",
+                ]), "danger");
                 return;
             }
-            const maxRetries = 5;
-            let best = null;
-            for (let attempt = 0; attempt < maxRetries; attempt++) {
-                const opts = attempt === 0 ? generationOptions : { ...generationOptions, seed: "" };
-                const result = generateSetlist(eligibleSongs, appConfig || DEFAULT_APP_CONFIG, opts);
-                if (!best || result.summary.score < best.summary.score) best = result;
-                if (validateConstraintMinimums(result)) break;
-                if (attempt === maxRetries - 1) {
-                    addToast("Couldn't fully meet minimum constraints — showing best result.", "danger");
-                }
+            generatedSetlist = result;
+            setlistLocked = false;
+            setlistSaved = false;
+            persistCurrentSetlist();
+            if (!validateConstraintMinimums(result)) {
+                addToast("Close enough! Some constraints bent but didn't break.", "warning");
             }
-            generatedSetlist = best;
-            addToast(`Generated ${generatedSetlist.songs.length} songs.`);
-        } catch (error) {
-            addToast(error?.message || "The generator faceplanted.", "danger");
-        }
+            const n = generatedSetlist.songs.length;
+            addToast(randomFrom([
+                `🎲 The dice have spoken. ${n} songs.`,
+                `${n} songs, rolled fresh. No refunds.`,
+                `Behold: ${n} tracks of pure destiny.`,
+                `${n} songs. Trust the roll.`,
+                `The rock gods have decided. ${n} songs.`,
+            ]));
+        };
+        worker.onerror = (err) => {
+            worker.terminate();
+            isGenerating = false;
+            addToast(randomFrom([
+                "The generator tripped over a cable.",
+                "Something went sideways. Blame the bassist.",
+                "Critical fumble — try again?",
+            ]), "danger");
+        };
+    }
+
+    function lockSetlist() {
+        if (!generatedSetlist) return;
+        if (setlistLocked) return;
+        setlistLocked = true;
+        persistCurrentSetlist();
+        addToast(randomFrom([
+            "Setlist locked in. No take-backs.",
+            "It's canon now.",
+            "Sealed. This one's going on stage.",
+        ]));
     }
 
     function saveCurrentSetlist() {
-        if (!generatedSetlist) return;
+        if (!generatedSetlist) {
+            console.warn("[Set Roll] saveCurrentSetlist: no generatedSetlist");
+            return;
+        }
+        const currentSaved = savedSetlists || [];
+        const songNames = generatedSetlist.songs.map(s => s.name || s.title || "?");
+        const funNames = [
+            "The Unhinged Encore", "Chaos Theory Vol. " + (currentSaved.length + 1),
+            "No Refunds", "The One That Slaps", "Certified Banger",
+            "Tuesday Night Special", "Blame the Dice", "Accidentally Perfect",
+            "The Hot Mess Express", "Trust the Process"
+        ];
         const entry = {
             id: uid("set"),
+            name: funNames[currentSaved.length % funNames.length],
             savedAt: nowIso(),
             summary: clone(generatedSetlist.summary),
             songs: clone(generatedSetlist.songs),
+            songNames,
             seed: generatedSetlist.seed,
             songCount: generatedSetlist.songs.length
         };
-        savedSetlists = [entry, ...savedSetlists].slice(0, MAX_SAVED_SETS);
+        savedSetlists = [entry, ...currentSaved].slice(0, MAX_SAVED_SETS);
         persistSavedSetlists();
-        addToast("Setlist saved.");
+        setlistSaved = true;
+        console.log("[Set Roll] saved setlist:", entry.name, entry.id, "total saved:", savedSetlists.length);
     }
 
     function removeSavedSetlist(id) {
         savedSetlists = savedSetlists.filter((s) => s.id !== id);
         persistSavedSetlists();
+    }
+
+    function updateSavedSetlist(id, fields) {
+        savedSetlists = savedSetlists.map((s) => s.id === id ? { ...s, ...fields } : s);
+        persistSavedSetlists();
+    }
+
+    function loadSavedSetlist(id) {
+        const saved = savedSetlists.find((s) => s.id === id);
+        if (!saved) return;
+        generatedSetlist = {
+            songs: clone(saved.songs),
+            summary: clone(saved.summary),
+            seed: saved.seed,
+        };
+        setlistLocked = true;
+        persistCurrentSetlist();
+        addToast(`Loaded ${saved.songs?.length || 0}-song set.`);
     }
 
     function reorderSetlistSong(fromIndex, toIndex) {
@@ -410,6 +594,7 @@ export function createAppStore(repo) {
         songList.splice(toIndex, 0, moved);
         const rescored = scoreFixedOrder(songList, appConfig);
         generatedSetlist = { ...generatedSetlist, songs: rescored.songs, summary: rescored.summary, _reordered: true };
+        persistCurrentSetlist();
     }
 
     // ---- generation options ----
@@ -486,13 +671,34 @@ export function createAppStore(repo) {
         });
     }
 
-    function addMember() {
+    function addMember(memberName) {
         updateEditor((song) => {
-            const base = `member${Object.keys(song.members || {}).length + 1}`;
-            let name = base;
-            let c = 1;
-            while (song.members[name]) { c++; name = `${base}-${c}`; }
-            song.members[name] = { instruments: [] };
+            let name = memberName;
+            if (!name) {
+                const base = `member${Object.keys(song.members || {}).length + 1}`;
+                name = base;
+                let c = 1;
+                while (song.members[name]) { c++; name = `${base}-${c}`; }
+            }
+            if (song.members[name]) return; // already in this song
+            // Seed instruments from band config if this member exists there
+            const bandMember = appConfig?.band?.members?.[name];
+            if (bandMember && (bandMember.instruments || []).length > 0) {
+                const defaultInst = bandMember.defaultInstrument || bandMember.instruments[0]?.name || "";
+                const inst = bandMember.instruments.find((i) => i.name === defaultInst) || bandMember.instruments[0];
+                const defaultTuning = inst?.defaultTuning;
+                const defaultTechnique = inst?.defaultTechnique;
+                song.members[name] = {
+                    instruments: [{
+                        name: inst.name,
+                        tuning: defaultTuning ? [defaultTuning] : [],
+                        capo: 0,
+                        picking: defaultTechnique ? [defaultTechnique] : []
+                    }]
+                };
+            } else {
+                song.members[name] = { instruments: [{ name: "", tuning: [], capo: 0, picking: [] }] };
+            }
         });
     }
 
@@ -541,6 +747,46 @@ export function createAppStore(repo) {
                 ...editorSong, updatedAt: nowIso()
             }));
             songs = songs.filter((s) => s.id !== saved.id).concat(saved).sort((a, b) => a.name.localeCompare(b.name));
+
+            // Sync member names and instruments from the song into band config
+            let configDirty = false;
+            let nextConfig = clone(appConfig) || { band: { members: {} } };
+            if (!nextConfig.band) nextConfig.band = {};
+            if (!nextConfig.band.members) nextConfig.band.members = {};
+
+            for (const [memberName, memberSetup] of Object.entries(saved.members || {})) {
+                if (!nextConfig.band.members[memberName]) {
+                    nextConfig.band.members[memberName] = { instruments: [] };
+                    configDirty = true;
+                }
+                const bandMember = nextConfig.band.members[memberName];
+                if (!bandMember.instruments) bandMember.instruments = [];
+                for (const inst of (memberSetup.instruments || [])) {
+                    if (!inst.name) continue;
+                    const existing = bandMember.instruments.find((i) => i.name === inst.name);
+                    if (!existing) {
+                        bandMember.instruments.push({
+                            name: inst.name, tunings: [], defaultTuning: "",
+                            techniques: [], defaultTechnique: ""
+                        });
+                        configDirty = true;
+                    }
+                    // Sync tunings that appear in songs but not in band config
+                    const bandInst = bandMember.instruments.find((i) => i.name === inst.name);
+                    for (const tuning of (inst.tuning || [])) {
+                        if (tuning && !(bandInst.tunings || []).includes(tuning)) {
+                            if (!bandInst.tunings) bandInst.tunings = [];
+                            bandInst.tunings.push(tuning);
+                            if (!bandInst.defaultTuning) bandInst.defaultTuning = tuning;
+                            configDirty = true;
+                        }
+                    }
+                }
+            }
+            if (configDirty) {
+                await persistConfigEdit(nextConfig);
+            }
+
             closeEditor();
             addToast(`Saved "${saved.name}".`);
         } catch (error) {
@@ -568,6 +814,36 @@ export function createAppStore(repo) {
             songs = songs.filter((e) => e.id !== song.id);
             if (editorSong?.id === song.id) closeEditor();
             addToast(`Deleted "${song.name}".`);
+        } catch (error) {
+            addToast(error?.message || "Could not delete.", "danger");
+        } finally {
+            busyMessage = "";
+        }
+    }
+
+    async function deleteAllData() {
+        if (!window.confirm("This will delete ALL songs, band config, and saved setlists. This cannot be undone.\n\nAre you sure?")) return;
+        if (!window.confirm("Really? Everything will be gone forever.")) return;
+        try {
+            busyMessage = "Deleting everything...";
+            // Delete all songs from RS
+            for (const song of songs) {
+                await repo.deleteSong(song.id);
+            }
+            // Reset config to blank
+            appConfig = await repo.ensureConfig(appConfig?.bandName || "My Band");
+            appConfig = setByPath(appConfig, "band.members", {});
+            await persistConfigEdit(appConfig);
+            // Clear local state
+            songs = [];
+            generatedSetlist = null;
+            setlistLocked = false;
+            setlistSaved = false;
+            savedSetlists = [];
+            persistSavedSetlists();
+            persistCurrentSetlist();
+            if (editorSong) closeEditor();
+            addToast("All data deleted.");
         } catch (error) {
             addToast(error?.message || "Could not delete.", "danger");
         } finally {
@@ -728,10 +1004,31 @@ export function createAppStore(repo) {
         return `${memberName}::${instrumentName}`;
     }
 
+    // Ensure a member and instrument exist in band config (creates them if missing)
+    async function ensureBandInstrument(memberName, instrumentName) {
+        if (!memberName || !instrumentName || !appConfig) return;
+        let dirty = false;
+        let next = clone(appConfig);
+        if (!next.band) next.band = {};
+        if (!next.band.members) next.band.members = {};
+        if (!next.band.members[memberName]) {
+            next.band.members[memberName] = { instruments: [] };
+            dirty = true;
+        }
+        const member = next.band.members[memberName];
+        if (!member.instruments) member.instruments = [];
+        if (!member.instruments.find((i) => i.name === instrumentName)) {
+            member.instruments.push({ name: instrumentName, tunings: [], defaultTuning: "", techniques: [], defaultTechnique: "" });
+            dirty = true;
+        }
+        if (dirty) await persistConfigEdit(next);
+    }
+
     async function addTuningChoice(memberName, instrumentName) {
         const draftKey = tuningDraftKey(memberName, instrumentName);
         const clean = (newTuningByInstrument[draftKey] || "").trim();
         if (!clean) { addToast("Type a tuning name first.", "danger"); return; }
+        await ensureBandInstrument(memberName, instrumentName);
         const currentInstruments = appConfig.band.members?.[memberName]?.instruments || [];
         const current = currentInstruments.find((i) => i.name === instrumentName);
         if ((current?.tunings || []).includes(clean)) { addToast("Already exists.", "danger"); return; }
@@ -742,6 +1039,7 @@ export function createAppStore(repo) {
             newTuningByInstrument = { ...newTuningByInstrument, [draftKey]: "" };
             addToast(`Added "${clean}" to ${instrumentName}.`);
         }
+        return clean;
     }
 
     async function removeTuningChoice(memberName, instrumentName, tuning) {
@@ -788,6 +1086,7 @@ export function createAppStore(repo) {
         const draftKey = techniqueDraftKey(memberName, instrumentName);
         const clean = (newTechniqueByInstrument[draftKey] || "").trim();
         if (!clean) { addToast("Type a technique name first.", "danger"); return; }
+        await ensureBandInstrument(memberName, instrumentName);
         const currentInstruments = appConfig.band.members?.[memberName]?.instruments || [];
         const current = currentInstruments.find((i) => i.name === instrumentName);
         if ((current?.techniques || []).includes(clean)) { addToast("Already exists.", "danger"); return; }
@@ -798,6 +1097,7 @@ export function createAppStore(repo) {
             newTechniqueByInstrument = { ...newTechniqueByInstrument, [draftKey]: "" };
             addToast(`Added "${clean}" technique to ${instrumentName}.`);
         }
+        return clean;
     }
 
     async function removeTechniqueChoice(memberName, instrumentName, technique) {
@@ -836,21 +1136,6 @@ export function createAppStore(repo) {
         return match ? match[1] : null;
     }
 
-    function selectedEnergies(config, slotId) {
-        const value = orderRuleValue(config, slotId, "energy");
-        if (Array.isArray(value)) return value;
-        if (value === null || value === undefined) return [];
-        return [value];
-    }
-
-    function toggleOrderEnergy(slotId, energy) {
-        const current = selectedEnergies(appConfig, slotId);
-        const next = current.includes(energy)
-            ? current.filter((e) => e !== energy)
-            : current.concat(energy).sort();
-        setOrderRule(slotId, "energy", next.length ? next : null);
-    }
-
     function orderToggleValue(config, slotId, fieldName) {
         const value = orderRuleValue(config, slotId, fieldName);
         if (value === true) return "yes";
@@ -872,10 +1157,17 @@ export function createAppStore(repo) {
 
     // ---- import/export ----
     function buildExportPayload() {
+        const currentSaved = savedSetlists || [];
         return {
-            app: "setlist-generator", schemaVersion: 1, exportedAt: nowIso(),
-            songs: clone(songs), config: clone(appConfig),
-            meta: { bandName: appConfig?.bandName || "", songCount: songs.length }
+            app: "setlist-generator", schemaVersion: 2, exportedAt: nowIso(),
+            songs: songs.map(normalizeSongRecord),
+            config: clone(appConfig),
+            savedSetlists: stripEnergy(clone(currentSaved)),
+            meta: {
+                bandName: appConfig?.bandName || "",
+                songCount: songs.length,
+                savedSetlistCount: currentSaved.length,
+            }
         };
     }
 
@@ -904,7 +1196,8 @@ export function createAppStore(repo) {
                 songs: payload.songs.map(normalizeSongRecord),
                 config: payload.config ? normalizeAppConfig({
                     ...clone(payload.config), bandName: payload.config.bandName || appConfig?.bandName || "", updatedAt: nowIso()
-                }) : null
+                }) : null,
+                savedSetlists: Array.isArray(payload.savedSetlists) ? stripEnergy(payload.savedSetlists) : null,
             };
         }
         if (payload && payload.general && payload.show && payload.props) {
@@ -939,8 +1232,16 @@ export function createAppStore(repo) {
                     fileName: importFile?.name || null, importedSongs: ws
                 });
             });
+
+            // Restore saved setlists and current setlist from full exports
+            if (imported.savedSetlists && imported.savedSetlists.length > 0) {
+                savedSetlists = imported.savedSetlists;
+                persistSavedSetlists();
+            }
             await reloadAll({ quiet: true });
-            addToast(`Imported ${ws} song${ws === 1 ? "" : "s"}.`);
+            const parts = [`${ws} song${ws === 1 ? "" : "s"}`];
+            if (imported.savedSetlists?.length) parts.push(`${imported.savedSetlists.length} saved setlist${imported.savedSetlists.length === 1 ? "" : "s"}`);
+            addToast(`Imported ${parts.join(", ")}.`);
         } catch (error) {
             addToast(error?.message || "Import failed.", "danger");
         } finally {
@@ -970,19 +1271,25 @@ export function createAppStore(repo) {
         repo.on("connected", async () => {
             connectionStatus = "connected";
             connectAddress = repo.getUserAddress() || connectAddress;
-            addToast(`Connected.`);
+            currentUserAddress = connectAddress;
+            loadUserLocalData();
             await reloadAll();
         });
 
         repo.on("disconnected", () => {
             connectionStatus = "disconnected";
+            clearUserLocalStorage();
+            clearUnscopedLocalStorage();
+            currentUserAddress = "";
             songs = [];
             appConfig = null;
             generatedSetlist = null;
+            setlistLocked = false;
+            setlistSaved = false;
+            savedSetlists = [];
             showFirstRunPrompt = false;
             selectedSongId = "";
             editorSong = null;
-            addToast("Disconnected.");
         });
 
         repo.on("error", (error) => {
@@ -1012,6 +1319,10 @@ export function createAppStore(repo) {
 
         get appConfig() { return appConfig; },
         get generatedSetlist() { return generatedSetlist; },
+        get isGenerating() { return isGenerating; },
+        get setlistLocked() { return setlistLocked; },
+        get setlistSaved() { return setlistSaved; },
+        get pendingRollConfirm() { return pendingRollConfirm; },
         get savedSetlists() { return savedSetlists; },
         get connectionStatus() { return connectionStatus; },
         get connectAddress() { return connectAddress; },
@@ -1025,6 +1336,7 @@ export function createAppStore(repo) {
         set firstRunBandName(v) { firstRunBandName = v; },
         get syncIndicatorVisible() { return syncIndicatorVisible; },
         get syncStatusLabel() { return syncStatusLabel; },
+        get syncActivelyRunning() { return syncActiveCount > 0; },
         get generationOptions() { return generationOptions; },
         get editorSong() { return editorSong; },
         get selectedSongId() { return selectedSongId; },
@@ -1065,6 +1377,7 @@ export function createAppStore(repo) {
         get instrumentTypeCount() { return instrumentTypeCount; },
         get visibleSongs() { return visibleSongs; },
         isSongIncomplete,
+        songIncompleteReasons,
         get incompleteSongCount() { return songs.filter((s) => isSongIncomplete(s)).length; },
         get unpracticedSongCount() { return songs.filter((s) => s.unpracticed).length; },
 
@@ -1074,9 +1387,14 @@ export function createAppStore(repo) {
         connectStorage,
         disconnectStorage,
         finishFirstRun,
-        generate,
+        requestRoll,
+        confirmRoll,
+        cancelRoll,
+        lockSetlist,
         saveCurrentSetlist,
         removeSavedSetlist,
+        updateSavedSetlist,
+        loadSavedSetlist,
         reorderSetlistSong,
         updateGenerationField,
         toggleListValue,
@@ -1098,6 +1416,7 @@ export function createAppStore(repo) {
         saveSong,
         duplicateSong,
         deleteSong,
+        deleteAllData,
         configFieldValue,
         updateConfigField,
         saveConfig,
@@ -1115,8 +1434,6 @@ export function createAppStore(repo) {
         setInstrumentDefaultTechnique,
         techniqueDraftKey,
         tuningDraftKey,
-        selectedEnergies,
-        toggleOrderEnergy,
         orderToggleValue,
         setOrderToggle,
         exportAllData,

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -4,7 +4,7 @@ import { scoreFixedOrder } from "../generator.js";
 import { clone, deepMerge, formatDelimitedList, getByPath, nowIso, parseDelimitedList, setByPath, titleForBand, tryParseJson, uid } from "../utils.js";
 import GeneratorWorker from "../generator.worker.js?worker";
 
-const STORAGE_PREFIX = "setlist-generator";
+const STORAGE_PREFIX = "setlist-roller";
 const MAX_SAVED_SETS = 5;
 
 // Scope localStorage keys per user so accounts don't leak data
@@ -269,9 +269,9 @@ export function createAppStore(repo) {
     // Remove any un-scoped legacy localStorage keys so they can't leak between accounts
     function clearUnscopedLocalStorage() {
         if (typeof localStorage === "undefined") return;
-        localStorage.removeItem("setlist-generator-ui-options");
-        localStorage.removeItem("setlist-generator-saved-sets");
-        localStorage.removeItem("setlist-generator-current-set");
+        localStorage.removeItem("setlist-roller-ui-options");
+        localStorage.removeItem("setlist-roller-saved-sets");
+        localStorage.removeItem("setlist-roller-current-set");
     }
 
     // Clear the current user's scoped localStorage keys (called on disconnect)
@@ -1179,7 +1179,7 @@ export function createAppStore(repo) {
     function buildExportPayload() {
         const currentSaved = savedSetlists || [];
         return {
-            app: "setlist-generator", schemaVersion: 2, exportedAt: nowIso(),
+            app: "setlist-roller", schemaVersion: 2, exportedAt: nowIso(),
             songs: songs.map(normalizeSongRecord),
             config: clone(appConfig),
             savedSetlists: stripEnergy(clone(currentSaved)),

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -830,11 +830,10 @@ export function createAppStore(repo) {
             for (const song of songs) {
                 await repo.deleteSong(song.id);
             }
-            // Reset config to blank
-            appConfig = await repo.ensureConfig(appConfig?.bandName || "My Band");
-            appConfig = setByPath(appConfig, "band.members", {});
-            await persistConfigEdit(appConfig);
+            // Delete config from RS so first-run triggers on reload
+            await repo.deleteConfig();
             // Clear local state
+            appConfig = null;
             songs = [];
             generatedSetlist = null;
             setlistLocked = false;
@@ -843,7 +842,13 @@ export function createAppStore(repo) {
             persistSavedSetlists();
             persistCurrentSetlist();
             if (editorSong) closeEditor();
-            addToast("All data deleted.");
+            // Trigger first-run experience
+            showFirstRunPrompt = true;
+            firstRunBandName = "";
+            navigate("roll");
+            generationOptions = defaultGenerationOptions(DEFAULT_APP_CONFIG);
+            persistGenerationOptions();
+            addToast("All data deleted. Name your band to start fresh.");
         } catch (error) {
             addToast(error?.message || "Could not delete.", "danger");
         } finally {

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -536,10 +536,7 @@ export function createAppStore(repo) {
     }
 
     function saveCurrentSetlist() {
-        if (!generatedSetlist) {
-            console.warn("[Set Roll] saveCurrentSetlist: no generatedSetlist");
-            return;
-        }
+        if (!generatedSetlist) return;
         const currentSaved = savedSetlists || [];
         const songNames = generatedSetlist.songs.map(s => s.name || s.title || "?");
         const funNames = [
@@ -561,7 +558,6 @@ export function createAppStore(repo) {
         savedSetlists = [entry, ...currentSaved].slice(0, MAX_SAVED_SETS);
         persistSavedSetlists();
         setlistSaved = true;
-        console.log("[Set Roll] saved setlist:", entry.name, entry.id, "total saved:", savedSetlists.length);
     }
 
     function removeSavedSetlist(id) {

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -31,6 +31,8 @@ export function createAppStore(repo) {
     let bootstrapMeta = $state(null);
     let generatedSetlist = $state(null);
     let isGenerating = $state(false);
+    let activeWorker = null;
+    let generationId = 0;
     let setlistLocked = $state(false);
     let setlistSaved = $state(false);
     let pendingRollConfirm = $state(false);
@@ -461,6 +463,13 @@ export function createAppStore(repo) {
         pendingRollConfirm = false;
     }
 
+    function terminateWorker() {
+        if (activeWorker) {
+            activeWorker.terminate();
+            activeWorker = null;
+        }
+    }
+
     function generate() {
         if (isGenerating) return;
         if (!songs.length) {
@@ -474,10 +483,13 @@ export function createAppStore(repo) {
             return;
         }
 
+        terminateWorker();
         isGenerating = true;
+        const thisGenId = ++generationId;
         const optionsList = [clone(generationOptions)];
 
         const worker = new GeneratorWorker();
+        activeWorker = worker;
         worker.postMessage({
             songs: clone(eligibleSongs),
             config: clone(appConfig || DEFAULT_APP_CONFIG),
@@ -487,6 +499,12 @@ export function createAppStore(repo) {
             const { type, result } = event.data;
             if (type !== "done") return;
             worker.terminate();
+            if (worker === activeWorker) activeWorker = null;
+            // Ignore stale results from a previous generation or disconnected session
+            if (thisGenId !== generationId || !currentUserAddress) {
+                isGenerating = false;
+                return;
+            }
             isGenerating = false;
             if (!result) {
                 addToast(randomFrom([
@@ -514,6 +532,7 @@ export function createAppStore(repo) {
         };
         worker.onerror = (err) => {
             worker.terminate();
+            if (worker === activeWorker) activeWorker = null;
             isGenerating = false;
             addToast(randomFrom([
                 "The generator tripped over a cable.",
@@ -1279,6 +1298,8 @@ export function createAppStore(repo) {
 
         repo.on("disconnected", () => {
             connectionStatus = "disconnected";
+            terminateWorker();
+            isGenerating = false;
             clearUserLocalStorage();
             clearUnscopedLocalStorage();
             currentUserAddress = "";

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -94,7 +94,7 @@ export function formatDelimitedList(value) {
 
 export function titleForBand(bandName) {
     const clean = String(bandName || "").trim();
-    return clean ? `${clean} — Set Roll` : "Set Roll";
+    return clean ? `${clean} — Setlist Roller` : "Setlist Roller";
 }
 
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -94,7 +94,7 @@ export function formatDelimitedList(value) {
 
 export function titleForBand(bandName) {
     const clean = String(bandName || "").trim();
-    return clean ? `${clean} Setlist Generator` : "Band Setlist Generator";
+    return clean ? `${clean} — Set Roll` : "Set Roll";
 }
 
 


### PR DESCRIPTION
## Summary
- **Dice-roll animation** with confetti burst, sticky hero bar with song count + roll button
- **Onboarding flow**: new users land on Roll page with guided steps to add songs
- **Song editor revamp**: type-ahead instrument input (datalist), inline add for tunings/techniques, local draft state for mobile-friendly instrument naming
- **Organic sync**: song editor changes (members, instruments, tunings) auto-flow back to band config; new songs get instruments pre-populated from band config
- **Privacy fix**: localStorage scoped per user via hashed address, cleared on disconnect — no more data leaking between accounts
- **Energy removal**: all energy-related residue stripped from app logic, UI, and exports
- **Settings drawer**: lives inside the hero bar, auto-collapses on roll, combined Demands + Tweak the Chaos into tabbed UI
- **Roll stats**: moved to collapsible debug section at bottom with score explanation
- **Toast redesign**: sits below top bar with dark distinct background, compact
- **Band/Settings page**: restructured with Members, Config, Data (export/import/delete all), Account sections
- **Delete All Data**: with double confirmation
- **Help and Saved screens** added
- **Generation moved to web worker** for non-blocking UI

## Test plan
- [ ] New user: connect, verify landing on Roll page with onboarding card
- [ ] Add a song with member + instrument + tuning — verify it syncs to band config
- [ ] Add second song — verify known members come with instruments pre-populated
- [ ] Roll a setlist — verify dice animation, confetti, settings auto-collapse
- [ ] Open settings drawer, switch between Demands and Tweak the Chaos tabs
- [ ] Disconnect and reconnect with different account — verify no data leakage
- [ ] Export data — verify no energy fields in JSON
- [ ] Delete All Data — verify double confirmation works
- [ ] Mobile: verify instrument name input works with Set button (no Enter required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)