### PR TITLE
Fix roll constraints, prune dead scaffolding, and retune anxiety scoring

### DIFF
--- a/src/lib/anxiety.js
+++ b/src/lib/anxiety.js
@@ -197,8 +197,6 @@ export function computeAnxiety(songs, config) {
     // while dense disruption (most spots affected) stays close to full weight.
     const spreadRatio = totalTransitions > 0 ? spotsWithChanges / totalTransitions : 0;
     const adjustedWeighted = totalWeighted * Math.pow(spreadRatio, 0.7);
-    const severityBoost = peakWeighted * 0.55;
-    const compositeWeighted = adjustedWeighted + severityBoost;
 
     // Dynamic scale from the band's own weights, with heavier props contributing
     // disproportionately more pressure than lightweight technique changes.
@@ -211,6 +209,10 @@ export function computeAnxiety(songs, config) {
         }
         avgWeight = sumW / propNames.length;
     }
+
+    const severityBoost = peakWeighted * 0.55;
+    const cadenceBoost = Math.max(0, spotsWithChanges - 2) * avgWeight * 0.1;
+    const compositeWeighted = adjustedWeighted + severityBoost + cadenceBoost;
 
     // Scale against a band-relative maximum and curve the low end downward so
     // scattered capo/technique-only sets do not read as medium anxiety.

--- a/src/lib/anxiety.js
+++ b/src/lib/anxiety.js
@@ -210,7 +210,7 @@ export function computeAnxiety(songs, config) {
         avgWeight = sumW / propNames.length;
     }
 
-    const severityBoost = peakWeighted * 0.55;
+    const severityBoost = peakWeighted * 0.62;
     const cadenceBoost = Math.max(0, spotsWithChanges - 2) * avgWeight * 0.16;
     const compositeWeighted = adjustedWeighted + severityBoost + cadenceBoost;
 

