### PR TITLE
Default covers and instrumentals to no limit

### DIFF
--- a/src/lib/components/roll/RollScreen.svelte
+++ b/src/lib/components/roll/RollScreen.svelte
@@ -230,7 +230,7 @@
               <input
                 type="checkbox"
                 checked={store.generationOptions.maxCovers < 0}
-                onchange={(e) => store.updateGenerationField("maxCovers", e.currentTarget.checked ? -1 : (store.appConfig?.general?.limits?.covers ?? 2))}
+                onchange={(e) => store.updateGenerationField("maxCovers", e.currentTarget.checked ? -1 : Math.max(0, store.appConfig?.general?.limits?.covers ?? 2))}
               />
               <span>No limit</span>
             </label>
@@ -249,7 +249,7 @@
               <input
                 type="checkbox"
                 checked={store.generationOptions.maxInstrumentals < 0}
-                onchange={(e) => store.updateGenerationField("maxInstrumentals", e.currentTarget.checked ? -1 : (store.appConfig?.general?.limits?.instrumentals ?? 2))}
+                onchange={(e) => store.updateGenerationField("maxInstrumentals", e.currentTarget.checked ? -1 : Math.max(0, store.appConfig?.general?.limits?.instrumentals ?? 2))}
               />
               <span>No limit</span>
             </label>

--- a/src/lib/components/roll/RollScreen.svelte
+++ b/src/lib/components/roll/RollScreen.svelte
@@ -221,6 +221,7 @@
             <input
               type="number"
               min="0"
+              aria-label="Max covers"
               disabled={store.generationOptions.maxCovers < 0}
               value={store.generationOptions.maxCovers < 0 ? "" : store.generationOptions.maxCovers}
               oninput={(e) => store.updateGenerationField("maxCovers", Number(e.currentTarget.value))}
@@ -229,7 +230,7 @@
               <input
                 type="checkbox"
                 checked={store.generationOptions.maxCovers < 0}
-                onchange={(e) => store.updateGenerationField("maxCovers", e.currentTarget.checked ? -1 : 2)}
+                onchange={(e) => store.updateGenerationField("maxCovers", e.currentTarget.checked ? -1 : (store.appConfig?.general?.limits?.covers ?? 2))}
               />
               <span>No limit</span>
             </label>
@@ -239,6 +240,7 @@
             <input
               type="number"
               min="0"
+              aria-label="Max instrumentals"
               disabled={store.generationOptions.maxInstrumentals < 0}
               value={store.generationOptions.maxInstrumentals < 0 ? "" : store.generationOptions.maxInstrumentals}
               oninput={(e) => store.updateGenerationField("maxInstrumentals", Number(e.currentTarget.value))}
@@ -247,7 +249,7 @@
               <input
                 type="checkbox"
                 checked={store.generationOptions.maxInstrumentals < 0}
-                onchange={(e) => store.updateGenerationField("maxInstrumentals", e.currentTarget.checked ? -1 : 2)}
+                onchange={(e) => store.updateGenerationField("maxInstrumentals", e.currentTarget.checked ? -1 : (store.appConfig?.general?.limits?.instrumentals ?? 2))}
               />
               <span>No limit</span>
             </label>

