### PR TITLE
Fix PWA auth relay sync and release flow

### DIFF
--- a/src/lib/remotestorage.js
+++ b/src/lib/remotestorage.js
@@ -19,6 +19,7 @@ const OBJECT_SCHEMA = {
 
 const AUTH_MESSAGE_TYPE = "setlist-roller-auth-result";
 const AUTH_POPUP_TIMEOUT_MS = 180000;
+const AUTH_POPUP_FEATURES = "popup=yes,width=480,height=720";
 
 export function isIosStandaloneAuthContext(env = globalThis.window) {
     if (!env) return false;
@@ -79,6 +80,7 @@ export function authorizeWithStandalonePopup(
     options,
     {
         env = globalThis.window,
+        popup: providedPopup = null,
         emitError = (error) => {
             throw error;
         },
@@ -96,9 +98,16 @@ export function authorizeWithStandalonePopup(
         clientId: options.clientId || env.location.origin,
     });
 
-    const popup = env.open(authUrl, "_blank", "popup=yes,width=480,height=720");
+    const popup = providedPopup || env.open(authUrl, "_blank", AUTH_POPUP_FEATURES);
     if (!popup) {
         throw new Error("Authorization popup was blocked.");
+    }
+    if (providedPopup) {
+        try {
+            popup.location.replace(authUrl);
+        } catch {
+            popup.location.href = authUrl;
+        }
     }
 
     let finished = false;
@@ -162,12 +171,45 @@ export function createRemoteStorageRepository() {
     });
 
     const localEventHandlers = new Map();
+    let reservedAuthPopup = null;
+
     function emitLocal(eventName, payload) {
         const handlers = localEventHandlers.get(eventName);
         if (!handlers) return;
         for (const handler of handlers) {
             handler(payload);
         }
+    }
+
+    function releaseReservedAuthPopup({ close = false } = {}) {
+        const popup = reservedAuthPopup;
+        reservedAuthPopup = null;
+        if (!popup || popup.closed) return null;
+        if (!close) return popup;
+        try {
+            popup.close();
+        } catch {
+            // Ignore popup close failures; they'll self-resolve on the client.
+        }
+        return null;
+    }
+
+    function reserveStandaloneAuthPopup(env = globalThis.window) {
+        if (!isIosStandaloneAuthContext(env) || reservedAuthPopup && !reservedAuthPopup.closed) {
+            return reservedAuthPopup;
+        }
+        const popup = env?.open?.("", "_blank", AUTH_POPUP_FEATURES) || null;
+        if (!popup) return null;
+        reservedAuthPopup = popup;
+        try {
+            popup.document?.write?.(
+                "<!doctype html><title>Setlist Roller Login</title><p style=\"font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;padding:24px\">Preparing login…</p>",
+            );
+            popup.document?.close?.();
+        } catch {
+            // about:blank remains usable even if we cannot write into it.
+        }
+        return popup;
     }
 
     remoteStorage.access.claim(APP_SCOPE, "rw");
@@ -191,9 +233,11 @@ export function createRemoteStorageRepository() {
                     authorizeOptions.scope = remoteStorage.access.scopeParameter;
                 }
                 authorizeWithStandalonePopup(remoteStorage, authorizeOptions, {
+                    popup: releaseReservedAuthPopup(),
                     emitError: (error) => emitLocal("error", error),
                 });
             } catch (error) {
+                releaseReservedAuthPopup({ close: true });
                 emitLocal("error", error instanceof Error ? error : new Error(String(error)));
             }
             return;
@@ -208,11 +252,17 @@ export function createRemoteStorageRepository() {
         connect(userAddress, token) {
             // Re-enable caching in case it was reset by a previous disconnect
             remoteStorage.caching.enable(`/${APP_SCOPE}/`);
+            if (!token) {
+                reserveStandaloneAuthPopup();
+            } else {
+                releaseReservedAuthPopup({ close: true });
+            }
             remoteStorage.connect(userAddress, token);
         },
 
         disconnect() {
             // Reset the local cache before disconnecting to prevent data leaking to the next account
+            releaseReservedAuthPopup({ close: true });
             remoteStorage.caching.reset();
             remoteStorage.disconnect();
         },
@@ -227,6 +277,11 @@ export function createRemoteStorageRepository() {
             remoteStorage.remote.connected = false;
             // Re-enable caching and connect to new account
             remoteStorage.caching.enable(`/${APP_SCOPE}/`);
+            if (!token) {
+                reserveStandaloneAuthPopup();
+            } else {
+                releaseReservedAuthPopup({ close: true });
+            }
             remoteStorage.connect(userAddress, token || undefined);
         },
 

--- a/src/lib/remotestorage.js
+++ b/src/lib/remotestorage.js
@@ -98,11 +98,12 @@ export function authorizeWithStandalonePopup(
         clientId: options.clientId || env.location.origin,
     });
 
-    const popup = providedPopup || env.open(authUrl, "_blank", AUTH_POPUP_FEATURES);
+    const popup =
+        providedPopup && !providedPopup.closed ? providedPopup : env.open(authUrl, "_blank", AUTH_POPUP_FEATURES);
     if (!popup) {
         throw new Error("Authorization popup was blocked.");
     }
-    if (providedPopup) {
+    if (popup === providedPopup) {
         try {
             popup.location.replace(authUrl);
         } catch {

--- a/src/lib/remotestorage.js
+++ b/src/lib/remotestorage.js
@@ -195,7 +195,7 @@ export function createRemoteStorageRepository() {
     }
 
     function reserveStandaloneAuthPopup(env = globalThis.window) {
-        if (!isIosStandaloneAuthContext(env) || reservedAuthPopup && !reservedAuthPopup.closed) {
+        if (!isIosStandaloneAuthContext(env) || (reservedAuthPopup && !reservedAuthPopup.closed)) {
             return reservedAuthPopup;
         }
         const popup = env?.open?.("", "_blank", AUTH_POPUP_FEATURES) || null;

--- a/src/lib/remotestorage.test.js
+++ b/src/lib/remotestorage.test.js
@@ -387,6 +387,158 @@ describe("createRemoteStorageRepository", () => {
         expect(errorHandler.mock.calls[0][0].message).toContain("popup was blocked");
     });
 
+    it("closes the reserved popup on disconnect", () => {
+        const popup = {
+            closed: false,
+            document: { write: vi.fn(), close: vi.fn() },
+            close: vi.fn(),
+        };
+        globalThis.window = {
+            matchMedia: vi.fn(() => ({ matches: true })),
+            navigator: {
+                standalone: true,
+                userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)",
+                platform: "iPhone",
+                maxTouchPoints: 5,
+            },
+            location: { origin: "https://app.example.com", hash: "" },
+            open: vi.fn(() => popup),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            setInterval: vi.fn(),
+            clearInterval: vi.fn(),
+            setTimeout: vi.fn(),
+            clearTimeout: vi.fn(),
+        };
+
+        const repo = createRemoteStorageRepository();
+        repo.connect("user@example.com");
+        expect(popup.close).not.toHaveBeenCalled();
+
+        repo.disconnect();
+        expect(popup.close).toHaveBeenCalledTimes(1);
+        expect(remoteStorageMockState.instance.caching.reset).toHaveBeenCalled();
+        expect(remoteStorageMockState.instance.disconnect).toHaveBeenCalled();
+    });
+
+    it("reserves a popup during standalone switchTo without a token", () => {
+        const popup = {
+            closed: false,
+            document: { write: vi.fn(), close: vi.fn() },
+            close: vi.fn(),
+        };
+        globalThis.window = {
+            matchMedia: vi.fn(() => ({ matches: true })),
+            navigator: {
+                standalone: true,
+                userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)",
+                platform: "iPhone",
+                maxTouchPoints: 5,
+            },
+            location: { origin: "https://app.example.com", hash: "" },
+            open: vi.fn(() => popup),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            setInterval: vi.fn(),
+            clearInterval: vi.fn(),
+            setTimeout: vi.fn(),
+            clearTimeout: vi.fn(),
+        };
+
+        const repo = createRemoteStorageRepository();
+        repo.switchTo("other@example.com");
+
+        expect(globalThis.window.open).toHaveBeenCalledWith("", "_blank", "popup=yes,width=480,height=720");
+        expect(remoteStorageMockState.instance.connect).toHaveBeenCalledWith("other@example.com", undefined);
+    });
+
+    it("closes reserved popup during switchTo with a token", () => {
+        const popup = {
+            closed: false,
+            document: { write: vi.fn(), close: vi.fn() },
+            close: vi.fn(),
+        };
+        globalThis.window = {
+            matchMedia: vi.fn(() => ({ matches: true })),
+            navigator: {
+                standalone: true,
+                userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)",
+                platform: "iPhone",
+                maxTouchPoints: 5,
+            },
+            location: { origin: "https://app.example.com", hash: "" },
+            open: vi.fn(() => popup),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            setInterval: vi.fn(),
+            clearInterval: vi.fn(),
+            setTimeout: vi.fn(),
+            clearTimeout: vi.fn(),
+        };
+
+        const repo = createRemoteStorageRepository();
+        // First connect without token to reserve a popup
+        repo.connect("user@example.com");
+        expect(popup.close).not.toHaveBeenCalled();
+
+        // Switch with a token — should close the reserved popup
+        repo.switchTo("other@example.com", "saved-token");
+        expect(popup.close).toHaveBeenCalledTimes(1);
+        expect(remoteStorageMockState.instance.connect).toHaveBeenLastCalledWith("other@example.com", "saved-token");
+    });
+
+    it("falls back to a fresh popup when the reserved popup was closed by the user", () => {
+        const closedPopup = {
+            closed: true,
+            location: { replace: vi.fn(), href: "" },
+            document: { write: vi.fn(), close: vi.fn() },
+            close: vi.fn(),
+        };
+        const freshPopup = {
+            closed: false,
+            location: { replace: vi.fn(), href: "" },
+            document: { write: vi.fn(), close: vi.fn() },
+            close: vi.fn(),
+        };
+        let openCallCount = 0;
+        globalThis.window = {
+            matchMedia: vi.fn(() => ({ matches: true })),
+            navigator: {
+                standalone: true,
+                userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)",
+                platform: "iPhone",
+                maxTouchPoints: 5,
+            },
+            location: { origin: "https://app.example.com", hash: "" },
+            open: vi.fn(() => {
+                openCallCount++;
+                return openCallCount === 1 ? closedPopup : freshPopup;
+            }),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            setInterval: vi.fn(() => 1),
+            clearInterval: vi.fn(),
+            setTimeout: vi.fn(() => 2),
+            clearTimeout: vi.fn(),
+        };
+
+        const repo = createRemoteStorageRepository();
+        repo.connect("user@example.com");
+
+        // The reserved popup is now "closed" (user dismissed it)
+        repo.remoteStorage.authorize({
+            authURL: "https://auth.example.com/oauth",
+            clientId: "https://app.example.com",
+            redirectUri: "https://app.example.com",
+            scope: "setlist-roller:rw",
+        });
+
+        // Should have opened a fresh popup since the reserved one was closed
+        expect(globalThis.window.open).toHaveBeenCalledTimes(2);
+        // The fresh popup should NOT have location.replace called (it was opened with the auth URL directly)
+        expect(freshPopup.location.replace).not.toHaveBeenCalled();
+    });
+
     it("pre-opens a popup during standalone connect and reuses it for authorize", () => {
         const popup = {
             closed: false,

--- a/src/lib/remotestorage.test.js
+++ b/src/lib/remotestorage.test.js
@@ -1,10 +1,71 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+const remoteStorageMockState = vi.hoisted(() => ({
+    instance: null,
+    defaultAuthorize: null,
+}));
+
+vi.mock("remotestoragejs", () => ({
+    default: vi.fn(() => remoteStorageMockState.instance),
+}));
+
 import {
     authorizeWithStandalonePopup,
     buildAuthorizeUrl,
+    createRemoteStorageRepository,
     createStandaloneAuthMessageHandler,
     isIosStandaloneAuthContext,
 } from "./remotestorage.js";
+
+let originalWindow;
+
+beforeEach(() => {
+    const defaultAuthorize = vi.fn();
+    const remoteStorage = {
+        access: {
+            claim: vi.fn(),
+            setStorageType: vi.fn(),
+            scopeParameter: "setlist-roller:rw",
+        },
+        caching: {
+            enable: vi.fn(),
+            reset: vi.fn(),
+        },
+        scope: vi.fn(() => ({
+            declareType: vi.fn(),
+            on: vi.fn(),
+            removeEventListener: vi.fn(),
+        })),
+        remote: {
+            storageApi: "webdav",
+            configure: vi.fn(),
+            connected: false,
+            userAddress: "",
+            token: "",
+        },
+        authorize: defaultAuthorize,
+        on: vi.fn(),
+        removeEventListener: vi.fn(),
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+        startSync: vi.fn(),
+        connected: false,
+    };
+
+    remoteStorageMockState.instance = remoteStorage;
+    remoteStorageMockState.defaultAuthorize = defaultAuthorize;
+    originalWindow = globalThis.window;
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    remoteStorageMockState.instance = null;
+    remoteStorageMockState.defaultAuthorize = null;
+    if (typeof originalWindow === "undefined") {
+        delete globalThis.window;
+    } else {
+        globalThis.window = originalWindow;
+    }
+});
 
 describe("isIosStandaloneAuthContext", () => {
     it("returns false without a browser-like environment", () => {
@@ -246,5 +307,136 @@ describe("authorizeWithStandalonePopup", () => {
         expect(timeoutCallback).toBeTypeOf("function");
         expect(clearInterval).toHaveBeenCalledWith(1);
         expect(clearTimeout).toHaveBeenCalledWith(2);
+    });
+});
+
+describe("createRemoteStorageRepository", () => {
+    it("does not throw when standalone authorize is called without options", () => {
+        globalThis.window = {
+            matchMedia: vi.fn(() => ({ matches: true })),
+            navigator: {
+                standalone: true,
+                userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)",
+                platform: "iPhone",
+                maxTouchPoints: 5,
+            },
+            location: {
+                origin: "https://app.example.com",
+                hash: "",
+            },
+            open: vi.fn(() => null),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            setInterval: vi.fn(),
+            clearInterval: vi.fn(),
+            setTimeout: vi.fn(),
+            clearTimeout: vi.fn(),
+        };
+
+        const repo = createRemoteStorageRepository();
+        const errorHandler = vi.fn();
+
+        repo.on("error", errorHandler);
+
+        expect(() => repo.remoteStorage.authorize()).not.toThrow();
+        expect(remoteStorageMockState.instance.access.setStorageType).toHaveBeenCalledWith("webdav");
+        expect(remoteStorageMockState.defaultAuthorize).not.toHaveBeenCalled();
+        expect(errorHandler).toHaveBeenCalledTimes(1);
+        expect(errorHandler.mock.calls[0][0]).toBeInstanceOf(Error);
+    });
+
+    it("uses the standalone popup authorize path and emits popup errors", () => {
+        globalThis.window = {
+            matchMedia: vi.fn(() => ({ matches: true })),
+            navigator: {
+                standalone: true,
+                userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)",
+                platform: "iPhone",
+                maxTouchPoints: 5,
+            },
+            location: {
+                origin: "https://app.example.com",
+                hash: "",
+            },
+            open: vi.fn(() => null),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            setInterval: vi.fn(),
+            clearInterval: vi.fn(),
+            setTimeout: vi.fn(),
+            clearTimeout: vi.fn(),
+        };
+
+        const repo = createRemoteStorageRepository();
+        const errorHandler = vi.fn();
+
+        repo.on("error", errorHandler);
+
+        expect(() =>
+            repo.remoteStorage.authorize({
+                authURL: "https://auth.example.com/oauth",
+                clientId: "https://app.example.com",
+                redirectUri: "https://app.example.com",
+                scope: "setlist-roller:rw",
+            }),
+        ).not.toThrow();
+        expect(remoteStorageMockState.instance.access.setStorageType).toHaveBeenCalledWith("webdav");
+        expect(remoteStorageMockState.defaultAuthorize).not.toHaveBeenCalled();
+        expect(errorHandler).toHaveBeenCalledTimes(1);
+        expect(errorHandler.mock.calls[0][0].message).toContain("popup was blocked");
+    });
+
+    it("pre-opens a popup during standalone connect and reuses it for authorize", () => {
+        const popup = {
+            closed: false,
+            location: {
+                replace: vi.fn(),
+                href: "",
+            },
+            document: {
+                write: vi.fn(),
+                close: vi.fn(),
+            },
+            close: vi.fn(),
+        };
+        globalThis.window = {
+            matchMedia: vi.fn(() => ({ matches: true })),
+            navigator: {
+                standalone: true,
+                userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)",
+                platform: "iPhone",
+                maxTouchPoints: 5,
+            },
+            location: {
+                origin: "https://app.example.com",
+                hash: "",
+            },
+            open: vi.fn(() => popup),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            setInterval: vi.fn(() => 1),
+            clearInterval: vi.fn(),
+            setTimeout: vi.fn(() => 2),
+            clearTimeout: vi.fn(),
+        };
+
+        const repo = createRemoteStorageRepository();
+
+        repo.connect("user@example.com");
+
+        expect(globalThis.window.open).toHaveBeenCalledTimes(1);
+        expect(globalThis.window.open).toHaveBeenCalledWith("", "_blank", "popup=yes,width=480,height=720");
+        expect(remoteStorageMockState.instance.connect).toHaveBeenCalledWith("user@example.com", undefined);
+
+        repo.remoteStorage.authorize({
+            authURL: "https://auth.example.com/oauth",
+            clientId: "https://app.example.com",
+            redirectUri: "https://app.example.com",
+            scope: "setlist-roller:rw",
+        });
+
+        expect(globalThis.window.open).toHaveBeenCalledTimes(1);
+        expect(popup.location.replace).toHaveBeenCalledTimes(1);
+        expect(popup.location.replace.mock.calls[0][0]).toContain("https://auth.example.com/oauth");
     });
 });

--- a/src/lib/remotestorage.test.js
+++ b/src/lib/remotestorage.test.js
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
 const remoteStorageMockState = vi.hoisted(() => ({
     instance: null,
     defaultAuthorize: null,


### PR DESCRIPTION
## Summary
- Fix standalone/PWA auth popup handling so login state can sync back into the app reliably.
- Add an auth relay page to support cross-window authentication handoff.
- Update remote storage/auth integration and add coverage for the sync flow.
- Switch CI and release workflows to `npm ci`, and commit release artifacts from committed source before tagging.
- Track `package-lock.json` and align release/deploy behavior with the committed build output.

## Testing
- `npm test`
- `npm run lint`
- Verified auth relay and popup handling changes via the new `src/lib/remotestorage.test.js` coverage.
- Not run: full end-to-end browser validation of the PWA auth flow in a production build.