--- a/src/lib/anxiety.js
+++ b/src/lib/anxiety.js
@@ -252,13 +252,19 @@ export function anxietyLabel(result) {
     if (changes === 0) {
         return "Bass player is relaxed for once. Zero gear changes — smooth sailing.";
     }
-    if (scaled <= 2) {
+    if (scaled <= 1) {
         return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player barely notices.`;
     }
-    if (scaled <= 5) {
+    if (scaled <= 3) {
         return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is rehearsing crowd work.`;
     }
-    if (scaled <= 7) {
+    if (scaled <= 4) {
+        return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is starting to sweat.`;
+    }
+    if (scaled <= 6) {
+        return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is checking the tuner between jokes.`;
+    }
+    if (scaled <= 8) {
         return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is visibly sweating.`;
     }
     return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is writing a stand-up set to fill all the dead air.`;

--- a/src/lib/anxiety.js
+++ b/src/lib/anxiety.js
@@ -13,7 +13,8 @@
  *   import { computeAnxiety } from "./anxiety.js";
  *   const result = computeAnxiety(songs, config);
  *   // result.scaled      — 0-10 integer
- *   // result.changes     — total member-changes (deduplicated per member per spot)
+ *   // result.changes     — disrupted transition spots
+ *   // result.memberChanges — total member-changes (deduplicated per member per spot)
  *   // result.spots       — how many song boundaries had a change
  *   // result.songCount   — total songs in setlist
  *   // result.weightedScore — max-weight per member, adjusted for spread
@@ -86,6 +87,67 @@ const DEFAULT_WEIGHTS = {
     earlyInstrumental: 4
 };
 
+export const ANXIETY_WEIGHT_EXPONENT = 1.35;
+
+function anxietyWeightPressure(weight) {
+    if (weight <= 0) {
+        return 0;
+    }
+    return Math.pow(weight, ANXIETY_WEIGHT_EXPONENT);
+}
+
+export function scoreAnxietyPressure(prevSong, nextSong, propNames, propConfig, weights) {
+    if (!prevSong) {
+        return { changed: false, memberChanges: 0, weightedScore: 0 };
+    }
+
+    const prevPerf = prevSong.performance || {};
+    const nextPerf = nextSong.performance || {};
+    const allMembers = new Set([...Object.keys(prevPerf), ...Object.keys(nextPerf)]);
+
+    let memberChanges = 0;
+    let weightedScore = 0;
+
+    for (const member of allMembers) {
+        let maxWeight = 0;
+
+        for (const propName of propNames) {
+            const rule = propConfig[propName] || {};
+            const kind = rule.kind || inferPropKind(propName);
+            const weightKey = rule.weightKey || propName;
+            const weight = weights[weightKey] || 0;
+            const prevMember = prevPerf[member];
+            const nextMember = nextPerf[member];
+            let changed = false;
+
+            if (kind === "instrumentSet") {
+                if (!prevMember || !nextMember) changed = true;
+                else if (prevMember.instrument !== nextMember.instrument) changed = true;
+            } else if (prevMember && nextMember) {
+                const field = rule.field || propName;
+                const left = normalizeValue(prevMember[field]);
+                const right = normalizeValue(nextMember[field]);
+                if (left !== right) changed = true;
+            }
+
+            if (changed && weight > maxWeight) {
+                maxWeight = weight;
+            }
+        }
+
+        if (maxWeight > 0) {
+            memberChanges += 1;
+            weightedScore += anxietyWeightPressure(maxWeight);
+        }
+    }
+
+    return {
+        changed: memberChanges > 0,
+        memberChanges,
+        weightedScore
+    };
+}
+
 /**
  * Compute the Bass Player Anxiety score for a fixed-order setlist.
  *
@@ -111,55 +173,11 @@ export function computeAnxiety(songs, config) {
         // Keep scoreTransition for per-prop notes/details
         const transition = scoreTransition(prev, curr, propNames, propConfig, weights);
 
-        // Per-member scoring: each member counts once at their highest-weighted
-        // changed prop. If nick changes capo (2) AND picking (1), that's 1 change
-        // scored at weight 2, not 2 changes scored at 3.
-        const prevPerf = prev.performance || {};
-        const currPerf = curr.performance || {};
-        const allMembers = new Set([...Object.keys(prevPerf), ...Object.keys(currPerf)]);
+        const pressure = scoreAnxietyPressure(prev, curr, propNames, propConfig, weights);
 
-        let spotMemberChanges = 0;
-        let spotWeighted = 0;
-
-        for (const member of allMembers) {
-            let maxWeight = 0;
-
-            for (const propName of propNames) {
-                const rule = propConfig[propName] || {};
-                const kind = rule.kind || inferPropKind(propName);
-                const weightKey = rule.weightKey || propName;
-                const w = weights[weightKey] || 0;
-
-                const prevM = prevPerf[member];
-                const currM = currPerf[member];
-
-                let changed = false;
-
-                if (kind === "instrumentSet") {
-                    if (!prevM || !currM) changed = true;
-                    else if (prevM.instrument !== currM.instrument) changed = true;
-                } else {
-                    // instrumentField or instrumentDelta — only compare shared members
-                    if (prevM && currM) {
-                        const field = rule.field || propName;
-                        const left = normalizeValue(prevM[field]);
-                        const right = normalizeValue(currM[field]);
-                        if (left !== right) changed = true;
-                    }
-                }
-
-                if (changed && w > maxWeight) maxWeight = w;
-            }
-
-            if (maxWeight > 0) {
-                spotMemberChanges++;
-                spotWeighted += maxWeight;
-            }
-        }
-
-        if (spotMemberChanges > 0) spotsWithChanges++;
-        totalWeighted += spotWeighted;
-        totalMemberChanges += spotMemberChanges;
+        if (pressure.changed) spotsWithChanges++;
+        totalWeighted += pressure.weightedScore;
+        totalMemberChanges += pressure.memberChanges;
 
         details.push({
             index: i,
@@ -167,8 +185,8 @@ export function computeAnxiety(songs, config) {
             to: curr.name || `Song ${i + 1}`,
             changes: transition.changes,
             notes: transition.notes,
-            score: spotWeighted,
-            memberChanges: spotMemberChanges
+            score: pressure.weightedScore,
+            memberChanges: pressure.memberChanges
         });
     }
 
@@ -178,36 +196,35 @@ export function computeAnxiety(songs, config) {
     const spreadRatio = totalTransitions > 0 ? spotsWithChanges / totalTransitions : 0;
     const adjustedWeighted = totalWeighted * Math.pow(spreadRatio, 0.7);
 
-    // Dynamic scale from the band's own weights
+    // Dynamic scale from the band's own weights, with heavier props contributing
+    // disproportionately more pressure than lightweight technique changes.
     let avgWeight = 0;
     if (propNames.length > 0) {
         let sumW = 0;
         for (const propName of propNames) {
             const weightKey = (propConfig[propName] || {}).weightKey || propName;
-            sumW += weights[weightKey] || 0;
+            sumW += anxietyWeightPressure(weights[weightKey] || 0);
         }
         avgWeight = sumW / propNames.length;
     }
 
-    // mediumBaseline: weighted score where anxiety hits 5/10
-    // maxBaseline: weighted score where anxiety hits 10/10
-    // Floor ensures short setlists don't spike to 10 from a single change
-    const mediumBaseline = Math.max(totalTransitions * 0.15 * avgWeight, avgWeight * 2);
-    const maxBaseline = Math.max(totalTransitions * 0.7 * avgWeight, avgWeight * 8);
-
-    let scaled;
-    if (maxBaseline <= 0) {
-        scaled = 0;
-    } else if (adjustedWeighted <= mediumBaseline) {
-        scaled = Math.round((adjustedWeighted / mediumBaseline) * 5);
-    } else {
-        scaled = 5 + Math.round(((adjustedWeighted - mediumBaseline) / (maxBaseline - mediumBaseline)) * 5);
+    // Scale against a band-relative maximum and curve the low end downward so
+    // scattered capo/technique-only sets do not read as medium anxiety.
+    const maxBaseline = Math.max(totalTransitions * 0.7 * avgWeight, avgWeight * 6);
+    let scaled = 0;
+    if (maxBaseline > 0) {
+        const normalized = Math.min(1, adjustedWeighted / maxBaseline);
+        scaled = Math.round(Math.pow(normalized, 0.8) * 10);
+        if (normalized > 0 && scaled === 0) {
+            scaled = 1;
+        }
     }
     scaled = Math.max(0, Math.min(10, scaled));
 
     return {
         scaled,
-        changes: totalMemberChanges,
+        changes: spotsWithChanges,
+        memberChanges: totalMemberChanges,
         spots: spotsWithChanges,
         songCount: songs.length,
         weightedScore: Math.round(adjustedWeighted * 10) / 10,
@@ -244,10 +261,13 @@ export function anxietyLabel(result) {
 
 // Export internals for testing
 export const _internals = {
+    ANXIETY_WEIGHT_EXPONENT,
     normalizeValue,
     displayValue,
     detectInstrumentSetChange,
     detectFieldChange,
+    scoreAnxietyPressure,
     scoreTransition,
-    inferPropKind
+    inferPropKind,
+    anxietyWeightPressure
 };

--- a/src/lib/anxiety.js
+++ b/src/lib/anxiety.js
@@ -256,18 +256,18 @@ export function anxietyLabel(result) {
         return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player barely notices.`;
     }
     if (scaled <= 3) {
-        return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is rehearsing crowd work.`;
+        return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is keeping one eye on the tuner.`;
     }
     if (scaled <= 4) {
         return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is starting to sweat.`;
     }
     if (scaled <= 6) {
-        return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is checking the tuner between jokes.`;
+        return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is counting setup moves before the song ends.`;
     }
     if (scaled <= 8) {
-        return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is visibly sweating.`;
+        return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is visibly sweating and stalling for time.`;
     }
-    return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is writing a stand-up set to fill all the dead air.`;
+    return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is looking for the fuse box and composing a farewell note.`;
 }
 
 

--- a/src/lib/anxiety.js
+++ b/src/lib/anxiety.js
@@ -211,7 +211,7 @@ export function computeAnxiety(songs, config) {
     }
 
     const severityBoost = peakWeighted * 0.55;
-    const cadenceBoost = Math.max(0, spotsWithChanges - 2) * avgWeight * 0.1;
+    const cadenceBoost = Math.max(0, spotsWithChanges - 2) * avgWeight * 0.16;
     const compositeWeighted = adjustedWeighted + severityBoost + cadenceBoost;
 
     // Scale against a band-relative maximum and curve the low end downward so

--- a/src/lib/anxiety.js
+++ b/src/lib/anxiety.js
@@ -252,22 +252,16 @@ export function anxietyLabel(result) {
     if (changes === 0) {
         return "Bass player is relaxed for once. Zero gear changes — smooth sailing.";
     }
-    if (scaled <= 1) {
+    if (scaled <= 2) {
         return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player barely notices.`;
     }
-    if (scaled <= 3) {
-        return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is keeping one eye on the tuner.`;
+    if (scaled <= 5) {
+        return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is rehearsing crowd work.`;
     }
-    if (scaled <= 4) {
-        return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is starting to sweat.`;
+    if (scaled <= 7) {
+        return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is visibly sweating.`;
     }
-    if (scaled <= 6) {
-        return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is counting setup moves before the song ends.`;
-    }
-    if (scaled <= 8) {
-        return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is visibly sweating and stalling for time.`;
-    }
-    return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is looking for the fuse box and composing a farewell note.`;
+    return `${changes} change${changes === 1 ? "" : "s"}${spotNote}. Bass player is writing a stand-up set to fill all the dead air.`;
 }
 
 

--- a/src/lib/anxiety.js
+++ b/src/lib/anxiety.js
@@ -164,6 +164,7 @@ export function computeAnxiety(songs, config) {
     let totalWeighted = 0;
     let totalMemberChanges = 0;
     let spotsWithChanges = 0;
+    let peakWeighted = 0;
     const details = [];
 
     for (let i = 1; i < songs.length; i++) {
@@ -178,6 +179,7 @@ export function computeAnxiety(songs, config) {
         if (pressure.changed) spotsWithChanges++;
         totalWeighted += pressure.weightedScore;
         totalMemberChanges += pressure.memberChanges;
+        peakWeighted = Math.max(peakWeighted, pressure.weightedScore);
 
         details.push({
             index: i,
@@ -195,6 +197,8 @@ export function computeAnxiety(songs, config) {
     // while dense disruption (most spots affected) stays close to full weight.
     const spreadRatio = totalTransitions > 0 ? spotsWithChanges / totalTransitions : 0;
     const adjustedWeighted = totalWeighted * Math.pow(spreadRatio, 0.7);
+    const severityBoost = peakWeighted * 0.55;
+    const compositeWeighted = adjustedWeighted + severityBoost;
 
     // Dynamic scale from the band's own weights, with heavier props contributing
     // disproportionately more pressure than lightweight technique changes.
@@ -213,7 +217,7 @@ export function computeAnxiety(songs, config) {
     const maxBaseline = Math.max(totalTransitions * 0.7 * avgWeight, avgWeight * 6);
     let scaled = 0;
     if (maxBaseline > 0) {
-        const normalized = Math.min(1, adjustedWeighted / maxBaseline);
+        const normalized = Math.min(1, compositeWeighted / maxBaseline);
         scaled = Math.round(Math.pow(normalized, 0.8) * 10);
         if (normalized > 0 && scaled === 0) {
             scaled = 1;
@@ -227,7 +231,7 @@ export function computeAnxiety(songs, config) {
         memberChanges: totalMemberChanges,
         spots: spotsWithChanges,
         songCount: songs.length,
-        weightedScore: Math.round(adjustedWeighted * 10) / 10,
+        weightedScore: Math.round(compositeWeighted * 10) / 10,
         totalTransitions,
         details
     };

--- a/src/lib/anxiety.test.js
+++ b/src/lib/anxiety.test.js
@@ -850,9 +850,9 @@ describe("anxietyLabel", () => {
         expect(label).toContain("1 spot over 15 songs");
     });
 
-    it("returns 'crowd work' for light mid anxiety", () => {
+    it("returns 'one eye on the tuner' for light mid anxiety", () => {
         const label = anxietyLabel({ scaled: 3, changes: 5, spots: 3, songCount: 15 });
-        expect(label).toContain("crowd work");
+        expect(label).toContain("one eye on the tuner");
         expect(label).toContain("3 spots over 15 songs");
     });
 
@@ -861,19 +861,19 @@ describe("anxietyLabel", () => {
         expect(label).toContain("starting to sweat");
     });
 
-    it("returns 'checking the tuner' for solid mid-high anxiety", () => {
+    it("returns 'counting setup moves' for solid mid-high anxiety", () => {
         const label = anxietyLabel({ scaled: 6, changes: 7, spots: 6, songCount: 15 });
-        expect(label).toContain("checking the tuner");
+        expect(label).toContain("counting setup moves");
     });
 
     it("returns 'sweating' for high anxiety", () => {
         const label = anxietyLabel({ scaled: 7, changes: 10, spots: 7, songCount: 15 });
-        expect(label).toContain("sweating");
+        expect(label).toContain("stalling for time");
     });
 
-    it("returns 'stand-up set' for extreme anxiety", () => {
+    it("returns 'fuse box' for extreme anxiety", () => {
         const label = anxietyLabel({ scaled: 9, changes: 18, spots: 12, songCount: 15 });
-        expect(label).toContain("stand-up set");
+        expect(label).toContain("fuse box");
     });
 
     it("pluralizes 'change' correctly", () => {

--- a/src/lib/anxiety.test.js
+++ b/src/lib/anxiety.test.js
@@ -474,6 +474,24 @@ describe("computeAnxiety — mixed mid-anxiety sets", () => {
         song("Run Along", "C", { mark: { ...guitarStd }, nick: { ...banjoPick } }),
     ];
 
+    const oneTuningCapoAndTechniqueSpots = [
+        song("Jackass Travels", "A", { mark: { ...guitarStd }, nick: { ...banjoCapo2Pick } }),
+        song("Pumpin' Gas", "A", { mark: { ...guitarStd }, nick: { ...banjoCapo2Pick } }),
+        song("Aerial Jones", "E", { mark: { ...guitarStd }, nick: { ...banjoCapo2Pick } }),
+        song("Break Man", "A", { mark: { ...guitarStd }, nick: { ...banjoCapo2Pick } }),
+        song("Run Along", "C", { mark: { ...guitarStd }, nick: { ...banjoPick } }),
+        song("Every Pyro in the Class", "G", { mark: { ...guitarStd }, nick: { ...banjoPick } }),
+        song("Courtroom Sketch Artist", "G", { mark: { ...guitarStd }, nick: { ...banjoPick } }),
+        song("In a Station Wagon", "G", { mark: { ...guitarStd }, nick: { ...banjoClaw } }),
+        song("Redwing", "G", { mark: { ...guitarStd }, nick: { ...banjoClaw } }),
+        song("High", "D", { mark: { ...guitarStd }, nick: { ...banjoPick } }),
+        song("Put Some Gravy", "D", { mark: { ...guitarStd }, nick: { ...banjoPick } }),
+        song("Euglena", "D", { mark: { ...guitarDaddad }, nick: { ...banjoPick } }),
+        song("O' the Topside", "E", { mark: { ...guitarDaddad }, nick: { ...banjoPickSlide } }),
+        song("Bottle of Soot", "D", { mark: { ...guitarDaddad }, nick: { ...banjoPickSlide } }),
+        song("The Corporeal Races", "G", { mark: { ...guitarDaddad }, nick: { ...banjoClaw } }),
+    ];
+
     it("keeps sparse low-change sets calmer than tuning-plus-churn sets", () => {
         const low = computeAnxiety(sparseLow, BAND_CONFIG);
         const mixed = computeAnxiety(oneTuningPlusChurn, BAND_CONFIG);
@@ -487,6 +505,12 @@ describe("computeAnxiety — mixed mid-anxiety sets", () => {
         const result = computeAnxiety(oneTuningManyTechniqueSpots, BAND_CONFIG);
         expect(result.scaled).toBeGreaterThanOrEqual(5);
         expect(result.changes).toBe(8);
+    });
+
+    it("keeps a tuning change plus capo and technique churn out of the low band", () => {
+        const result = computeAnxiety(oneTuningCapoAndTechniqueSpots, BAND_CONFIG);
+        expect(result.scaled).toBeGreaterThanOrEqual(5);
+        expect(result.changes).toBe(6);
     });
 });
 

--- a/src/lib/anxiety.test.js
+++ b/src/lib/anxiety.test.js
@@ -492,6 +492,24 @@ describe("computeAnxiety — mixed mid-anxiety sets", () => {
         song("The Corporeal Races", "G", { mark: { ...guitarDaddad }, nick: { ...banjoClaw } }),
     ];
 
+    const oneTuningFourSpotSet = [
+        song("O' the Topside", "E", { mark: { ...guitarDaddad }, nick: { ...banjoPickSlide } }),
+        song("Bottle of Soot", "D", { mark: { ...guitarDaddad }, nick: { ...banjoPickSlide } }),
+        song("Redwing", "G", { mark: { ...guitarDaddad }, nick: { ...banjoClaw } }),
+        song("In a Station Wagon", "G", { mark: { ...guitarDaddad }, nick: { ...banjoClaw } }),
+        song("The Corporeal Races", "G", { mark: { ...guitarDaddad }, nick: { ...banjoClaw } }),
+        song("Euglena", "D", { mark: { ...guitarDaddad }, nick: { ...banjoPick } }),
+        song("Every Pyro in the Class", "G", { mark: { ...guitarStd }, nick: { ...banjoPick } }),
+        song("High", "D", { mark: { ...guitarStd }, nick: { ...banjoPick } }),
+        song("Put Some Gravy", "D", { mark: { ...guitarStd }, nick: { ...banjoPick } }),
+        song("Courtroom Sketch Artist", "G", { mark: { ...guitarStd }, nick: { ...banjoPick } }),
+        song("Run Along", "C", { mark: { ...guitarStd }, nick: { ...banjoPick } }),
+        song("Jackass Travels", "A", { mark: { ...guitarStd }, nick: { ...banjoCapo2Pick } }),
+        song("Aerial Jones", "E", { mark: { ...guitarStd }, nick: { ...banjoCapo2Pick } }),
+        song("Pumpin' Gas", "A", { mark: { ...guitarStd }, nick: { ...banjoCapo2Pick } }),
+        song("Break Man", "A", { mark: { ...guitarStd }, nick: { ...banjoCapo2Pick } }),
+    ];
+
     it("keeps sparse low-change sets calmer than tuning-plus-churn sets", () => {
         const low = computeAnxiety(sparseLow, BAND_CONFIG);
         const mixed = computeAnxiety(oneTuningPlusChurn, BAND_CONFIG);
@@ -511,6 +529,12 @@ describe("computeAnxiety — mixed mid-anxiety sets", () => {
         const result = computeAnxiety(oneTuningCapoAndTechniqueSpots, BAND_CONFIG);
         expect(result.scaled).toBeGreaterThanOrEqual(5);
         expect(result.changes).toBe(6);
+    });
+
+    it("keeps a four-spot set with one tuning hit above the low band", () => {
+        const result = computeAnxiety(oneTuningFourSpotSet, BAND_CONFIG);
+        expect(result.scaled).toBeGreaterThanOrEqual(4);
+        expect(result.changes).toBe(4);
     });
 });
 

--- a/src/lib/anxiety.test.js
+++ b/src/lib/anxiety.test.js
@@ -23,30 +23,25 @@ const BAND_CONFIG = {
         tuning: {
             kind: "instrumentField",
             field: "tuning",
-            summaryLabel: "tuning changes",
             minStreak: 2,
             allowChangeOnLastSong: true
         },
         capo: {
             kind: "instrumentDelta",
             field: "capo",
-            summaryLabel: "capo steps",
             minStreak: 2,
             allowChangeOnLastSong: true
         },
         instruments: {
             kind: "instrumentSet",
             weightKey: "instrument",
-            summaryLabel: "instrument swaps",
             minStreak: 2,
-            allowChangeOnLastSong: true,
-            mutuallyExclusive: []
+            allowChangeOnLastSong: true
         },
         picking: {
             kind: "instrumentField",
             field: "picking",
             weightKey: "technique",
-            summaryLabel: "technique changes",
             minStreak: 1,
             allowChangeOnLastSong: true
         }

--- a/src/lib/anxiety.test.js
+++ b/src/lib/anxiety.test.js
@@ -850,30 +850,20 @@ describe("anxietyLabel", () => {
         expect(label).toContain("1 spot over 15 songs");
     });
 
-    it("returns 'one eye on the tuner' for light mid anxiety", () => {
-        const label = anxietyLabel({ scaled: 3, changes: 5, spots: 3, songCount: 15 });
-        expect(label).toContain("one eye on the tuner");
-        expect(label).toContain("3 spots over 15 songs");
-    });
-
-    it("returns 'starting to sweat' for a 4/10 set", () => {
+    it("returns 'crowd work' for medium anxiety", () => {
         const label = anxietyLabel({ scaled: 4, changes: 4, spots: 4, songCount: 15 });
-        expect(label).toContain("starting to sweat");
-    });
-
-    it("returns 'counting setup moves' for solid mid-high anxiety", () => {
-        const label = anxietyLabel({ scaled: 6, changes: 7, spots: 6, songCount: 15 });
-        expect(label).toContain("counting setup moves");
+        expect(label).toContain("crowd work");
+        expect(label).toContain("4 spots over 15 songs");
     });
 
     it("returns 'sweating' for high anxiety", () => {
         const label = anxietyLabel({ scaled: 7, changes: 10, spots: 7, songCount: 15 });
-        expect(label).toContain("stalling for time");
+        expect(label).toContain("sweating");
     });
 
-    it("returns 'fuse box' for extreme anxiety", () => {
+    it("returns 'stand-up set' for extreme anxiety", () => {
         const label = anxietyLabel({ scaled: 9, changes: 18, spots: 12, songCount: 15 });
-        expect(label).toContain("fuse box");
+        expect(label).toContain("stand-up set");
     });
 
     it("pluralizes 'change' correctly", () => {

--- a/src/lib/anxiety.test.js
+++ b/src/lib/anxiety.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { computeAnxiety, anxietyLabel, _internals } from "./anxiety.js";
 
-const { normalizeValue, displayValue, detectInstrumentSetChange, detectFieldChange, scoreTransition } = _internals;
+const { normalizeValue, displayValue, detectInstrumentSetChange, detectFieldChange, scoreTransition, anxietyWeightPressure } = _internals;
 
 // ---------------------------------------------------------------------------
 // Test config matching the user's real band setup
@@ -447,9 +447,8 @@ describe("computeAnxiety — low-anxiety 15-song setlist", () => {
     it("scores 1-3 for a setlist with only low-weight changes", () => {
         const result = computeAnxiety(lowSetlist, BAND_CONFIG);
         expect(result.spots).toBe(3);
-        // Per-member: T1 nick technique (1), T2 nick technique (1),
-        // T3 mark capo (1 member) + nick capo (1 member, max of capo vs no other change)
-        expect(result.changes).toBe(4);
+        expect(result.changes).toBe(3);
+        expect(result.memberChanges).toBe(4);
         expect(result.scaled).toBeGreaterThanOrEqual(1);
         expect(result.scaled).toBeLessThanOrEqual(3);
     });
@@ -508,13 +507,14 @@ describe("computeAnxiety — per-member deduplication", () => {
         expect(result.changes).toBe(1);
     });
 
-    it("two members each changing = 2 changes", () => {
+    it("two members each changing still counts as one disrupted spot", () => {
         const songs = [
             song("A", "G", { mark: { tuning: "Standard" }, nick: { tuning: "Open G" } }),
             song("B", "G", { mark: { tuning: "DADDAD" }, nick: { tuning: "Open D" } })
         ];
         const result = computeAnxiety(songs, BAND_CONFIG);
-        expect(result.changes).toBe(2);
+        expect(result.changes).toBe(1);
+        expect(result.memberChanges).toBe(2);
     });
 });
 
@@ -782,8 +782,8 @@ describe("transition-by-transition detail verification", () => {
         expect(t.changes.tuning.changed).toBe(true);
         expect(t.changes.picking.changed).toBe(true);
         expect(t.changes.capo.changed).toBe(false);
-        // Per-member: nick changes 3 things, score = max weight (tuning=4)
-        expect(t.score).toBe(4);
+        // Per-member: nick changes 3 things, score = transformed max weight (tuning=4)
+        expect(t.score).toBeCloseTo(anxietyWeightPressure(4), 5);
         expect(t.memberChanges).toBe(1);
     });
 
@@ -795,8 +795,8 @@ describe("transition-by-transition detail verification", () => {
         expect(t.changes.instruments.changed).toBe(false);
         expect(t.changes.tuning.changed).toBe(false);
         expect(t.changes.picking.changed).toBe(false);
-        // Per-member: nick changes capo only, score = capo weight (2)
-        expect(t.score).toBe(2);
+        // Per-member: nick changes capo only, score = transformed capo pressure
+        expect(t.score).toBeCloseTo(anxietyWeightPressure(2), 5);
         expect(t.memberChanges).toBe(1);
     });
 
@@ -807,20 +807,21 @@ describe("transition-by-transition detail verification", () => {
         expect(t.changes.tuning.changed).toBe(true);
         expect(t.changes.capo.changed).toBe(true);
         expect(t.changes.picking.changed).toBe(true);
-        // Per-member: nick changes everything, score = max weight (tuning=4)
-        expect(t.score).toBe(4);
+        // Per-member: nick changes everything, score = transformed max weight (tuning=4)
+        expect(t.score).toBeCloseTo(anxietyWeightPressure(4), 5);
         expect(t.memberChanges).toBe(1);
     });
 
-    it("total changes matches sum of detail memberChanges", () => {
+    it("total memberChanges matches sum of detail memberChanges", () => {
         const result = computeAnxiety(setlist, BAND_CONFIG);
         const sumFromDetails = result.details.reduce((sum, d) => sum + d.memberChanges, 0);
-        expect(result.changes).toBe(sumFromDetails);
+        expect(result.memberChanges).toBe(sumFromDetails);
     });
 
     it("spots matches count of non-zero detail entries", () => {
         const result = computeAnxiety(setlist, BAND_CONFIG);
         const spots = result.details.filter(d => d.memberChanges > 0).length;
         expect(result.spots).toBe(spots);
+        expect(result.changes).toBe(spots);
     });
 });

--- a/src/lib/anxiety.test.js
+++ b/src/lib/anxiety.test.js
@@ -397,11 +397,11 @@ describe("computeAnxiety — tuning-heavy 15-song setlist", () => {
         song("Song 15", "D", { mark: { instrument: "guitar", tuning: "Standard" }, nick: { instrument: "banjo", tuning: "Open G", picking: ["picking"] } }),
     ];
 
-    it("scores 7-8 for a setlist with 2 tuning changes and technique changes", () => {
+    it("scores 7-9 for a setlist with 2 tuning changes and technique changes", () => {
         const result = computeAnxiety(tuningSetlist, BAND_CONFIG);
         // 2 tuning changes (weight 4 each, affecting 2 members) should drive anxiety high
         expect(result.scaled).toBeGreaterThanOrEqual(7);
-        expect(result.scaled).toBeLessThanOrEqual(8);
+        expect(result.scaled).toBeLessThanOrEqual(9);
     });
 
     it("tuning changes contribute more to weighted score than technique changes", () => {
@@ -413,6 +413,80 @@ describe("computeAnxiety — tuning-heavy 15-song setlist", () => {
 
         expect(tuningTransition1.score).toBeGreaterThan(techniqueOnly.score);
         expect(tuningTransition2.score).toBeGreaterThan(techniqueOnly.score);
+    });
+});
+
+describe("computeAnxiety — mixed mid-anxiety sets", () => {
+    const guitarStd = { instrument: "guitar", tuning: "Standard", capo: 0, picking: [] };
+    const guitarDaddad = { instrument: "guitar", tuning: "DADDAD", capo: 0, picking: [] };
+    const banjoPick = { instrument: "banjo", tuning: "Open G", capo: 0, picking: ["picking"] };
+    const banjoPickSlide = { instrument: "banjo", tuning: "Open G", capo: 0, picking: ["picking", "slide"] };
+    const banjoSlidePick = { instrument: "banjo", tuning: "Open G", capo: 0, picking: ["slide", "picking"] };
+    const banjoClaw = { instrument: "banjo", tuning: "Open G", capo: 0, picking: ["clawhammer"] };
+    const banjoCapo2Pick = { instrument: "banjo", tuning: "Open G", capo: 2, picking: ["picking"] };
+    const banjoSlide = { instrument: "banjo", tuning: "Open G", capo: 0, picking: ["slide"] };
+
+    const sparseLow = [
+        song("High", "D", { mark: { ...guitarStd }, nick: { ...banjoPick } }),
+        song("Trying to get to the Port", "G", { mark: { ...guitarStd }, nick: { ...banjoPick } }),
+        song("Put Some Gravy", "D", { mark: { ...guitarStd }, nick: { ...banjoPick } }),
+        song("Run Along", "C", { mark: { ...guitarStd }, nick: { ...banjoPick } }),
+        song("Farewell to Cheyenne", "", { mark: { ...guitarStd }, nick: { ...banjoPick } }),
+        song("Redwing", "G", { mark: { ...guitarStd }, nick: { ...banjoClaw } }),
+        song("In a Station Wagon", "G", { mark: { ...guitarStd }, nick: { ...banjoClaw } }),
+        song("Bottle of Soot", "D", { mark: { ...guitarStd }, nick: { ...banjoSlidePick } }),
+        song("Lester Young", "G", { mark: { ...guitarStd }, nick: { ...banjoSlidePick } }),
+    ];
+
+    const oneTuningPlusChurn = [
+        song("Courtroom Sketch Artist", "G", { mark: { ...guitarDaddad }, nick: { ...banjoPick } }),
+        song("Euglena", "D", { mark: { ...guitarDaddad }, nick: { ...banjoPick } }),
+        song("O' the Topside", "E", { mark: { ...guitarDaddad }, nick: { ...banjoPickSlide } }),
+        song("Bottle of Soot", "D", { mark: { ...guitarDaddad }, nick: { ...banjoSlidePick } }),
+        song("Redwing", "G", { mark: { ...guitarDaddad }, nick: { ...banjoClaw } }),
+        song("The Corporeal Races", "G", { mark: { ...guitarDaddad }, nick: { ...banjoClaw } }),
+        song("In a Station Wagon", "G", { mark: { ...guitarStd }, nick: { ...banjoClaw } }),
+        song("Run Along", "C", { mark: { ...guitarStd }, nick: { ...banjoPick } }),
+        song("Jackass Travels", "A", { mark: { ...guitarStd }, nick: { ...banjoCapo2Pick } }),
+        song("Aerial Jones", "E", { mark: { ...guitarStd }, nick: { ...banjoCapo2Pick } }),
+        song("Pumpin' Gas", "A", { mark: { ...guitarStd }, nick: { ...banjoCapo2Pick } }),
+        song("Break Man", "A", { mark: { ...guitarStd }, nick: { ...banjoCapo2Pick } }),
+        song("Every Pyro in the Class", "G", { mark: { ...guitarStd }, nick: { ...banjoPick } }),
+        song("Put Some Gravy", "D", { mark: { ...guitarStd }, nick: { ...banjoPick } }),
+        song("High", "D", { mark: { ...guitarStd }, nick: { ...banjoPick } }),
+    ];
+
+    const oneTuningManyTechniqueSpots = [
+        song("Bob Dylan", "D", { mark: { ...guitarDaddad }, nick: { ...banjoPickSlide } }),
+        song("Lester Young", "G", { mark: { ...guitarDaddad }, nick: { ...banjoSlidePick } }),
+        song("O' the Topside", "E", { mark: { ...guitarDaddad }, nick: { ...banjoPickSlide } }),
+        song("Every Pyro in the Class", "G", { mark: { ...guitarDaddad }, nick: { ...banjoPick } }),
+        song("Farewell to Cheyenne", "", { mark: { ...guitarDaddad }, nick: { ...banjoPick } }),
+        song("Ain't No Willow", "E", { mark: { ...guitarDaddad }, nick: { ...banjoClaw } }),
+        song("The Corporeal Races", "G", { mark: { ...guitarDaddad }, nick: { ...banjoClaw } }),
+        song("Courtroom Sketch Artist", "G", { mark: { ...guitarDaddad }, nick: { ...banjoPick } }),
+        song("Put Some Gravy", "D", { mark: { ...guitarStd }, nick: { ...banjoPick } }),
+        song("Folsom Prison", "E", { mark: { ...guitarStd }, nick: { ...banjoSlidePick } }),
+        song("Bottle of Soot", "D", { mark: { ...guitarStd }, nick: { ...banjoSlidePick } }),
+        song("In a Station Wagon", "G", { mark: { ...guitarStd }, nick: { ...banjoClaw } }),
+        song("Turning into a Tree", "C", { mark: { ...guitarStd }, nick: { ...banjoClaw } }),
+        song("Burma Road", "F", { mark: { ...guitarStd }, nick: { ...banjoSlide } }),
+        song("Run Along", "C", { mark: { ...guitarStd }, nick: { ...banjoPick } }),
+    ];
+
+    it("keeps sparse low-change sets calmer than tuning-plus-churn sets", () => {
+        const low = computeAnxiety(sparseLow, BAND_CONFIG);
+        const mixed = computeAnxiety(oneTuningPlusChurn, BAND_CONFIG);
+
+        expect(low.scaled).toBeLessThan(mixed.scaled);
+        expect(low.scaled).toBeLessThanOrEqual(2);
+        expect(mixed.scaled).toBeGreaterThanOrEqual(5);
+    });
+
+    it("scores a tuning change plus many real transition spots in the mid range", () => {
+        const result = computeAnxiety(oneTuningManyTechniqueSpots, BAND_CONFIG);
+        expect(result.scaled).toBeGreaterThanOrEqual(5);
+        expect(result.changes).toBe(8);
     });
 });
 

--- a/src/lib/anxiety.test.js
+++ b/src/lib/anxiety.test.js
@@ -850,10 +850,20 @@ describe("anxietyLabel", () => {
         expect(label).toContain("1 spot over 15 songs");
     });
 
-    it("returns 'crowd work' for medium anxiety", () => {
-        const label = anxietyLabel({ scaled: 4, changes: 5, spots: 3, songCount: 15 });
+    it("returns 'crowd work' for light mid anxiety", () => {
+        const label = anxietyLabel({ scaled: 3, changes: 5, spots: 3, songCount: 15 });
         expect(label).toContain("crowd work");
         expect(label).toContain("3 spots over 15 songs");
+    });
+
+    it("returns 'starting to sweat' for a 4/10 set", () => {
+        const label = anxietyLabel({ scaled: 4, changes: 4, spots: 4, songCount: 15 });
+        expect(label).toContain("starting to sweat");
+    });
+
+    it("returns 'checking the tuner' for solid mid-high anxiety", () => {
+        const label = anxietyLabel({ scaled: 6, changes: 7, spots: 6, songCount: 15 });
+        expect(label).toContain("checking the tuner");
     });
 
     it("returns 'sweating' for high anxiety", () => {

--- a/src/lib/components/band/BandScreen.svelte
+++ b/src/lib/components/band/BandScreen.svelte
@@ -394,7 +394,7 @@
         <div class="section-block">
             <h3 class="section-label">Config</h3>
             <button class="card link-card" onclick={() => { store.bandSubView = "advanced"; }}>
-                <span class="link-card-label">Generation settings, weights, and order rules</span>
+                <span class="link-card-label">Transition costs and switching rules</span>
                 <span class="link-card-arrow">&rsaquo;</span>
             </button>
         </div>

--- a/src/lib/components/roll/SetlistSongCard.svelte
+++ b/src/lib/components/roll/SetlistSongCard.svelte
@@ -3,6 +3,17 @@
 
   let expanded = $state(false);
 
+  function normalizeTechniqueValue(value) {
+    if (!Array.isArray(value)) return String(value || "");
+    return value.filter((technique) => technique && technique !== "none").slice().sort().join(",");
+  }
+
+  function techniqueDisplay(value) {
+    if (!Array.isArray(value)) return value || null;
+    const normalized = value.filter((technique) => technique && technique !== "none").slice().sort();
+    return normalized.length ? normalized.join(", ") : null;
+  }
+
   function toggleExpand() {
     expanded = !expanded;
   }
@@ -22,11 +33,11 @@
       if (curr.capo) changes.push(`capo ${curr.capo}`);
       else if (prev?.capo) changes.push("capo off");
     }
-    const currTech = String(curr.picking || "");
-    const prevTech = prev ? String(prev.picking || "") : "";
+    const currTech = normalizeTechniqueValue(curr.picking);
+    const prevTech = prev ? normalizeTechniqueValue(prev.picking) : "";
     if (currTech !== prevTech && currTech) {
-      const techDisplay = Array.isArray(curr.picking) ? curr.picking.filter(t => t !== "none").join(", ") : currTech;
-      if (techDisplay) changes.push(techDisplay);
+      const tech = techniqueDisplay(curr.picking);
+      if (tech) changes.push(tech);
     }
     return changes;
   }
@@ -77,7 +88,7 @@
       {:else if song.performance}
         <div class="change-lines">
           {#each Object.entries(song.performance) as [memberName, perf]}
-            {@const techStr = Array.isArray(perf.picking) && perf.picking.length ? perf.picking.filter(t => t !== "none").join(", ") || null : null}
+            {@const techStr = techniqueDisplay(perf.picking)}
             {@const parts = [perf.instrument, perf.tuning, perf.capo ? `capo ${perf.capo}` : null, techStr].filter(Boolean)}
             {#if parts.length > 0}
               <div class="change-line first-song">

--- a/src/lib/components/saved/SavedScreen.svelte
+++ b/src/lib/components/saved/SavedScreen.svelte
@@ -119,6 +119,17 @@
     return d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
   }
 
+  function normalizeTechniqueValue(value) {
+    if (!Array.isArray(value)) return String(value || "");
+    return value.filter((technique) => technique && technique !== "none").slice().sort().join(",");
+  }
+
+  function techniqueDisplay(value) {
+    if (!Array.isArray(value)) return value || null;
+    const normalized = value.filter((technique) => technique && technique !== "none").slice().sort();
+    return normalized.length ? normalized.join(", ") : null;
+  }
+
   // Transition notes — same logic as SetlistSongCard
   function getChanges(song, prevSong, memberName) {
     const curr = song.performance?.[memberName];
@@ -135,11 +146,11 @@
       if (curr.capo) changes.push(`capo ${curr.capo}`);
       else if (prev?.capo) changes.push("capo off");
     }
-    const currTech = String(curr.picking || "");
-    const prevTech = prev ? String(prev.picking || "") : "";
+    const currTech = normalizeTechniqueValue(curr.picking);
+    const prevTech = prev ? normalizeTechniqueValue(prev.picking) : "";
     if (currTech !== prevTech && currTech) {
-      const techDisplay = Array.isArray(curr.picking) ? curr.picking.filter(t => t !== "none").join(", ") : currTech;
-      if (techDisplay) changes.push(techDisplay);
+      const tech = techniqueDisplay(curr.picking);
+      if (tech) changes.push(tech);
     }
     return changes;
   }
@@ -154,7 +165,7 @@
       } else {
         // First song: show initial setup
         const perf = song.performance[memberName];
-        const techStr = Array.isArray(perf.picking) && perf.picking.length ? perf.picking.filter(t => t !== "none").join(", ") || null : null;
+        const techStr = techniqueDisplay(perf.picking);
         const parts = [perf.instrument, perf.tuning, perf.capo ? `capo ${perf.capo}` : null, techStr].filter(Boolean);
         if (parts.length > 0) lines.push({ member: memberName, changes: parts, isSetup: true });
       }

--- a/src/lib/config-meta.js
+++ b/src/lib/config-meta.js
@@ -114,11 +114,3 @@ export const CONFIG_SECTIONS = [
         ]
     }
 ];
-
-
-export const CONFIG_REFERENCE = CONFIG_SECTIONS.flatMap((section) => {
-    return section.fields.map((field) => ({
-        section: section.title,
-        ...field
-    }));
-});

--- a/src/lib/defaults.js
+++ b/src/lib/defaults.js
@@ -47,60 +47,37 @@ const DEFAULT_CONFIG_TEMPLATE = {
             blockShuffleTemperature: 1.4
         }
     },
-    show: {
-        members: {}
-    },
+    show: {},
     props: {
         tuning: {
             kind: "instrumentField",
             field: "tuning",
-            summaryLabel: "tuning changes",
             minStreak: 2,
             allowChangeOnLastSong: true
         },
         capo: {
             kind: "instrumentDelta",
             field: "capo",
-            summaryLabel: "capo steps",
             minStreak: 2,
             allowChangeOnLastSong: true
         },
         instruments: {
             kind: "instrumentSet",
             weightKey: "instrument",
-            summaryLabel: "instrument swaps",
             minStreak: 2,
-            allowChangeOnLastSong: true,
-            mutuallyExclusive: []
+            allowChangeOnLastSong: true
         },
         picking: {
             kind: "instrumentField",
             field: "picking",
             weightKey: "technique",
-            summaryLabel: "technique changes",
             minStreak: 1,
             allowChangeOnLastSong: true
         }
-    },
-    band: {
-        members: {}
-    },
-    catalog: {
-        tunings: [],
-        tuningsByInstrument: {}
     }
 };
 
 export const DEFAULT_APP_CONFIG = createDefaultAppConfig();
-
-function normalizeCatalogConfig(seedConfig = {}) {
-    return {
-        tunings: Array.isArray(seedConfig.catalog?.tunings)
-            ? seedConfig.catalog.tunings.slice()
-            : [],
-        tuningsByInstrument: clone(seedConfig.catalog?.tuningsByInstrument || {})
-    };
-}
 
 export function normalizeMemberRecord(memberConfig) {
     const instruments = Array.isArray(memberConfig?.instruments)
@@ -123,20 +100,12 @@ export function normalizeMemberRecord(memberConfig) {
     };
 }
 
-function normalizeBandMembers(seedMembers = {}) {
-    return Object.entries(seedMembers || {}).reduce((result, [memberName, memberConfig]) => {
-        result[memberName] = normalizeMemberRecord(memberConfig);
-        return result;
-    }, {});
-}
-
 export function createDefaultAppConfig({ bandName = "", seedConfig = DEFAULT_CONFIG_TEMPLATE } = {}) {
     const timestamp = nowIso();
     const baseConfig = clone(seedConfig);
     baseConfig.show = baseConfig.show || {};
     delete baseConfig.show.members;
     delete baseConfig.band?.members;
-    baseConfig.catalog = normalizeCatalogConfig(baseConfig);
 
     return {
         bandName,
@@ -192,12 +161,10 @@ export function normalizeAppConfig(config) {
     }
 
     const timestamp = config.createdAt || nowIso();
-    const catalog = normalizeCatalogConfig(config);
 
     const normalized = deepMerge(createDefaultAppConfig({ bandName: config.bandName || "" }), {
         ...clone(config),
         bandName: config.bandName || "",
-        catalog,
         schemaVersion: config.schemaVersion || SCHEMA_VERSION,
         createdAt: config.createdAt || timestamp,
         updatedAt: config.updatedAt || timestamp
@@ -205,6 +172,7 @@ export function normalizeAppConfig(config) {
     // Members are now stored as individual files; strip from config
     delete normalized.band?.members;
     delete normalized.show?.members;
+    delete normalized.catalog;
     return normalized;
 }
 

--- a/src/lib/generator.js
+++ b/src/lib/generator.js
@@ -345,7 +345,7 @@ class SetList {
             if (!result[groupId]) {
                 result[groupId] = {
                     id: groupId,
-                    weight: this._weights.instrument || 3,
+                    weight: this._weights.instrument ?? 3,
                     constraints: []
                 };
             }
@@ -357,7 +357,7 @@ class SetList {
             if (!result[groupId]) {
                 result[groupId] = {
                     id: groupId,
-                    weight: this._weights.tuning || 4,
+                    weight: this._weights.tuning ?? 4,
                     constraints: []
                 };
             }
@@ -375,8 +375,8 @@ class SetList {
             return {
                 ...group,
                 keys,
-                keyToBit: keys.reduce((result, key, index) => {
-                    result[key] = (1 << index);
+                keyToIndex: keys.reduce((result, key, index) => {
+                    result[key] = index;
                     return result;
                 }, {})
             };
@@ -416,7 +416,7 @@ class SetList {
             return `${constraint.member}:${constraint.instrument}:${constraint.tuning}`;
         }));
         const totals = { instruments: {}, tunings: {} };
-        const groupMasksBySongId = {};
+        const groupCapabilitiesBySongId = {};
         const bySongId = {};
 
         for (let index = 0; index < catalog.length; index += 1) {
@@ -424,10 +424,6 @@ class SetList {
             const variants = variantCache.get(song.id) || [];
             const instrumentKeys = new Set();
             const tuningKeys = new Set();
-            const groupMasks = this._minimumGroups.reduce((result, group) => {
-                result[group.id] = 0;
-                return result;
-            }, {});
 
             for (let variantIndex = 0; variantIndex < variants.length; variantIndex += 1) {
                 const performance = variants[variantIndex].performance || {};
@@ -444,22 +440,25 @@ class SetList {
                         }
                     }
                 }
-
-                this._minimumGroups.forEach((group) => {
-                    for (let keyIndex = 0; keyIndex < group.keys.length; keyIndex += 1) {
-                        const key = group.keys[keyIndex];
-                        if (instrumentKeys.has(key) || tuningKeys.has(key)) {
-                            groupMasks[group.id] |= group.keyToBit[key];
-                        }
-                    }
-                });
             }
 
             bySongId[song.id] = {
                 instruments: Array.from(instrumentKeys),
                 tunings: Array.from(tuningKeys)
             };
-            groupMasksBySongId[song.id] = groupMasks;
+            groupCapabilitiesBySongId[song.id] = this._minimumGroups.reduce((result, group) => {
+                const capabilityIndexes = [];
+                for (let keyIndex = 0; keyIndex < group.keys.length; keyIndex += 1) {
+                    const key = group.keys[keyIndex];
+                    if (instrumentKeys.has(key) || tuningKeys.has(key)) {
+                        capabilityIndexes.push(group.keyToIndex[key]);
+                    }
+                }
+                if (capabilityIndexes.length) {
+                    result[group.id] = capabilityIndexes;
+                }
+                return result;
+            }, {});
 
             bySongId[song.id].instruments.forEach((key) => {
                 totals.instruments[key] = (totals.instruments[key] || 0) + 1;
@@ -469,7 +468,7 @@ class SetList {
             });
         }
 
-        return { bySongId, totals, groupMasksBySongId };
+        return { bySongId, totals, groupCapabilitiesBySongId };
     }
 
     _consumeRemainingPotentialCounts(remainingPotentialCounts, songId) {
@@ -489,23 +488,23 @@ class SetList {
         return next;
     }
 
-    _remainingGroupCapabilityMasks(state, consumedSongId, groupId) {
-        const masks = [];
+    _remainingGroupCapabilities(state, consumedSongId, groupId) {
+        const capabilities = [];
         for (let index = 0; index < this._catalog.length; index += 1) {
             const song = this._catalog[index];
             if (song.id === consumedSongId || state.usedIds[song.id]) {
                 continue;
             }
 
-            const mask = this._minimumGroupMasksBySongId?.[song.id]?.[groupId] || 0;
-            if (mask) {
-                masks.push(mask);
+            const capability = this._minimumGroupCapabilitiesBySongId?.[song.id]?.[groupId];
+            if (capability?.length) {
+                capabilities.push(capability);
             }
         }
-        return masks;
+        return capabilities;
     }
 
-    _canSatisfyGroupDeficits(group, deficits, remainingMasks, remainingSlots) {
+    _canSatisfyGroupDeficits(deficits, remainingCapabilities, remainingSlots) {
         const totalNeeded = deficits.reduce((sum, deficit) => sum + deficit, 0);
         if (!totalNeeded) {
             return true;
@@ -513,33 +512,53 @@ class SetList {
         if (totalNeeded > remainingSlots) {
             return false;
         }
+        if (remainingCapabilities.length < totalNeeded) {
+            return false;
+        }
 
-        const subsetCount = 1 << group.keys.length;
-        for (let subsetMask = 1; subsetMask < subsetCount; subsetMask += 1) {
-            let required = 0;
-            for (let index = 0; index < deficits.length; index += 1) {
-                if (subsetMask & (1 << index)) {
-                    required += deficits[index];
+        const slotsByKeyIndex = deficits.map(() => []);
+        let totalSlots = 0;
+        deficits.forEach((deficit, keyIndex) => {
+            for (let count = 0; count < deficit; count += 1) {
+                slotsByKeyIndex[keyIndex].push(totalSlots);
+                totalSlots += 1;
+            }
+        });
+
+        const slotToSongIndex = new Array(totalSlots).fill(-1);
+        const tryAssign = (songIndex, seenSlots) => {
+            const songCapabilities = remainingCapabilities[songIndex];
+            for (let capabilityIndex = 0; capabilityIndex < songCapabilities.length; capabilityIndex += 1) {
+                const keyIndex = songCapabilities[capabilityIndex];
+                const slotIndexes = slotsByKeyIndex[keyIndex];
+                for (let slotIndex = 0; slotIndex < slotIndexes.length; slotIndex += 1) {
+                    const slot = slotIndexes[slotIndex];
+                    if (seenSlots[slot]) {
+                        continue;
+                    }
+                    seenSlots[slot] = true;
+                    const assignedSongIndex = slotToSongIndex[slot];
+                    if (assignedSongIndex === -1 || tryAssign(assignedSongIndex, seenSlots)) {
+                        slotToSongIndex[slot] = songIndex;
+                        return true;
+                    }
                 }
             }
-            if (!required) {
-                continue;
-            }
+            return false;
+        };
 
-            let possible = 0;
-            for (let maskIndex = 0; maskIndex < remainingMasks.length; maskIndex += 1) {
-                if (remainingMasks[maskIndex] & subsetMask) {
-                    possible += 1;
+        let matched = 0;
+        for (let songIndex = 0; songIndex < remainingCapabilities.length; songIndex += 1) {
+            const seenSlots = new Array(totalSlots).fill(false);
+            if (tryAssign(songIndex, seenSlots)) {
+                matched += 1;
+                if (matched === totalNeeded) {
+                    return true;
                 }
-            }
-            possible = Math.min(possible, remainingSlots);
-
-            if (possible < required) {
-                return false;
             }
         }
 
-        return true;
+        return false;
     }
 
     _scoreMinimumPenalty(state, songId, position, usageCounts, remainingPotentialCounts) {
@@ -556,7 +575,7 @@ class SetList {
             }
             if (deficit > 0) {
                 const slack = Math.max(0, possible - deficit);
-                penalty += deficit * (this._weights.instrument || 3) * (1 + (1 / (slack + 1)));
+                penalty += deficit * (this._weights.instrument ?? 3) * (1 + (1 / (slack + 1)));
             }
         }
 
@@ -570,7 +589,7 @@ class SetList {
             }
             if (deficit > 0) {
                 const slack = Math.max(0, possible - deficit);
-                penalty += deficit * (this._weights.tuning || 4) * (1 + (1 / (slack + 1)));
+                penalty += deficit * (this._weights.tuning ?? 4) * (1 + (1 / (slack + 1)));
             }
         }
 
@@ -585,9 +604,8 @@ class SetList {
             });
 
             if (!this._canSatisfyGroupDeficits(
-                group,
                 deficits,
-                this._remainingGroupCapabilityMasks(state, songId, group.id),
+                this._remainingGroupCapabilities(state, songId, group.id),
                 remainingSlots
             )) {
                 return Infinity;
@@ -643,7 +661,7 @@ class SetList {
         const minimumPotentialContext = this._buildMinimumPotentialContext(catalog, variantCache);
         this._minimumPotentialBySongId = minimumPotentialContext.bySongId;
         this._minimumPotentialTotals = minimumPotentialContext.totals;
-        this._minimumGroupMasksBySongId = minimumPotentialContext.groupMasksBySongId;
+        this._minimumGroupCapabilitiesBySongId = minimumPotentialContext.groupCapabilitiesBySongId;
         this._minimumsRelaxed = false;
         let states = [this._initialState()];
 

--- a/src/lib/generator.js
+++ b/src/lib/generator.js
@@ -581,7 +581,7 @@ class SetList {
         return false;
     }
 
-    _scoreMinimumPenalty(state, songId, position, usageCounts, remainingPotentialCounts) {
+    _scoreMinimumPenalty(state, songId, position, usageCounts, remainingPotentialCounts, remainingGroupCapabilitiesById = null) {
         const remainingSlots = this._count - position;
         let penalty = 0;
 
@@ -622,10 +622,14 @@ class SetList {
                 const usageBucket = "tuning" in constraint ? usageCounts.tunings : usageCounts.instruments;
                 return Math.max(0, constraint.min - (usageBucket[key] || 0));
             });
+            const totalNeeded = deficits.reduce((sum, deficit) => sum + deficit, 0);
+            if (!totalNeeded) {
+                continue;
+            }
 
             if (!this._canSatisfyGroupDeficits(
                 deficits,
-                this._remainingGroupCapabilities(state, songId, group.id),
+                remainingGroupCapabilitiesById?.[group.id] ?? this._remainingGroupCapabilities(state, songId, group.id),
                 remainingSlots
             )) {
                 return Infinity;
@@ -1017,6 +1021,7 @@ class SetList {
 
         const variants = this._variantCache.get(song.id);
         const nextRemainingPotentialCounts = this._consumeRemainingPotentialCounts(state.remainingPotentialCounts, song.id);
+        let remainingGroupCapabilitiesById = null;
         for (let vi = 0; vi < variants.length; vi++) {
             const variant = variants[vi];
             const propTransition = this._scoreConfiguredPropsLite(prevItem, variant);
@@ -1026,7 +1031,21 @@ class SetList {
 
             const nextPropState = this._advancePropState(state, propTransition.changes, prevItem);
             const nextUsageCounts = this._updateUsageCounts(state.usageCounts, variant);
-            const minimumPenalty = this._scoreMinimumPenalty(state, song.id, position, nextUsageCounts, nextRemainingPotentialCounts);
+            if (!remainingGroupCapabilitiesById && this._minimumGroups.length) {
+                remainingGroupCapabilitiesById = Object.create(null);
+                for (let groupIndex = 0; groupIndex < this._minimumGroups.length; groupIndex += 1) {
+                    const group = this._minimumGroups[groupIndex];
+                    remainingGroupCapabilitiesById[group.id] = this._remainingGroupCapabilities(state, song.id, group.id);
+                }
+            }
+            const minimumPenalty = this._scoreMinimumPenalty(
+                state,
+                song.id,
+                position,
+                nextUsageCounts,
+                nextRemainingPotentialCounts,
+                remainingGroupCapabilitiesById
+            );
 
             const positionScore = this._scorePositionLite(variant, position);
             const transitionScore = propTransition.score;

--- a/src/lib/generator.js
+++ b/src/lib/generator.js
@@ -1,5 +1,5 @@
 import { deepMerge, toArray } from "./utils.js";
-import { computeAnxiety } from "./anxiety.js";
+import { computeAnxiety, scoreAnxietyPressure } from "./anxiety.js";
 import {
     normalizeValue,
     displayValue,
@@ -25,6 +25,11 @@ function clampFloat(value, fallback, minimum) {
         return fallback;
     }
     return Math.max(minimum, parsed);
+}
+
+
+function clampUnit(value) {
+    return Math.max(0, Math.min(1, value));
 }
 
 
@@ -216,6 +221,7 @@ class SetList {
         this._rng = createRng(this._seed);
         this._randomness = merge(DEFAULT_RANDOMNESS, this._config.general?.randomness || {});
         this._randomness = merge(this._randomness, this._options.randomness || {});
+        this._chaosLevel = clampUnit((clampFloat(this._randomness.temperature, 0.85, 0.01) - 0.3) / 1.7);
         if (this._options.fixedSongIds) {
             const idSet = new Set(this._options.fixedSongIds);
             this._catalog = this._songs.all().filter(s => idSet.has(s.id));
@@ -305,6 +311,20 @@ class SetList {
 
     _songBias(songId) {
         return this._songBiasById[songId] || 0;
+    }
+
+    _chaosAdjustment(prevItem, nextVariant) {
+        const centeredChaos = (this._chaosLevel * 2) - 1;
+        if (!prevItem || centeredChaos === 0) {
+            return 0;
+        }
+
+        const pressure = scoreAnxietyPressure(prevItem, nextVariant, this._propNames, this._propConfig, this._weights);
+        if (!pressure.changed) {
+            return centeredChaos > 0 ? centeredChaos * 1.5 : 0;
+        }
+
+        return -(pressure.weightedScore + 1.5) * centeredChaos;
     }
 
     /**
@@ -1010,10 +1030,11 @@ class SetList {
 
             const positionScore = this._scorePositionLite(variant, position);
             const transitionScore = propTransition.score;
+            const chaosAdjustment = this._chaosAdjustment(prevItem, variant);
 
             if (minimumPenalty === Infinity) {
                 // Track as fallback in case all variants are impossible
-                const fbScore = transitionScore + positionScore + this._songBias(variant.id);
+                const fbScore = transitionScore + positionScore + this._songBias(variant.id) + chaosAdjustment;
                 if (fbScore < fallbackScore) {
                     fallbackScore = fbScore;
                     fallback = {
@@ -1029,7 +1050,7 @@ class SetList {
                 continue;
             }
 
-            const incrementalScore = transitionScore + positionScore + this._songBias(variant.id) + minimumPenalty;
+            const incrementalScore = transitionScore + positionScore + this._songBias(variant.id) + minimumPenalty + chaosAdjustment;
             const exploratoryScore = incrementalScore + this._randomJitter(this._randomness.variantJitter);
 
             if (exploratoryScore < bestScore) {

--- a/src/lib/generator.js
+++ b/src/lib/generator.js
@@ -228,6 +228,7 @@ class SetList {
         }
         this._songBiasById = this._buildSongBiases(this._catalog);
         this._minConstraints = this._buildMinConstraints();
+        this._minimumGroups = this._buildMinimumGroups();
         this._list = [];
         this._summary = {
             score: 0,
@@ -260,7 +261,7 @@ class SetList {
     }
 
     _normalizeSeed(seed) {
-        if (seed === undefined || seed === null || seed === "") {
+        if (seed === undefined || seed === null || seed === "" || seed === 0 || seed === "0") {
             return Math.floor(Date.now() + (Math.random() * 1000000));
         }
         const parsed = Number.parseInt(seed, 10);
@@ -338,6 +339,50 @@ class SetList {
         return constraints;
     }
 
+    _buildMinimumGroups() {
+        const instrumentGroups = Object.values(this._minConstraints.instruments.reduce((result, constraint) => {
+            const groupId = `instrument:${constraint.member}`;
+            if (!result[groupId]) {
+                result[groupId] = {
+                    id: groupId,
+                    weight: this._weights.instrument || 3,
+                    constraints: []
+                };
+            }
+            result[groupId].constraints.push(constraint);
+            return result;
+        }, {}));
+        const tuningGroups = Object.values(this._minConstraints.tunings.reduce((result, constraint) => {
+            const groupId = `tuning:${constraint.member}:${constraint.instrument}`;
+            if (!result[groupId]) {
+                result[groupId] = {
+                    id: groupId,
+                    weight: this._weights.tuning || 4,
+                    constraints: []
+                };
+            }
+            result[groupId].constraints.push(constraint);
+            return result;
+        }, {}));
+
+        return instrumentGroups.concat(tuningGroups).map((group) => {
+            const keys = group.constraints.map((constraint) => {
+                if ("tuning" in constraint) {
+                    return `${constraint.member}:${constraint.instrument}:${constraint.tuning}`;
+                }
+                return `${constraint.member}:${constraint.instrument}`;
+            });
+            return {
+                ...group,
+                keys,
+                keyToBit: keys.reduce((result, key, index) => {
+                    result[key] = (1 << index);
+                    return result;
+                }, {})
+            };
+        });
+    }
+
     /**
      * Count instrument/tuning usage from a variant's performance.
      */
@@ -363,20 +408,155 @@ class SetList {
      * when we're falling behind on meeting minimums.
      * Returns Infinity if it's mathematically impossible to meet them.
      */
-    _scoreMinimumPenalty(usageCounts, position) {
-        const remaining = this._count - position;
+    _buildMinimumPotentialContext(catalog, variantCache) {
+        const requiredInstrumentKeys = new Set(this._minConstraints.instruments.map((constraint) => {
+            return `${constraint.member}:${constraint.instrument}`;
+        }));
+        const requiredTuningKeys = new Set(this._minConstraints.tunings.map((constraint) => {
+            return `${constraint.member}:${constraint.instrument}:${constraint.tuning}`;
+        }));
+        const totals = { instruments: {}, tunings: {} };
+        const groupMasksBySongId = {};
+        const bySongId = {};
+
+        for (let index = 0; index < catalog.length; index += 1) {
+            const song = catalog[index];
+            const variants = variantCache.get(song.id) || [];
+            const instrumentKeys = new Set();
+            const tuningKeys = new Set();
+            const groupMasks = this._minimumGroups.reduce((result, group) => {
+                result[group.id] = 0;
+                return result;
+            }, {});
+
+            for (let variantIndex = 0; variantIndex < variants.length; variantIndex += 1) {
+                const performance = variants[variantIndex].performance || {};
+                for (const [member, setup] of Object.entries(performance)) {
+                    const instrumentKey = `${member}:${setup.instrument}`;
+                    if (requiredInstrumentKeys.has(instrumentKey)) {
+                        instrumentKeys.add(instrumentKey);
+                    }
+
+                    if (setup.tuning) {
+                        const tuningKey = `${member}:${setup.instrument}:${setup.tuning}`;
+                        if (requiredTuningKeys.has(tuningKey)) {
+                            tuningKeys.add(tuningKey);
+                        }
+                    }
+                }
+
+                this._minimumGroups.forEach((group) => {
+                    for (let keyIndex = 0; keyIndex < group.keys.length; keyIndex += 1) {
+                        const key = group.keys[keyIndex];
+                        if (instrumentKeys.has(key) || tuningKeys.has(key)) {
+                            groupMasks[group.id] |= group.keyToBit[key];
+                        }
+                    }
+                });
+            }
+
+            bySongId[song.id] = {
+                instruments: Array.from(instrumentKeys),
+                tunings: Array.from(tuningKeys)
+            };
+            groupMasksBySongId[song.id] = groupMasks;
+
+            bySongId[song.id].instruments.forEach((key) => {
+                totals.instruments[key] = (totals.instruments[key] || 0) + 1;
+            });
+            bySongId[song.id].tunings.forEach((key) => {
+                totals.tunings[key] = (totals.tunings[key] || 0) + 1;
+            });
+        }
+
+        return { bySongId, totals, groupMasksBySongId };
+    }
+
+    _consumeRemainingPotentialCounts(remainingPotentialCounts, songId) {
+        const next = {
+            instruments: { ...remainingPotentialCounts.instruments },
+            tunings: { ...remainingPotentialCounts.tunings }
+        };
+        const capabilities = this._minimumPotentialBySongId[songId] || { instruments: [], tunings: [] };
+
+        capabilities.instruments.forEach((key) => {
+            next.instruments[key] = Math.max(0, (next.instruments[key] || 0) - 1);
+        });
+        capabilities.tunings.forEach((key) => {
+            next.tunings[key] = Math.max(0, (next.tunings[key] || 0) - 1);
+        });
+
+        return next;
+    }
+
+    _remainingGroupCapabilityMasks(state, consumedSongId, groupId) {
+        const masks = [];
+        for (let index = 0; index < this._catalog.length; index += 1) {
+            const song = this._catalog[index];
+            if (song.id === consumedSongId || state.usedIds[song.id]) {
+                continue;
+            }
+
+            const mask = this._minimumGroupMasksBySongId?.[song.id]?.[groupId] || 0;
+            if (mask) {
+                masks.push(mask);
+            }
+        }
+        return masks;
+    }
+
+    _canSatisfyGroupDeficits(group, deficits, remainingMasks, remainingSlots) {
+        const totalNeeded = deficits.reduce((sum, deficit) => sum + deficit, 0);
+        if (!totalNeeded) {
+            return true;
+        }
+        if (totalNeeded > remainingSlots) {
+            return false;
+        }
+
+        const subsetCount = 1 << group.keys.length;
+        for (let subsetMask = 1; subsetMask < subsetCount; subsetMask += 1) {
+            let required = 0;
+            for (let index = 0; index < deficits.length; index += 1) {
+                if (subsetMask & (1 << index)) {
+                    required += deficits[index];
+                }
+            }
+            if (!required) {
+                continue;
+            }
+
+            let possible = 0;
+            for (let maskIndex = 0; maskIndex < remainingMasks.length; maskIndex += 1) {
+                if (remainingMasks[maskIndex] & subsetMask) {
+                    possible += 1;
+                }
+            }
+            possible = Math.min(possible, remainingSlots);
+
+            if (possible < required) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    _scoreMinimumPenalty(state, songId, position, usageCounts, remainingPotentialCounts) {
+        const remainingSlots = this._count - position;
         let penalty = 0;
 
         for (const c of this._minConstraints.instruments) {
             const key = `${c.member}:${c.instrument}`;
             const have = usageCounts.instruments[key] || 0;
             const deficit = c.min - have;
-            if (deficit > 0 && deficit > remaining) {
+            const possible = Math.min(remainingPotentialCounts.instruments[key] || 0, remainingSlots);
+            if (deficit > 0 && deficit > possible) {
                 return Infinity; // impossible to meet
             }
             if (deficit > 0) {
-                // Proportional penalty: higher when deadline is closer
-                penalty += deficit * (this._weights.instrument || 3) * (1 + (1 / (remaining + 1)));
+                const slack = Math.max(0, possible - deficit);
+                penalty += deficit * (this._weights.instrument || 3) * (1 + (1 / (slack + 1)));
             }
         }
 
@@ -384,11 +564,33 @@ class SetList {
             const key = `${c.member}:${c.instrument}:${c.tuning}`;
             const have = usageCounts.tunings[key] || 0;
             const deficit = c.min - have;
-            if (deficit > 0 && deficit > remaining) {
+            const possible = Math.min(remainingPotentialCounts.tunings[key] || 0, remainingSlots);
+            if (deficit > 0 && deficit > possible) {
                 return Infinity;
             }
             if (deficit > 0) {
-                penalty += deficit * (this._weights.tuning || 4) * (1 + (1 / (remaining + 1)));
+                const slack = Math.max(0, possible - deficit);
+                penalty += deficit * (this._weights.tuning || 4) * (1 + (1 / (slack + 1)));
+            }
+        }
+
+        for (let groupIndex = 0; groupIndex < this._minimumGroups.length; groupIndex += 1) {
+            const group = this._minimumGroups[groupIndex];
+            const deficits = group.constraints.map((constraint) => {
+                const key = "tuning" in constraint
+                    ? `${constraint.member}:${constraint.instrument}:${constraint.tuning}`
+                    : `${constraint.member}:${constraint.instrument}`;
+                const usageBucket = "tuning" in constraint ? usageCounts.tunings : usageCounts.instruments;
+                return Math.max(0, constraint.min - (usageBucket[key] || 0));
+            });
+
+            if (!this._canSatisfyGroupDeficits(
+                group,
+                deficits,
+                this._remainingGroupCapabilityMasks(state, songId, group.id),
+                remainingSlots
+            )) {
+                return Infinity;
             }
         }
 
@@ -410,7 +612,11 @@ class SetList {
             propChangeCounts: zeroMap(this._propNames),
             propStreaks: zeroMap(this._propNames),
             changeTotals: zeroMap(this._propNames),
-            usageCounts: { instruments: {}, tunings: {} }
+            usageCounts: { instruments: {}, tunings: {} },
+            remainingPotentialCounts: {
+                instruments: { ...(this._minimumPotentialTotals?.instruments || {}) },
+                tunings: { ...(this._minimumPotentialTotals?.tunings || {}) }
+            }
         };
     }
 
@@ -426,7 +632,6 @@ class SetList {
     }
 
     _build() {
-        let states = [this._initialState()];
         const catalog = this._randomness.shuffleCatalog ? this._shuffle(this._catalog) : this._catalog.slice();
 
         // Pre-expand and cache all variants once
@@ -435,9 +640,16 @@ class SetList {
             variantCache.set(catalog[i].id, this._songs.expandVariants(catalog[i], this._show));
         }
         this._variantCache = variantCache;
+        const minimumPotentialContext = this._buildMinimumPotentialContext(catalog, variantCache);
+        this._minimumPotentialBySongId = minimumPotentialContext.bySongId;
+        this._minimumPotentialTotals = minimumPotentialContext.totals;
+        this._minimumGroupMasksBySongId = minimumPotentialContext.groupMasksBySongId;
+        this._minimumsRelaxed = false;
+        let states = [this._initialState()];
 
         for (let position = 1; position <= this._count; position += 1) {
             const nextStates = [];
+            const fallbackStates = [];
 
             for (let si = 0; si < states.length; si++) {
                 const state = states[si];
@@ -447,19 +659,29 @@ class SetList {
                         continue;
                     }
 
-                    const nextState = this._buildNextState(state, song, position);
-                    if (nextState) {
-                        nextStates.push(nextState);
+                    const result = this._buildNextState(state, song, position);
+                    if (!result) {
+                        continue;
+                    }
+                    if (result.feasibleState) {
+                        nextStates.push(result.feasibleState);
+                    }
+                    if (result.fallbackState) {
+                        fallbackStates.push(result.fallbackState);
                     }
                 }
             }
 
-            if (!nextStates.length) {
+            const pool = nextStates.length ? nextStates : fallbackStates;
+            if (!pool.length) {
                 break;
             }
+            if (!nextStates.length && fallbackStates.length) {
+                this._minimumsRelaxed = true;
+            }
 
-            nextStates.sort(compareStates);
-            states = this._selectBeamStates(nextStates);
+            pool.sort(compareStates);
+            states = this._selectBeamStates(pool);
         }
 
         const best = this._pickFinalState(states);
@@ -692,7 +914,8 @@ class SetList {
                 covers: state.coverCount,
                 instrumentals: state.instrumentalCount,
                 changes: state.changeTotals,
-                anxiety
+                anxiety,
+                minimumsRelaxed: Boolean(this._minimumsRelaxed)
             }
         };
     }
@@ -709,28 +932,40 @@ class SetList {
         }
 
         const bestVariant = this._findBestVariant(state, song, position);
-        if (!bestVariant) {
+        if (!bestVariant.feasible && !bestVariant.fallback) {
             return null;
         }
 
-        const newScore = state.score + bestVariant.incrementalScore;
-        const usedIds = Object.create(state.usedIds);
-        usedIds[song.id] = true;
+        const buildState = (variantState) => {
+            if (!variantState) {
+                return null;
+            }
+
+            const newScore = state.score + variantState.incrementalScore;
+            const usedIds = Object.create(state.usedIds);
+            usedIds[song.id] = true;
+
+            return {
+                head: { item: variantState.item, prev: state.head },
+                length: state.length + 1,
+                usedIds,
+                score: newScore,
+                coverCount: nextCoverCount,
+                instrumentalCount: nextInstrumentalCount,
+                lastItem: variantState.item,
+                rankScore: newScore + this._randomJitter(this._randomness.stateJitter),
+                _tiebreaker: this._rng(),
+                propChangeCounts: variantState.propChangeCounts,
+                propStreaks: variantState.propStreaks,
+                changeTotals: variantState.changeTotals,
+                usageCounts: variantState.usageCounts,
+                remainingPotentialCounts: variantState.remainingPotentialCounts
+            };
+        };
 
         return {
-            head: { item: bestVariant.item, prev: state.head },
-            length: state.length + 1,
-            usedIds,
-            score: newScore,
-            coverCount: nextCoverCount,
-            instrumentalCount: nextInstrumentalCount,
-            lastItem: bestVariant.item,
-            rankScore: newScore + this._randomJitter(this._randomness.stateJitter),
-            _tiebreaker: this._rng(),
-            propChangeCounts: bestVariant.propChangeCounts,
-            propStreaks: bestVariant.propStreaks,
-            changeTotals: bestVariant.changeTotals,
-            usageCounts: bestVariant.usageCounts
+            feasibleState: buildState(bestVariant.feasible),
+            fallbackState: buildState(bestVariant.fallback)
         };
     }
 
@@ -743,6 +978,7 @@ class SetList {
         let fallbackScore = Infinity;
 
         const variants = this._variantCache.get(song.id);
+        const nextRemainingPotentialCounts = this._consumeRemainingPotentialCounts(state.remainingPotentialCounts, song.id);
         for (let vi = 0; vi < variants.length; vi++) {
             const variant = variants[vi];
             const propTransition = this._scoreConfiguredPropsLite(prevItem, variant);
@@ -752,7 +988,7 @@ class SetList {
 
             const nextPropState = this._advancePropState(state, propTransition.changes, prevItem);
             const nextUsageCounts = this._updateUsageCounts(state.usageCounts, variant);
-            const minimumPenalty = this._scoreMinimumPenalty(nextUsageCounts, position);
+            const minimumPenalty = this._scoreMinimumPenalty(state, song.id, position, nextUsageCounts, nextRemainingPotentialCounts);
 
             const positionScore = this._scorePositionLite(variant, position);
             const transitionScore = propTransition.score;
@@ -767,6 +1003,7 @@ class SetList {
                         propStreaks: nextPropState.propStreaks,
                         changeTotals: nextPropState.changeTotals,
                         usageCounts: nextUsageCounts,
+                        remainingPotentialCounts: nextRemainingPotentialCounts,
                         incrementalScore: fbScore,
                         item: variant
                     };
@@ -784,13 +1021,17 @@ class SetList {
                     propStreaks: nextPropState.propStreaks,
                     changeTotals: nextPropState.changeTotals,
                     usageCounts: nextUsageCounts,
+                    remainingPotentialCounts: nextRemainingPotentialCounts,
                     incrementalScore,
                     item: variant
                 };
             }
         }
 
-        return best || fallback;
+        return {
+            feasible: best,
+            fallback
+        };
     }
 
     // Lite version: returns { score, changes } without building notes arrays

--- a/src/lib/generator.test.js
+++ b/src/lib/generator.test.js
@@ -213,6 +213,35 @@ function scarceTuningCatalog(memberName = "nick") {
     ];
 }
 
+function overlappingInstrumentCatalog(memberName = "nick", instrumentCount = 32) {
+    const instrumentNames = Array.from({ length: instrumentCount }, (_, index) => `instrument-${index + 1}`);
+    const sharedTuning = ["Standard"];
+
+    return [
+        makeSong("Flexible Song", {
+            members: {
+                [memberName]: {
+                    instruments: instrumentNames.map((name) => ({
+                        name,
+                        tuning: sharedTuning,
+                        capo: 0,
+                        picking: []
+                    }))
+                }
+            }
+        }),
+        ...Array.from({ length: instrumentCount - 1 }, (_, index) => makeSong(`Fixed Song ${index + 1}`, {
+            members: {
+                [memberName]: {
+                    instruments: [
+                        { name: instrumentNames[0], tuning: sharedTuning, capo: 0, picking: [] }
+                    ]
+                }
+            }
+        }))
+    ];
+}
+
 
 // ===================================================================
 // Basic generation
@@ -714,6 +743,39 @@ describe("generateSetlist — minSongsPerInstrument", () => {
         }));
 
         expect(result.songs).toHaveLength(4);
+        expect(result.summary.minimumsRelaxed).toBe(true);
+    });
+
+    it("handles large overlapping instrument groups without overflow and relaxes impossible minimums", () => {
+        const songs = overlappingInstrumentCatalog();
+        const allowedInstruments = songs[0].members.nick.instruments.map((instrument) => instrument.name);
+        const config = makeConfig({
+            general: {
+                weighting: {
+                    tuning: 4,
+                    capo: 2,
+                    instrument: 0,
+                    technique: 1,
+                    positionMiss: 8,
+                    earlyCover: 2,
+                    earlyInstrumental: 2
+                }
+            }
+        });
+
+        const result = generateSetlist(songs, config, deterministicOptions({
+            count: allowedInstruments.length,
+            show: {
+                members: {
+                    nick: {
+                        allowedInstruments,
+                        minSongsPerInstrument: 1
+                    }
+                }
+            }
+        }));
+
+        expect(result.songs).toHaveLength(allowedInstruments.length);
         expect(result.summary.minimumsRelaxed).toBe(true);
     });
 });

--- a/src/lib/generator.test.js
+++ b/src/lib/generator.test.js
@@ -242,6 +242,28 @@ function overlappingInstrumentCatalog(memberName = "nick", instrumentCount = 32)
     ];
 }
 
+function anxietyPressureCatalog() {
+    return Array.from({ length: 9 }, (_, songIndex) => makeSong(`Pressure ${songIndex + 1}`, {
+        id: `pressure-${songIndex + 1}`,
+        members: {
+            mark: {
+                instruments: [
+                    { name: "guitar", tuning: ["Standard"], capo: 0, picking: [] },
+                    { name: "guitar", tuning: ["DADDAD"], capo: 0, picking: [] },
+                    { name: "mandolin", tuning: ["Standard"], capo: 0, picking: [] }
+                ]
+            },
+            nick: {
+                instruments: [
+                    { name: "banjo", tuning: ["Open G"], capo: 0, picking: ["picking"] },
+                    { name: "banjo", tuning: ["Open D"], capo: 0, picking: ["clawhammer"] },
+                    { name: "guitar", tuning: ["Standard"], capo: 2, picking: ["picking"] }
+                ]
+            }
+        }
+    }));
+}
+
 
 // ===================================================================
 // Basic generation
@@ -837,6 +859,52 @@ describe("generateSetlist — minSongsPerTuning", () => {
             expect(counts.DADGAD).toBe(2);
             expect(result.summary.minimumsRelaxed).toBe(false);
         }
+    });
+});
+
+describe("generateSetlist — chaos slider anxiety bias", () => {
+    it("keeps low chaos calmer and high chaos much more anxious on a transition-heavy catalog", () => {
+        const songs = anxietyPressureCatalog();
+        const config = makeConfig();
+        const seeds = [1, 2, 3, 4, 5, 6];
+        const lowScores = [];
+        const highScores = [];
+
+        for (const seed of seeds) {
+            const low = generateSetlist(songs, config, deterministicOptions({
+                count: songs.length,
+                seed,
+                randomness: {
+                    shuffleCatalog: false,
+                    songBias: 0,
+                    variantJitter: 0,
+                    stateJitter: 0,
+                    temperature: 0.3,
+                    finalChoicePool: 1
+                }
+            }));
+            const high = generateSetlist(songs, config, deterministicOptions({
+                count: songs.length,
+                seed,
+                randomness: {
+                    shuffleCatalog: false,
+                    songBias: 0,
+                    variantJitter: 0,
+                    stateJitter: 0,
+                    temperature: 2.0,
+                    finalChoicePool: 1
+                }
+            }));
+
+            lowScores.push(low.summary.anxiety.scaled);
+            highScores.push(high.summary.anxiety.scaled);
+        }
+
+        const average = (values) => values.reduce((sum, value) => sum + value, 0) / values.length;
+
+        expect(average(lowScores)).toBeLessThanOrEqual(3);
+        expect(average(highScores)).toBeGreaterThanOrEqual(7);
+        expect(Math.min(...highScores)).toBeGreaterThan(Math.max(...lowScores));
     });
 });
 