--- a/src/lib/components/roll/RollScreen.svelte
+++ b/src/lib/components/roll/RollScreen.svelte
@@ -216,24 +216,42 @@
 
       {#if settingsTab === "chaos" || !hasConstraints}
         <div class="quick-row">
-          <label class="adv-field">
+          <div class="adv-field">
             <span>Max covers</span>
             <input
               type="number"
               min="0"
-              value={store.generationOptions.maxCovers}
+              disabled={store.generationOptions.maxCovers < 0}
+              value={store.generationOptions.maxCovers < 0 ? "" : store.generationOptions.maxCovers}
               oninput={(e) => store.updateGenerationField("maxCovers", Number(e.currentTarget.value))}
             />
-          </label>
-          <label class="adv-field">
+            <label class="no-limit-toggle">
+              <input
+                type="checkbox"
+                checked={store.generationOptions.maxCovers < 0}
+                onchange={(e) => store.updateGenerationField("maxCovers", e.currentTarget.checked ? -1 : 2)}
+              />
+              <span>No limit</span>
+            </label>
+          </div>
+          <div class="adv-field">
             <span>Max instrumentals</span>
             <input
               type="number"
               min="0"
-              value={store.generationOptions.maxInstrumentals}
+              disabled={store.generationOptions.maxInstrumentals < 0}
+              value={store.generationOptions.maxInstrumentals < 0 ? "" : store.generationOptions.maxInstrumentals}
               oninput={(e) => store.updateGenerationField("maxInstrumentals", Number(e.currentTarget.value))}
             />
-          </label>
+            <label class="no-limit-toggle">
+              <input
+                type="checkbox"
+                checked={store.generationOptions.maxInstrumentals < 0}
+                onchange={(e) => store.updateGenerationField("maxInstrumentals", e.currentTarget.checked ? -1 : 2)}
+              />
+              <span>No limit</span>
+            </label>
+          </div>
         </div>
 
         <div class="variety-field">
@@ -930,6 +948,30 @@
     font-size: 0.85rem;
     font-weight: 600;
     -moz-appearance: textfield;
+  }
+
+  .adv-field input[type="number"]:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .no-limit-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    cursor: pointer;
+  }
+
+  .no-limit-toggle input[type="checkbox"] {
+    min-height: auto;
+    width: auto;
+    margin: 0;
+    cursor: pointer;
+  }
+
+  .no-limit-toggle span {
+    font-size: 0.7rem;
+    font-weight: 600;
   }
 
   .adv-field input::-webkit-inner-spin-button,

