### PR TITLE
Add dynamic PWA homescreen icons matching die color

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,9 @@
     />
     <title>Setlist Roller</title>
     <link rel="icon" type="image/svg+xml" href="/icon.svg" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="theme-color" content="#e15b37" />
     <!-- SYNC: key + resolution logic duplicated from src/lib/theme.svelte.js to avoid FOITC -->
     <script>
       try {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -9,7 +9,8 @@
     import SongsScreen from "./lib/components/songs/SongsScreen.svelte";
     import { createRemoteStorageRepository } from "./lib/remotestorage.js";
     import { createAppStore } from "./lib/stores/app.svelte.js";
-    import { DEFAULT_DIE_COLOR, darkenHex, hexToRgb } from "./lib/utils.js";
+    import { generateDieSvgString, updatePwaIcons } from "./lib/pwa-icon.js";
+    import { DEFAULT_DIE_COLOR, hexToRgb } from "./lib/utils.js";
 
     const repo = createRemoteStorageRepository();
     const store = createAppStore(repo);
@@ -23,25 +24,12 @@
     let dieColorRgb = $derived(hexToRgb(dieColor));
 
     let faviconHref = $derived(
-        `data:image/svg+xml,${encodeURIComponent(
-            `<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">` +
-            `<path fill="${dieColor}" d="M256 66L420.5 161 256 256 91.5 161Z"/>` +
-            `<path fill="${darkenHex(dieColor, 0.78)}" d="M91.5 161L256 256 256 446 91.5 351Z"/>` +
-            `<path fill="${darkenHex(dieColor, 0.62)}" d="M256 256L420.5 161 420.5 351 256 446Z"/>` +
-            `<path fill="none" stroke="#000" stroke-width="2.5" stroke-opacity=".1" stroke-linejoin="round" d="M256 66L420.5 161 420.5 351 256 446 91.5 351 91.5 161Z"/>` +
-            `<path stroke="#000" stroke-width="2" stroke-opacity=".08" d="M256 256L91.5 161M256 256L420.5 161M256 256L256 446"/>` +
-            `<ellipse cx="256" cy="113.5" rx="18" ry="10" fill="#fff"/>` +
-            `<ellipse cx="338.25" cy="161" rx="18" ry="10" fill="#fff"/>` +
-            `<ellipse cx="256" cy="161" rx="18" ry="10" fill="#fff"/>` +
-            `<ellipse cx="173.75" cy="161" rx="18" ry="10" fill="#fff"/>` +
-            `<ellipse cx="256" cy="208.5" rx="18" ry="10" fill="#fff"/>` +
-            `<ellipse cx="132.6" cy="232" rx="13" ry="16" fill="#ebebeb"/>` +
-            `<ellipse cx="173.8" cy="303" rx="13" ry="16" fill="#ebebeb"/>` +
-            `<ellipse cx="214.9" cy="374" rx="13" ry="16" fill="#ebebeb"/>` +
-            `<ellipse cx="338.3" cy="303" rx="13" ry="16" fill="#d9d9d9"/>` +
-            `</svg>`
-        )}`
+        `data:image/svg+xml,${encodeURIComponent(generateDieSvgString(dieColor))}`
     );
+
+    $effect(() => {
+        updatePwaIcons(dieColor);
+    });
 </script>
 
 <svelte:head>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -7,9 +7,9 @@
     import RollScreen from "./lib/components/roll/RollScreen.svelte";
     import SavedScreen from "./lib/components/saved/SavedScreen.svelte";
     import SongsScreen from "./lib/components/songs/SongsScreen.svelte";
+    import { generateDieSvgString, updatePwaIcons } from "./lib/pwa-icon.js";
     import { createRemoteStorageRepository } from "./lib/remotestorage.js";
     import { createAppStore } from "./lib/stores/app.svelte.js";
-    import { generateDieSvgString, updatePwaIcons } from "./lib/pwa-icon.js";
     import { DEFAULT_DIE_COLOR, hexToRgb } from "./lib/utils.js";
 
     const repo = createRemoteStorageRepository();

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -28,7 +28,7 @@
     );
 
     $effect(() => {
-        updatePwaIcons(dieColor);
+        void updatePwaIcons(dieColor).catch((e) => console.error("PWA icon update failed", e));
     });
 </script>
 

--- a/src/lib/pwa-icon.js
+++ b/src/lib/pwa-icon.js
@@ -84,9 +84,7 @@ export async function updatePwaIcons(dieColor) {
     };
 
     if (prevManifestUrl) URL.revokeObjectURL(prevManifestUrl);
-    prevManifestUrl = URL.createObjectURL(
-        new Blob([JSON.stringify(manifest)], { type: "application/json" })
-    );
+    prevManifestUrl = URL.createObjectURL(new Blob([JSON.stringify(manifest)], { type: "application/json" }));
     upsertLink("manifest", { href: prevManifestUrl });
 
     upsertMeta("theme-color", dieColor);

--- a/src/lib/pwa-icon.js
+++ b/src/lib/pwa-icon.js
@@ -22,16 +22,21 @@ export function generateDieSvgString(color) {
 }
 
 function svgToPngDataUrl(svgString, size) {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
         const img = new Image();
         img.onload = () => {
             const canvas = document.createElement("canvas");
             canvas.width = size;
             canvas.height = size;
             const ctx = canvas.getContext("2d");
+            if (!ctx) {
+                reject(new Error("Failed to get 2d canvas context"));
+                return;
+            }
             ctx.drawImage(img, 0, 0, size, size);
             resolve(canvas.toDataURL("image/png"));
         };
+        img.onerror = () => reject(new Error("Failed to load SVG for PNG conversion"));
         img.src = `data:image/svg+xml,${encodeURIComponent(svgString)}`;
     });
 }
@@ -58,8 +63,10 @@ function upsertMeta(name, content) {
 }
 
 let prevManifestUrl = null;
+let requestId = 0;
 
 export async function updatePwaIcons(dieColor) {
+    const currentRequest = ++requestId;
     const svg = generateDieSvgString(dieColor);
 
     const [png180, png192, png512] = await Promise.all([
@@ -67,6 +74,8 @@ export async function updatePwaIcons(dieColor) {
         svgToPngDataUrl(svg, 192),
         svgToPngDataUrl(svg, 512),
     ]);
+
+    if (currentRequest !== requestId) return;
 
     upsertLink("apple-touch-icon", { href: png180 });
 

--- a/src/lib/pwa-icon.js
+++ b/src/lib/pwa-icon.js
@@ -1,0 +1,93 @@
+import { darkenHex } from "./utils.js";
+
+export function generateDieSvgString(color) {
+    return (
+        `<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">` +
+        `<path fill="${color}" d="M256 66L420.5 161 256 256 91.5 161Z"/>` +
+        `<path fill="${darkenHex(color, 0.78)}" d="M91.5 161L256 256 256 446 91.5 351Z"/>` +
+        `<path fill="${darkenHex(color, 0.62)}" d="M256 256L420.5 161 420.5 351 256 446Z"/>` +
+        `<path fill="none" stroke="#000" stroke-width="2.5" stroke-opacity=".1" stroke-linejoin="round" d="M256 66L420.5 161 420.5 351 256 446 91.5 351 91.5 161Z"/>` +
+        `<path stroke="#000" stroke-width="2" stroke-opacity=".08" d="M256 256L91.5 161M256 256L420.5 161M256 256L256 446"/>` +
+        `<ellipse cx="256" cy="113.5" rx="18" ry="10" fill="#fff"/>` +
+        `<ellipse cx="338.25" cy="161" rx="18" ry="10" fill="#fff"/>` +
+        `<ellipse cx="256" cy="161" rx="18" ry="10" fill="#fff"/>` +
+        `<ellipse cx="173.75" cy="161" rx="18" ry="10" fill="#fff"/>` +
+        `<ellipse cx="256" cy="208.5" rx="18" ry="10" fill="#fff"/>` +
+        `<ellipse cx="132.6" cy="232" rx="13" ry="16" fill="#ebebeb"/>` +
+        `<ellipse cx="173.8" cy="303" rx="13" ry="16" fill="#ebebeb"/>` +
+        `<ellipse cx="214.9" cy="374" rx="13" ry="16" fill="#ebebeb"/>` +
+        `<ellipse cx="338.3" cy="303" rx="13" ry="16" fill="#d9d9d9"/>` +
+        `</svg>`
+    );
+}
+
+function svgToPngDataUrl(svgString, size) {
+    return new Promise((resolve) => {
+        const img = new Image();
+        img.onload = () => {
+            const canvas = document.createElement("canvas");
+            canvas.width = size;
+            canvas.height = size;
+            const ctx = canvas.getContext("2d");
+            ctx.drawImage(img, 0, 0, size, size);
+            resolve(canvas.toDataURL("image/png"));
+        };
+        img.src = `data:image/svg+xml,${encodeURIComponent(svgString)}`;
+    });
+}
+
+function upsertLink(rel, attrs) {
+    let el = document.querySelector(`link[rel="${rel}"]`);
+    if (!el) {
+        el = document.createElement("link");
+        el.rel = rel;
+        document.head.appendChild(el);
+    }
+    for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+    return el;
+}
+
+function upsertMeta(name, content) {
+    let el = document.querySelector(`meta[name="${name}"]`);
+    if (!el) {
+        el = document.createElement("meta");
+        el.name = name;
+        document.head.appendChild(el);
+    }
+    el.content = content;
+}
+
+let prevManifestUrl = null;
+
+export async function updatePwaIcons(dieColor) {
+    const svg = generateDieSvgString(dieColor);
+
+    const [png180, png192, png512] = await Promise.all([
+        svgToPngDataUrl(svg, 180),
+        svgToPngDataUrl(svg, 192),
+        svgToPngDataUrl(svg, 512),
+    ]);
+
+    upsertLink("apple-touch-icon", { href: png180 });
+
+    const manifest = {
+        name: "Setlist Roller",
+        short_name: "Setlist Roller",
+        start_url: ".",
+        display: "standalone",
+        background_color: "#1a1a1e",
+        theme_color: dieColor,
+        icons: [
+            { src: png192, sizes: "192x192", type: "image/png" },
+            { src: png512, sizes: "512x512", type: "image/png" },
+        ],
+    };
+
+    if (prevManifestUrl) URL.revokeObjectURL(prevManifestUrl);
+    prevManifestUrl = URL.createObjectURL(
+        new Blob([JSON.stringify(manifest)], { type: "application/json" })
+    );
+    upsertLink("manifest", { href: prevManifestUrl });
+
+    upsertMeta("theme-color", dieColor);
+}


### PR DESCRIPTION
## Summary
- Adds a new `pwa-icon.js` module that renders the colored die SVG to PNG via canvas at 180/192/512px sizes
- Dynamically sets `apple-touch-icon` (iOS) and a blob-URL web app manifest with icons (Android) so the homescreen icon reflects the user's selected die color
- Adds PWA meta tags (`apple-mobile-web-app-capable`, `theme-color`) to `index.html` as static fallbacks
- Extracts the shared die SVG template from `App.svelte` into the new module, eliminating duplication
- Icons update reactively whenever the die color is changed in band settings