--- a/src/lib/generator.test.js
+++ b/src/lib/generator.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { generateSetlist, scoreFixedOrder, buildDefaultPerformance } from "./generator.js";
 
 
@@ -62,37 +62,31 @@ function makeConfig(overrides = {}) {
             tuning: {
                 kind: "instrumentField",
                 field: "tuning",
-                summaryLabel: "tuning changes",
                 minStreak: 2,
                 allowChangeOnLastSong: true
             },
             capo: {
                 kind: "instrumentDelta",
                 field: "capo",
-                summaryLabel: "capo steps",
                 minStreak: 2,
                 allowChangeOnLastSong: true
             },
             instruments: {
                 kind: "instrumentSet",
                 weightKey: "instrument",
-                summaryLabel: "instrument swaps",
                 minStreak: 2,
-                allowChangeOnLastSong: true,
-                mutuallyExclusive: []
+                allowChangeOnLastSong: true
             },
             picking: {
                 kind: "instrumentField",
                 field: "picking",
                 weightKey: "technique",
-                summaryLabel: "technique changes",
                 minStreak: 1,
                 allowChangeOnLastSong: true
             }
         },
         show: overrides.show || { members: {} },
-        band: overrides.band || { members: {} },
-        catalog: overrides.catalog || { tunings: [], tuningsByInstrument: {} }
+        band: overrides.band || { members: {} }
     };
 }
 
