### PR TITLE
Add/remove songs, optimize order on re-roll

### DIFF
--- a/src/lib/components/roll/RollScreen.svelte
+++ b/src/lib/components/roll/RollScreen.svelte
@@ -10,6 +10,17 @@
   let showConfetti = $state(false);
   let diceValue = $state(6);
   let landed = $state(false);
+  let showAddSongPicker = $state(false);
+  let addSongSearch = $state("");
+  let setlistSongIds = $derived(
+    new Set((store.generatedSetlist?.songs || []).map((s) => s.id))
+  );
+  let filteredPickerSongs = $derived(() => {
+    const eligible = store.songs?.filter((s) => !s.unpracticed) || [];
+    if (!addSongSearch) return eligible;
+    const q = addSongSearch.toLowerCase();
+    return eligible.filter((s) => s.name.toLowerCase().includes(q));
+  });
 
   // Watch for generation completing with a result
   let prevGenerating = false;
@@ -356,12 +367,14 @@
               prevSong={i > 0 ? store.generatedSetlist.songs[i - 1] : null}
               onDragStart={handleDragStart}
               onEdit={handleEditSong}
+              onRemove={(idx) => store.removeSetlistSong(idx)}
             />
           </div>
         {/each}
       </div>
 
       <div class="setlist-actions">