--- a/src/lib/defaults.js
+++ b/src/lib/defaults.js
@@ -7,8 +7,8 @@ const DEFAULT_CONFIG_TEMPLATE = {
         count: 9,
         beamWidth: 512,
         limits: {
-            covers: 0,
-            instrumentals: 0
+            covers: -1,
+            instrumentals: -1
         },
         order: {
             first: [

--- a/src/lib/defaults.js
+++ b/src/lib/defaults.js
@@ -7,8 +7,8 @@ const DEFAULT_CONFIG_TEMPLATE = {
         count: 9,
         beamWidth: 512,
         limits: {
-            covers: 2,
-            instrumentals: 2
+            covers: 0,
+            instrumentals: 0
         },
         order: {
             first: [

--- a/src/lib/generator.js
+++ b/src/lib/generator.js
@@ -257,14 +257,14 @@ class SetList {
         const normalized = merge({
             count: this._config.general?.count || 15,
             beamWidth: this._config.general?.beamWidth || 20,
-            maxCovers: limits.covers || 2,
-            maxInstrumentals: limits.instrumentals || 2
+            maxCovers: limits.covers ?? 0,
+            maxInstrumentals: limits.instrumentals ?? 0
         }, options || {});
 
         normalized.count = clampInteger(normalized.count, this._config.general?.count || 15, 1);
         normalized.beamWidth = clampInteger(normalized.beamWidth, this._config.general?.beamWidth || 20, 1);
-        normalized.maxCovers = clampInteger(normalized.maxCovers, limits.covers || 2, 0);
-        normalized.maxInstrumentals = clampInteger(normalized.maxInstrumentals, limits.instrumentals || 2, 0);
+        normalized.maxCovers = clampInteger(normalized.maxCovers, limits.covers ?? 0, 0);
+        normalized.maxInstrumentals = clampInteger(normalized.maxInstrumentals, limits.instrumentals ?? 0, 0);
         normalized.show = deepMerge(this._config.show || {}, normalized.show || {});
         return normalized;
     }
@@ -979,10 +979,10 @@ class SetList {
         const nextCoverCount = state.coverCount + (song.cover ? 1 : 0);
         const nextInstrumentalCount = state.instrumentalCount + (song.instrumental ? 1 : 0);
 
-        if (nextCoverCount > this._options.maxCovers) {
+        if (this._options.maxCovers > 0 && nextCoverCount > this._options.maxCovers) {
             return null;
         }
-        if (nextInstrumentalCount > this._options.maxInstrumentals) {
+        if (this._options.maxInstrumentals > 0 && nextInstrumentalCount > this._options.maxInstrumentals) {
             return null;
         }
 

--- a/src/lib/generator.js
+++ b/src/lib/generator.js
@@ -257,14 +257,18 @@ class SetList {
         const normalized = merge({
             count: this._config.general?.count || 15,
             beamWidth: this._config.general?.beamWidth || 20,
-            maxCovers: limits.covers ?? 0,
-            maxInstrumentals: limits.instrumentals ?? 0
+            maxCovers: limits.covers ?? -1,
+            maxInstrumentals: limits.instrumentals ?? -1
         }, options || {});
 
         normalized.count = clampInteger(normalized.count, this._config.general?.count || 15, 1);
         normalized.beamWidth = clampInteger(normalized.beamWidth, this._config.general?.beamWidth || 20, 1);
-        normalized.maxCovers = clampInteger(normalized.maxCovers, limits.covers ?? 0, 0);
-        normalized.maxInstrumentals = clampInteger(normalized.maxInstrumentals, limits.instrumentals ?? 0, 0);
+        if (normalized.maxCovers >= 0) {
+            normalized.maxCovers = clampInteger(normalized.maxCovers, limits.covers ?? -1, 0);
+        }
+        if (normalized.maxInstrumentals >= 0) {
+            normalized.maxInstrumentals = clampInteger(normalized.maxInstrumentals, limits.instrumentals ?? -1, 0);
+        }
         normalized.show = deepMerge(this._config.show || {}, normalized.show || {});
         return normalized;
     }
@@ -979,10 +983,10 @@ class SetList {
         const nextCoverCount = state.coverCount + (song.cover ? 1 : 0);
         const nextInstrumentalCount = state.instrumentalCount + (song.instrumental ? 1 : 0);
 
-        if (this._options.maxCovers > 0 && nextCoverCount > this._options.maxCovers) {
+        if (this._options.maxCovers >= 0 && nextCoverCount > this._options.maxCovers) {
             return null;
         }
-        if (this._options.maxInstrumentals > 0 && nextInstrumentalCount > this._options.maxInstrumentals) {
+        if (this._options.maxInstrumentals >= 0 && nextInstrumentalCount > this._options.maxInstrumentals) {
             return null;
         }
 

--- a/src/lib/generator.js
+++ b/src/lib/generator.js
@@ -19,6 +19,14 @@ function clampInteger(value, fallback, minimum) {
     return Math.max(minimum, parsed);
 }
 
+function normalizeLimitField(value, fallback) {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isNaN(parsed)) {
+        return fallback;
+    }
+    return parsed < 0 ? -1 : parsed;
+}
+
 
 function clampFloat(value, fallback, minimum) {
     const parsed = Number.parseFloat(value);
@@ -263,12 +271,8 @@ class SetList {
 
         normalized.count = clampInteger(normalized.count, this._config.general?.count || 15, 1);
         normalized.beamWidth = clampInteger(normalized.beamWidth, this._config.general?.beamWidth || 20, 1);
-        if (normalized.maxCovers >= 0) {
-            normalized.maxCovers = clampInteger(normalized.maxCovers, limits.covers ?? -1, 0);
-        }
-        if (normalized.maxInstrumentals >= 0) {
-            normalized.maxInstrumentals = clampInteger(normalized.maxInstrumentals, limits.instrumentals ?? -1, 0);
-        }
+        normalized.maxCovers = normalizeLimitField(normalized.maxCovers, limits.covers ?? -1);
+        normalized.maxInstrumentals = normalizeLimitField(normalized.maxInstrumentals, limits.instrumentals ?? -1);
         normalized.show = deepMerge(this._config.show || {}, normalized.show || {});
         return normalized;
     }

--- a/src/lib/generator.test.js
+++ b/src/lib/generator.test.js
@@ -374,6 +374,22 @@ describe("generateSetlist — cover and instrumental limits", () => {
         expect(instrumentals.length).toBeLessThanOrEqual(1);
     });
 
+    it("maxCovers=0 means no limit", () => {
+        const songs = Array.from({ length: 10 }, (_, i) =>
+            makeSong(`Song ${i + 1}`, { cover: true })
+        );
+        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 10, maxCovers: 0 }));
+        expect(result.songs.length).toBe(10);
+    });
+
+    it("maxInstrumentals=0 means no limit", () => {
+        const songs = Array.from({ length: 10 }, (_, i) =>
+            makeSong(`Song ${i + 1}`, { instrumental: true })
+        );
+        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 10, maxInstrumentals: 0 }));
+        expect(result.songs.length).toBe(10);
+    });
+
     it("all covers with maxCovers=1 produces exactly 1 song", () => {
         const songs = Array.from({ length: 5 }, (_, i) =>
             makeSong(`Cover ${i + 1}`, { cover: true })

--- a/src/lib/generator.test.js
+++ b/src/lib/generator.test.js
@@ -374,20 +374,38 @@ describe("generateSetlist — cover and instrumental limits", () => {
         expect(instrumentals.length).toBeLessThanOrEqual(1);
     });
 
-    it("maxCovers=0 means no limit", () => {
+    it("maxCovers=-1 means no limit", () => {
         const songs = Array.from({ length: 10 }, (_, i) =>
             makeSong(`Song ${i + 1}`, { cover: true })
         );
-        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 10, maxCovers: 0 }));
+        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 10, maxCovers: -1 }));
         expect(result.songs.length).toBe(10);
     });
 
-    it("maxInstrumentals=0 means no limit", () => {
+    it("maxInstrumentals=-1 means no limit", () => {
         const songs = Array.from({ length: 10 }, (_, i) =>
             makeSong(`Song ${i + 1}`, { instrumental: true })
         );
-        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 10, maxInstrumentals: 0 }));
+        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 10, maxInstrumentals: -1 }));
         expect(result.songs.length).toBe(10);
+    });
+
+    it("maxCovers=0 means no covers allowed", () => {
+        const songs = [
+            ...Array.from({ length: 5 }, (_, i) => makeSong(`Cover ${i + 1}`, { cover: true })),
+            ...Array.from({ length: 5 }, (_, i) => makeSong(`Original ${i + 1}`))
+        ];
+        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 5, maxCovers: 0 }));
+        expect(result.songs.filter(s => s.cover).length).toBe(0);
+    });
+
+    it("maxInstrumentals=0 means no instrumentals allowed", () => {
+        const songs = [
+            ...Array.from({ length: 5 }, (_, i) => makeSong(`Inst ${i + 1}`, { instrumental: true })),
+            ...Array.from({ length: 5 }, (_, i) => makeSong(`Vocal ${i + 1}`))
+        ];
+        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 5, maxInstrumentals: 0 }));
+        expect(result.songs.filter(s => s.instrumental).length).toBe(0);
     });
 
     it("all covers with maxCovers=1 produces exactly 1 song", () => {

--- a/src/lib/generator.test.js
+++ b/src/lib/generator.test.js
@@ -390,6 +390,16 @@ describe("generateSetlist — cover and instrumental limits", () => {
         expect(result.songs.length).toBe(10);
     });
 
+    it("NaN maxCovers falls back to config default", () => {
+        const songs = Array.from({ length: 10 }, (_, i) =>
+            makeSong(`Song ${i + 1}`, { cover: true })
+        );
+        const config = makeConfig({ general: { limits: { covers: 1, instrumentals: -1 } } });
+        const result = generateSetlist(songs, config, deterministicOptions({ count: 10, maxCovers: NaN }));
+        const covers = result.songs.filter(s => s.cover);
+        expect(covers.length).toBeLessThanOrEqual(1);
+    });
+
     it("maxCovers=0 means no covers allowed", () => {
         const songs = [
             ...Array.from({ length: 5 }, (_, i) => makeSong(`Cover ${i + 1}`, { cover: true })),

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -106,8 +106,8 @@ export function createAppStore(repo) {
         return {
             count: source.general?.count || 15,
             beamWidth: source.general?.beamWidth || 20,
-            maxCovers: source.general?.limits?.covers || 0,
-            maxInstrumentals: source.general?.limits?.instrumentals || 0,
+            maxCovers: source.general?.limits?.covers ?? -1,
+            maxInstrumentals: source.general?.limits?.instrumentals ?? -1,
             keyFlow: false,
             seed: "",
             randomness: {


### PR DESCRIPTION
Changes the default behavior for cover and instrumental limits from a max of 2 to unlimited. Uses -1 as the sentinel for "no limit" so that 0 means "none allowed." Adds a "No limit" checkbox in the UI that disables and greys out the number input when checked. Includes tests for unlimited, zero-allowed, and NaN fallback behavior.