@@ -149,6 +143,74 @@ function twoTuningCatalog(count, memberName = "nick") {
             }
         })
     );
+}
+
+/** Generate a catalog where only the first two songs can satisfy the alternate instrument */
+function scarceInstrumentCatalog(memberName = "nick") {
+    return [
+        makeSong("Song A", {
+            members: {
+                [memberName]: {
+                    instruments: [
+                        { name: "guitar", tuning: ["Standard"], capo: 0, picking: [] },
+                        { name: "banjo", tuning: ["Open G"], capo: 0, picking: [] }
+                    ]
+                }
+            }
+        }),
+        makeSong("Song B", {
+            members: {
+                [memberName]: {
+                    instruments: [
+                        { name: "guitar", tuning: ["Standard"], capo: 0, picking: [] },
+                        { name: "banjo", tuning: ["Open G"], capo: 0, picking: [] }
+                    ]
+                }
+            }
+        }),
+        ...Array.from({ length: 4 }, (_, i) => makeSong(`Song ${String.fromCharCode(67 + i)}`, {
+            members: {
+                [memberName]: {
+                    instruments: [
+                        { name: "guitar", tuning: ["Standard"], capo: 0, picking: [] }
+                    ]
+                }
+            }
+        }))
+    ];
+}
+
+/** Generate a catalog where only the first two songs can satisfy the alternate tuning */
+function scarceTuningCatalog(memberName = "nick") {
+    return [
+        makeSong("Song A", {
+            members: {
+                [memberName]: {
+                    instruments: [
+                        { name: "guitar", tuning: ["Standard", "DADGAD"], capo: 0, picking: [] }
+                    ]
+                }
+            }
+        }),
+        makeSong("Song B", {
+            members: {
+                [memberName]: {
+                    instruments: [
+                        { name: "guitar", tuning: ["Standard", "DADGAD"], capo: 0, picking: [] }
+                    ]
+                }
+            }
+        }),
+        ...Array.from({ length: 4 }, (_, i) => makeSong(`Song ${String.fromCharCode(67 + i)}`, {
+            members: {
+                [memberName]: {
+                    instruments: [
+                        { name: "guitar", tuning: ["Standard"], capo: 0, picking: [] }
+                    ]
+                }
+            }
+        }))
+    ];
 }
 
 