+        <button class="save-set-btn add-song-btn" onclick={() => { showAddSongPicker = true; }}>+ Add song</button>
         {#if store.setlistLocked}
           <div class="locked-badge">🔒 Locked in</div>
           {#if store.setlistSaved}
@@ -387,11 +400,44 @@
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div class="confirm-dialog" onclick={(e) => e.stopPropagation()}>
         <p class="confirm-title">This setlist is locked in.</p>
-        <p class="confirm-desc">Rolling again will wipe it. You sure?</p>
-        <div class="confirm-actions">
+        <p class="confirm-desc">What do you want to do?</p>
+        <div class="confirm-actions-stacked">
+          <button class="confirm-btn optimize" onclick={store.confirmOptimizeOrder}>Optimize order</button>
+          <button class="confirm-btn proceed" onclick={store.confirmFreshRoll}>Fresh roll</button>
           <button class="confirm-btn cancel" onclick={store.cancelRoll}>Keep it</button>
-          <button class="confirm-btn proceed" onclick={store.confirmRoll}>Roll anyway</button>
         </div>
+      </div>
+    </div>
+  {/if}
+
+  {#if showAddSongPicker}
+    <div class="confirm-overlay" onclick={() => { showAddSongPicker = false; }}>
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div class="confirm-dialog add-song-dialog" onclick={(e) => e.stopPropagation()}>
+        <p class="confirm-title">Add a song</p>
+        <input
+          class="add-song-search"
+          type="text"
+          placeholder="Search songs..."
+          bind:value={addSongSearch}
+        />
+        <div class="add-song-list">
+          {#each filteredPickerSongs() as song}
+            {@const inSetlist = setlistSongIds.has(song.id)}
+            <button
+              class="add-song-item"
+              class:in-setlist={inSetlist}
+              disabled={inSetlist}
+              onclick={() => { store.addSetlistSong(song.id); showAddSongPicker = false; addSongSearch = ""; }}
+            >
+              {song.name}
+              {#if inSetlist}<span class="in-setlist-tag">added</span>{/if}
+            </button>
+          {:else}
+            <p class="add-song-empty">No songs available</p>
+          {/each}
+        </div>
+        <button class="confirm-btn cancel" onclick={() => { showAddSongPicker = false; addSongSearch = ""; }}>Cancel</button>
       </div>
     </div>
   {/if}
@@ -1083,6 +1129,94 @@
   .confirm-btn.proceed {
     background: var(--accent, #e15b37);
     color: #fff;
+  }
+
+  .confirm-btn.optimize {
+    background: var(--ink, #182230);
+    color: #fff;
+  }
+
+  .confirm-actions-stacked {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    margin-top: 0.25rem;
+  }
+
+  .add-song-btn {
+    background: var(--line, rgba(27, 49, 80, 0.08));
+    color: var(--ink, #182230);
+    border: 1px dashed rgba(27, 49, 80, 0.2);
+  }
+
+  .add-song-dialog {
+    max-height: 70vh;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .add-song-search {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--line, rgba(27, 49, 80, 0.12));
+    border-radius: var(--radius-md, 12px);
+    font-size: 0.88rem;
+    outline: none;
+    box-sizing: border-box;
+  }
+
+  .add-song-search:focus {
+    border-color: var(--accent, #e15b37);
+  }
+
+  .add-song-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    overflow-y: auto;
+    max-height: 40vh;
+  }
+
+  .add-song-item {
+    text-align: left;
+    padding: 0.55rem 0.75rem;
+    border: 1px solid var(--line, rgba(27, 49, 80, 0.08));
+    border-radius: var(--radius-md, 12px);
+    background: rgba(255, 255, 255, 0.92);
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: var(--ink, #182230);
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .add-song-item:active:not(:disabled) {
+    background: rgba(225, 91, 55, 0.06);
+  }
+
+  .add-song-item.in-setlist {
+    opacity: 0.45;
+    cursor: default;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .in-setlist-tag {
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--muted, #8a95a5);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .add-song-empty {
+    font-size: 0.85rem;
+    color: var(--muted, #8a95a5);
+    text-align: center;
+    padding: 1rem;
+    margin: 0;
   }
 
   @keyframes fade-in {

--- a/src/lib/components/roll/SetlistSongCard.svelte
+++ b/src/lib/components/roll/SetlistSongCard.svelte
@@ -1,5 +1,5 @@
 <script>
-  const { song, index, prevSong, onDragStart, onEdit } = $props();
+  const { song, index, prevSong, onDragStart, onEdit, onRemove } = $props();
 
   let expanded = $state(false);
 
@@ -96,6 +96,10 @@
       <button class="edit-btn" onclick={(e) => { e.stopPropagation(); if (onEdit) onEdit(song.id); expanded = false; }}>
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
         Edit song
+      </button>
+      <button class="edit-btn remove-btn" onclick={(e) => { e.stopPropagation(); if (onRemove) onRemove(index); expanded = false; }}>
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6L6 18"/><path d="M6 6l12 12"/></svg>
+        Remove
       </button>
     </div>
   {/if}
@@ -232,5 +236,15 @@
 
   .edit-btn:active {
     background: rgba(0, 0, 0, 0.04);
+  }
+
+  .remove-btn {
+    color: var(--muted, #8a95a5);
+    border-color: rgba(27, 49, 80, 0.1);
+  }
+
+  .remove-btn:active {
+    background: rgba(225, 91, 55, 0.06);
+    color: var(--accent, #e15b37);
   }
 </style>

--- a/src/lib/generator.js
+++ b/src/lib/generator.js
@@ -216,11 +216,17 @@ class SetList {
         this._rng = createRng(this._seed);
         this._randomness = merge(DEFAULT_RANDOMNESS, this._config.general?.randomness || {});
         this._randomness = merge(this._randomness, this._options.randomness || {});
-        this._catalog = this._songs.all().filter((song) => {
-            return this._songs.expandVariants(song, this._show).length > 0;
-        });
+        if (this._options.fixedSongIds) {
+            const idSet = new Set(this._options.fixedSongIds);
+            this._catalog = this._songs.all().filter(s => idSet.has(s.id));
+            this._count = this._catalog.length;
+        } else {
+            this._catalog = this._songs.all().filter((song) => {
+                return this._songs.expandVariants(song, this._show).length > 0;
+            });
+            this._count = Math.min(this._options.count, this._catalog.length);
+        }
         this._songBiasById = this._buildSongBiases(this._catalog);
-        this._count = Math.min(this._options.count, this._catalog.length);
         this._minConstraints = this._buildMinConstraints();
         this._list = [];
         this._summary = {
@@ -1114,4 +1120,11 @@ export function scoreFixedOrder(fixedSongs, config) {
             anxiety
         }
     };
+}
+
+export function buildDefaultPerformance(song, showConstraints = {}) {
+    const catalog = new SongsCatalog([song]);
+    const variants = catalog.expandVariants(song, showConstraints);
+    if (!variants.length) return {};
+    return variants[0].performance || {};
 }

--- a/src/lib/generator.test.js
+++ b/src/lib/generator.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { generateSetlist, scoreFixedOrder } from "./generator.js";
+import { generateSetlist, scoreFixedOrder, buildDefaultPerformance } from "./generator.js";
 
 
 // ---------------------------------------------------------------------------
@@ -707,5 +707,80 @@ describe("generateSetlist — edge cases", () => {
         ];
         const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 3 }));
         expect(result.songs).toHaveLength(3);
+    });
+});
+
+
+// ---------------------------------------------------------------------------
+// fixedSongIds
+// ---------------------------------------------------------------------------
+
+describe("generateSetlist — fixedSongIds", () => {
+    const catalog = Array.from({ length: 10 }, (_, i) => makeSong(`Song ${i + 1}`));
+
+    it("restricts output to exactly the fixed song IDs", () => {
+        const fixedIds = ["song-2", "song-5", "song-7"];
+        const result = generateSetlist(catalog, makeConfig(), deterministicOptions({
+            count: 3,
+            fixedSongIds: fixedIds,
+        }));
+        expect(result.songs).toHaveLength(3);
+        const resultIds = result.songs.map(s => s.id).sort();
+        expect(resultIds).toEqual([...fixedIds].sort());
+    });
+
+    it("ignores count option and uses all fixed songs", () => {
+        const fixedIds = ["song-1", "song-3", "song-4", "song-6"];
+        const result = generateSetlist(catalog, makeConfig(), deterministicOptions({
+            count: 2,
+            fixedSongIds: fixedIds,
+        }));
+        expect(result.songs).toHaveLength(4);
+    });
+
+    it("includes songs that would be filtered without fixedSongIds", () => {
+        // Without fixedSongIds, song-8 through song-10 would be in the pool.
+        // With fixedSongIds, only the specified subset is used.
+        const fixedIds = ["song-1", "song-2"];
+        const result = generateSetlist(catalog, makeConfig(), deterministicOptions({
+            count: 10,
+            fixedSongIds: fixedIds,
+        }));
+        expect(result.songs).toHaveLength(2);
+        const resultIds = result.songs.map(s => s.id).sort();
+        expect(resultIds).toEqual([...fixedIds].sort());
+    });
+});
+
+
+// ---------------------------------------------------------------------------
+// buildDefaultPerformance
+// ---------------------------------------------------------------------------
+
+describe("buildDefaultPerformance", () => {
+    it("returns performance for a song with members", () => {
+        const song = makeSong("Tune", {
+            members: {
+                nick: { instruments: [{ name: "guitar", tuning: ["Standard"], capo: 0, picking: ["pick"] }] }
+            }
+        });
+        const perf = buildDefaultPerformance(song);
+        expect(perf).toHaveProperty("nick");
+        expect(perf.nick.instrument).toBe("guitar");
+        expect(perf.nick.tuning).toBe("Standard");
+    });
+
+    it("returns empty object for song with no members", () => {
+        const song = makeSong("Simple");
+        const perf = buildDefaultPerformance(song);
+        expect(perf).toEqual({});
+    });
+
+    it("returns empty object when show constraints filter all instruments", () => {
+        const song = makeSong("Filtered", {
+            members: { nick: { instruments: [{ name: "banjo", tuning: ["Open G"], capo: 0, picking: [] }] } }
+        });
+        const perf = buildDefaultPerformance(song, { members: { nick: { allowedInstruments: ["guitar"] } } });
+        expect(perf).toEqual({});
     });
 });

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -646,6 +646,7 @@ export function createAppStore(repo) {
         }
         const rescored = scoreFixedOrder(songList, appConfig);
         generatedSetlist = { ...generatedSetlist, songs: rescored.songs, summary: rescored.summary };
+        setlistSaved = false;
         persistCurrentSetlist();
     }
 
@@ -672,6 +673,7 @@ export function createAppStore(repo) {
         });
         const rescored = scoreFixedOrder(songList, appConfig);
         generatedSetlist = { ...generatedSetlist, songs: rescored.songs, summary: rescored.summary };
+        setlistSaved = false;
         persistCurrentSetlist();
     }
 

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -1,6 +1,6 @@
 import { DEFAULT_APP_CONFIG, blankSong, normalizeAppConfig, normalizeSongRecord } from "../defaults.js";
 import { CONFIG_SECTIONS } from "../config-meta.js";
-import { scoreFixedOrder } from "../generator.js";
+import { scoreFixedOrder, buildDefaultPerformance } from "../generator.js";
 import { clone, deepMerge, formatDelimitedList, getByPath, nowIso, parseDelimitedList, setByPath, titleForBand, tryParseJson, uid } from "../utils.js";
 import GeneratorWorker from "../generator.worker.js?worker";
 
@@ -453,10 +453,25 @@ export function createAppStore(repo) {
         generate();
     }
 
-    function confirmRoll() {
+    function confirmFreshRoll() {
         pendingRollConfirm = false;
         setlistLocked = false;
         generate();
+    }
+
+    function confirmOptimizeOrder() {
+        if (!generatedSetlist) return;
+        pendingRollConfirm = false;
+        const currentSongs = generatedSetlist.songs;
+        const currentCovers = currentSongs.filter(s => s.cover).length;
+        const currentInstrumentals = currentSongs.filter(s => s.instrumental).length;
+        generate({
+            fixedSongIds: currentSongs.map(s => s.id),
+            count: currentSongs.length,
+            maxCovers: Math.max(currentCovers, generationOptions.maxCovers),
+            maxInstrumentals: Math.max(currentInstrumentals, generationOptions.maxInstrumentals),
+            _keepLock: true,
+        });
     }
 
     function cancelRoll() {
@@ -470,7 +485,7 @@ export function createAppStore(repo) {
         }
     }
 
-    function generate() {
+    function generate(overrideOptions = {}) {
         if (isGenerating) return;
         if (!songs.length) {
             addToast("Can't roll with no songs! Add a few first.", "danger");
@@ -486,7 +501,9 @@ export function createAppStore(repo) {
         terminateWorker();
         isGenerating = true;
         const thisGenId = ++generationId;
-        const optionsList = [clone(generationOptions)];
+        const opts = clone(generationOptions);
+        Object.assign(opts, overrideOptions);
+        const optionsList = [opts];
 
         const worker = new GeneratorWorker();
         activeWorker = worker;
@@ -515,8 +532,12 @@ export function createAppStore(repo) {
                 return;
             }
             generatedSetlist = result;
-            setlistLocked = false;
-            setlistSaved = false;
+            if (opts._keepLock) {
+                setlistSaved = false;
+            } else {
+                setlistLocked = false;
+                setlistSaved = false;
+            }
             persistCurrentSetlist();
             if (!validateConstraintMinimums(result)) {
                 addToast("Close enough! Some constraints bent but didn't break.", "warning");
@@ -611,6 +632,54 @@ export function createAppStore(repo) {
         generatedSetlist = { ...generatedSetlist, songs: rescored.songs, summary: rescored.summary, _reordered: true };
         persistCurrentSetlist();
     }
+
+    function removeSetlistSong(index) {
+        if (!generatedSetlist) return;
+        const songList = clone(generatedSetlist.songs);
+        songList.splice(index, 1);
+        if (!songList.length) {
+            generatedSetlist = null;
+            setlistLocked = false;
+            setlistSaved = false;
+            persistCurrentSetlist();
+            return;
+        }
+        const rescored = scoreFixedOrder(songList, appConfig);
+        generatedSetlist = { ...generatedSetlist, songs: rescored.songs, summary: rescored.summary };
+        persistCurrentSetlist();
+    }
+
+    function addSetlistSong(songId) {
+        if (!generatedSetlist) return;
+        if (generatedSetlist.songs.some((s) => s.id === songId)) return;
+        const song = songs.find((s) => s.id === songId);
+        if (!song) return;
+        const performance = buildDefaultPerformance(song, generationOptions?.show || {});
+        const songList = clone(generatedSetlist.songs);
+        songList.push({
+            id: song.id,
+            name: song.name,
+            cover: song.cover || false,
+            instrumental: song.instrumental || false,
+            key: song.key || "",
+            performance,
+            position: songList.length + 1,
+            incrementalScore: 0,
+            cumulativeScore: 0,
+            transitionNotes: [],
+            positionNotes: [],
+            contextNotes: [],
+        });
+        const rescored = scoreFixedOrder(songList, appConfig);
+        generatedSetlist = { ...generatedSetlist, songs: rescored.songs, summary: rescored.summary };
+        persistCurrentSetlist();
+    }
+
+    let songsNotInSetlist = $derived.by(() => {
+        if (!generatedSetlist?.songs) return songs.filter((s) => !s.unpracticed);
+        const usedIds = new Set(generatedSetlist.songs.map((s) => s.id));
+        return songs.filter((s) => !s.unpracticed && !usedIds.has(s.id));
+    });
 
     // ---- generation options ----
     function updateGenerationField(path, value) {
@@ -1315,9 +1384,11 @@ export function createAppStore(repo) {
         });
 
         repo.on("error", (error) => {
-            connectionStatus = "disconnected";
             loadError = error?.message || "remoteStorage error.";
             addToast(loadError, "danger");
+            // Fully disconnect so the RS instance resets its auth state,
+            // allowing the user to reconnect from the login screen.
+            repo.disconnect();
         });
 
         repo.onChange(async (event) => {
@@ -1410,7 +1481,8 @@ export function createAppStore(repo) {
         disconnectStorage,
         finishFirstRun,
         requestRoll,
-        confirmRoll,
+        confirmFreshRoll,
+        confirmOptimizeOrder,
         cancelRoll,
         lockSetlist,
         saveCurrentSetlist,
@@ -1418,6 +1490,9 @@ export function createAppStore(repo) {
         updateSavedSetlist,
         loadSavedSetlist,
         reorderSetlistSong,
+        removeSetlistSong,
+        addSetlistSong,
+        get songsNotInSetlist() { return songsNotInSetlist; },
         updateGenerationField,
         toggleListValue,
         ensureMemberShowConfig,


### PR DESCRIPTION
## Summary
- **Add/remove songs** from a rolled setlist — expand a song card to remove it, or click "+ Add song" to pick from the catalog (already-added songs shown greyed out)
- **Optimize order re-roll** — when a locked setlist is re-rolled, choose between "Optimize order" (same songs, best ordering), "Fresh roll" (wipe and re-generate), or "Keep it" (cancel)
- **Auth error fix** — RS auth errors (expired/revoked token) now properly disconnect so the Connect button works again

## Test plan
- [x] Roll a setlist, expand a card, click "Remove" — song removed, list rescored
- [x] Click "+ Add song", verify already-added songs are greyed out and disabled
- [x] Add a song from picker, verify it appends and rescores
- [x] Lock the setlist, click Roll — verify 3-option dialog appears
- [x] Choose "Optimize order" — same songs, new order, stays locked
- [x] Roll again from locked state, choose "Fresh roll" — new setlist, unlocked
- [x] `npm test` passes (137 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)