### PR TITLE
Fix saving reordered setlists to Greatest Hits

### DIFF
--- a/src/lib/components/roll/RollScreen.svelte
+++ b/src/lib/components/roll/RollScreen.svelte
@@ -995,7 +995,7 @@
   }
 
   .roadie-val {
-    font-size: 1rem;
+    font-size: 0.90rem;
     font-weight: 800;
     color: var(--ink, #182230);
   }
@@ -1003,7 +1003,7 @@
   .roadie-hint {
     flex-basis: 100%;
     margin: 0;
-    font-size: 0.82rem;
+    font-size: 0.85rem;
     line-height: 1.35;
     color: var(--muted, #575d67);
   }

--- a/src/lib/components/roll/RollScreen.svelte
+++ b/src/lib/components/roll/RollScreen.svelte
@@ -395,6 +395,12 @@
         {/each}
       </div>
 
+      <div class="roadie-score">
+        <span class="roadie-label">Bass Player Anxiety</span>
+        <span class="roadie-val">{anxietyLevel.scaled}/10</span>
+        <p class="roadie-hint">{anxietyLevel.label}</p>
+      </div>
+
       <div class="setlist-actions">
         <button class="save-set-btn add-song-btn" onclick={() => { showAddSongPicker = true; }}>+ Add song</button>
         {#if store.setlistLocked}
@@ -409,11 +415,6 @@
         {/if}
       </div>
 
-      <div class="roadie-score">
-        <span class="roadie-label">Bass Player Anxiety</span>
-        <span class="roadie-val">{anxietyLevel.scaled}/10</span>
-        <p class="roadie-hint">{anxietyLevel.label}</p>
-      </div>
     </section>
   {/if}
 
@@ -988,13 +989,13 @@
   }
 
   .roadie-label {
-    font-size: 0.72rem;
+    font-size: 0.90rem;
     font-weight: 700;
-    color: var(--muted, #8a95a5);
+    color: var(--muted, #575d67);
   }
 
   .roadie-val {
-    font-size: 0.82rem;
+    font-size: 1rem;
     font-weight: 800;
     color: var(--ink, #182230);
   }
@@ -1002,9 +1003,9 @@
   .roadie-hint {
     flex-basis: 100%;
     margin: 0;
-    font-size: 0.68rem;
+    font-size: 0.82rem;
     line-height: 1.35;
-    color: var(--muted, #8a95a5);
+    color: var(--muted, #575d67);
   }
 
   .song-list {

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -646,6 +646,7 @@ export function createAppStore(repo) {
             seed: saved.seed,
         };
         setlistLocked = true;
+        setlistSaved = true;
         persistCurrentSetlist();
         addToast(`Loaded ${saved.songs?.length || 0}-song set.`);
     }

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -657,6 +657,7 @@ export function createAppStore(repo) {
         songList.splice(toIndex, 0, moved);
         const rescored = scoreFixedOrder(songList, appConfig);
         generatedSetlist = { ...generatedSetlist, songs: rescored.songs, summary: rescored.summary, _reordered: true };
+        setlistSaved = false;
         persistCurrentSetlist();
     }
 


### PR DESCRIPTION
## Summary
- Reset `setlistSaved` flag in `reorderSetlistSong()` so the "Save to Greatest Hits" button reappears after dragging songs to a new order on an already-saved setlist
- Matches existing behavior of `removeSetlistSong()` and `addSetlistSong()`, which already reset this flag
- Adjusting Anxiety display to be above the control buttons and increase font