@@ -221,6 +283,20 @@ describe("generateSetlist — determinism", () => {
         const ids1 = r1.songs.map(s => s.id).join(",");
         const ids2 = r2.songs.map(s => s.id).join(",");
         expect(ids1).not.toBe(ids2);
+    });
+
+    it("treats seed=0 as random to match the Roll UI intent", () => {
+        const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000);
+        const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.25);
+
+        try {
+            const songs = simpleCatalog(8);
+            const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 5, seed: 0 }));
+            expect(result.seed).toBe(251000);
+        } finally {
+            nowSpy.mockRestore();
+            randomSpy.mockRestore();
+        }
     });
 });
 
@@ -572,6 +648,74 @@ describe("generateSetlist — minSongsPerInstrument", () => {
         }
         expect(hasBoth).toBeGreaterThanOrEqual(8);
     });
+
+    it("treats the requirement as hard when a satisfying set exists", () => {
+        const songs = scarceInstrumentCatalog();
+        const config = makeConfig();
+        const opts = deterministicOptions({
+            count: 4,
+            show: {
+                members: {
+                    nick: {
+                        allowedInstruments: ["guitar", "banjo"],
+                        minSongsPerInstrument: 2
+                    }
+                }
+            }
+        });
+
+        for (let seed = 1; seed <= 10; seed++) {
+            const result = generateSetlist(songs, config, { ...opts, seed });
+            const counts = result.songs.reduce((acc, song) => {
+                const instrument = song.performance.nick?.instrument;
+                acc[instrument] = (acc[instrument] || 0) + 1;
+                return acc;
+            }, {});
+
+            expect(counts.guitar).toBe(2);
+            expect(counts.banjo).toBe(2);
+            expect(result.summary.minimumsRelaxed).toBe(false);
+        }
+    });
+
+    it("falls back to best effort only when the requirement is impossible", () => {
+        const songs = [
+            makeSong("Song A", {
+                members: {
+                    nick: {
+                        instruments: [
+                            { name: "guitar", tuning: ["Standard"], capo: 0, picking: [] },
+                            { name: "banjo", tuning: ["Open G"], capo: 0, picking: [] }
+                        ]
+                    }
+                }
+            }),
+            ...Array.from({ length: 3 }, (_, i) => makeSong(`Song ${i + 2}`, {
+                members: {
+                    nick: {
+                        instruments: [
+                            { name: "guitar", tuning: ["Standard"], capo: 0, picking: [] }
+                        ]
+                    }
+                }
+            }))
+        ];
+        const config = makeConfig();
+        const result = generateSetlist(songs, config, deterministicOptions({
+            count: 4,
+            show: {
+                members: {
+                    nick: {
+                        allowedInstruments: ["guitar", "banjo"],
+                        minSongsPerInstrument: 2
+                    }
+                }
+            }
+        }));
+
+        expect(result.songs).toHaveLength(4);
+        expect(result.summary.minimumsRelaxed).toBe(true);
+    });
 });
 
 
@@ -602,6 +746,35 @@ describe("generateSetlist — minSongsPerTuning", () => {
             if (standardCount >= 2 && dadgadCount >= 2) bothMet++;
         }
         expect(bothMet).toBeGreaterThanOrEqual(7);
+    });
+
+    it("treats tuning minimums as hard when a satisfying set exists", () => {
+        const songs = scarceTuningCatalog();
+        const config = makeConfig();
+        const opts = deterministicOptions({
+            count: 4,
+            show: {
+                members: {
+                    nick: {
+                        allowedTunings: { guitar: ["Standard", "DADGAD"] },
+                        minSongsPerTuning: { guitar: 2 }
+                    }
+                }
+            }
+        });
+
+        for (let seed = 1; seed <= 10; seed++) {
+            const result = generateSetlist(songs, config, { ...opts, seed });
+            const counts = result.songs.reduce((acc, song) => {
+                const tuning = song.performance.nick?.tuning;
+                acc[tuning] = (acc[tuning] || 0) + 1;
+                return acc;
+            }, {});
+
+            expect(counts.Standard).toBe(2);
+            expect(counts.DADGAD).toBe(2);
+            expect(result.summary.minimumsRelaxed).toBe(false);
+        }
     });
 });
 

--- a/src/lib/generator.worker.js
+++ b/src/lib/generator.worker.js
@@ -1,17 +1,7 @@
 import { generateSetlist } from "./generator.js";
 
 self.onmessage = function (event) {
-    const { songs, config, optionsList } = event.data;
-    let best = null;
-
-    for (let i = 0; i < optionsList.length; i++) {
-        const result = generateSetlist(songs, config, optionsList[i]);
-        if (!best || result.summary.score < best.summary.score) {
-            best = result;
-        }
-        // Post progress so the UI knows we're still working
-        self.postMessage({ type: "progress", attempt: i + 1, total: optionsList.length });
-    }
-
-    self.postMessage({ type: "done", result: best });
+    const { songs, config, options } = event.data;
+    const result = generateSetlist(songs, config, options);
+    self.postMessage({ type: "done", result });
 };

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -539,8 +539,8 @@ export function createAppStore(repo) {
                 setlistSaved = false;
             }
             persistCurrentSetlist();
-            if (!validateConstraintMinimums(result)) {
-                addToast("Close enough! Some constraints bent but didn't break.", "warning");
+            if (result.summary?.minimumsRelaxed || !validateConstraintMinimums(result)) {
+                addToast("Couldn't meet every demand, but it got close.", "warning");
             }
             const n = generatedSetlist.songs.length;
             addToast(randomFrom([

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -504,14 +504,13 @@ export function createAppStore(repo) {
         const thisGenId = ++generationId;
         const opts = clone(generationOptions);
         Object.assign(opts, overrideOptions);
-        const optionsList = [opts];
 
         const worker = new GeneratorWorker();
         activeWorker = worker;
         worker.postMessage({
             songs: clone(eligibleSongs),
             config: clone(appConfig || DEFAULT_APP_CONFIG),
-            optionsList
+            options: opts
         });
         worker.onmessage = (event) => {
             const { type, result } = event.data;
@@ -1274,32 +1273,6 @@ export function createAppStore(repo) {
         }
     }
 
-    // ---- set arc / order rules ----
-    function orderRuleValue(config, slotId, fieldName) {
-        const rules = getByPath(config, `general.order.${slotId}`, []);
-        const match = rules.find(([name]) => name === fieldName);
-        return match ? match[1] : null;
-    }
-
-    function orderToggleValue(config, slotId, fieldName) {
-        const value = orderRuleValue(config, slotId, fieldName);
-        if (value === true) return "yes";
-        if (value === false) return "no";
-        return "either";
-    }
-
-    function setOrderToggle(slotId, fieldName, value) {
-        if (value === "either") { setOrderRule(slotId, fieldName, null); return; }
-        setOrderRule(slotId, fieldName, value === "yes");
-    }
-
-    function setOrderRule(slotId, fieldName, nextValue) {
-        const rules = clone(getByPath(appConfig, `general.order.${slotId}`, []))
-            .filter(([name]) => name !== fieldName);
-        if (nextValue !== null && nextValue !== undefined) rules.push([fieldName, nextValue]);
-        appConfig = setByPath(appConfig, `general.order.${slotId}`, rules);
-    }
-
     // ---- import/export ----
     function buildExportPayload() {
         const currentSaved = savedSetlists || [];
@@ -1674,8 +1647,6 @@ export function createAppStore(repo) {
         setInstrumentDefaultTechnique,
         techniqueDraftKey,
         tuningDraftKey,
-        orderToggleValue,
-        setOrderToggle,
         exportAllData,
         importFromFile,
         performanceSummary,


### PR DESCRIPTION
## Summary
- make minimum songs per instrument and tuning hard constraints when a satisfying roll exists, with best-effort fallback only when the demand is impossible
- fix seed `0` so it behaves as random to match the current roll-screen behavior
- remove dead config/runtime scaffolding and stale worker/store paths that no longer affect generation
- clarify the Band settings copy and shorten the fallback roll message
- retune anxiety scoring so heavy transitions matter more, chaos affects the actual roll objective, and midrange sets land closer to expected pressure
- normalize displayed picking-technique diffs so ordering-only changes no longer inflate visible counts
- add regression coverage for hard minimums, seed handling, anxiety ranking, label output, and the real-world set examples used during tuning

## Verification
- npm test