### PR TITLE
Fix standalone PWA auth defaults for remoteStorage login

### DIFF
--- a/src/lib/remotestorage.js
+++ b/src/lib/remotestorage.js
@@ -53,7 +53,7 @@ export function buildAuthorizeUrl(options) {
 
 export function normalizeStandaloneAuthorizeOptions(options, env = globalThis.window) {
     const authorizeOptions = { ...(options ?? {}) };
-    if (typeof authorizeOptions.scope === "undefined") {
+    if (typeof authorizeOptions.scope !== "string" || authorizeOptions.scope.trim() === "") {
         throw new Error("Cannot authorize due to undefined or empty scope; did you forget to access.claim()?");
     }
     if (typeof authorizeOptions.redirectUri === "undefined") {
@@ -61,13 +61,13 @@ export function normalizeStandaloneAuthorizeOptions(options, env = globalThis.wi
             throw new Error("Standalone authorization requires a browser location.");
         }
         let redirectUri = env.location.origin;
-        if (env.location.pathname && env.location.pathname !== "/") {
+        if (env.location.pathname) {
             redirectUri += env.location.pathname;
         }
         authorizeOptions.redirectUri = redirectUri;
     }
     if (typeof authorizeOptions.clientId === "undefined") {
-        authorizeOptions.clientId = authorizeOptions.redirectUri.match(/^(https?:\/\/[^/]+)/)?.[0];
+        authorizeOptions.clientId = new URL(authorizeOptions.redirectUri).origin;
     }
     return authorizeOptions;
 }

--- a/src/lib/remotestorage.js
+++ b/src/lib/remotestorage.js
@@ -51,6 +51,27 @@ export function buildAuthorizeUrl(options) {
     return url.toString();
 }
 
+export function normalizeStandaloneAuthorizeOptions(options, env = globalThis.window) {
+    const authorizeOptions = { ...(options ?? {}) };
+    if (typeof authorizeOptions.scope === "undefined") {
+        throw new Error("Cannot authorize due to undefined or empty scope; did you forget to access.claim()?");
+    }
+    if (typeof authorizeOptions.redirectUri === "undefined") {
+        if (!env?.location?.origin) {
+            throw new Error("Standalone authorization requires a browser location.");
+        }
+        let redirectUri = env.location.origin;
+        if (env.location.pathname && env.location.pathname !== "/") {
+            redirectUri += env.location.pathname;
+        }
+        authorizeOptions.redirectUri = redirectUri;
+    }
+    if (typeof authorizeOptions.clientId === "undefined") {
+        authorizeOptions.clientId = authorizeOptions.redirectUri.match(/^(https?:\/\/[^/]+)/)?.[0];
+    }
+    return authorizeOptions;
+}
+
 export function createStandaloneAuthMessageHandler({ attemptId, origin, onSuccess, onError }) {
     return (event) => {
         if (event.origin !== origin) return false;
@@ -228,11 +249,11 @@ export function createRemoteStorageRepository() {
     remoteStorage.authorize = (options) => {
         if (isIosStandaloneAuthContext()) {
             try {
-                const authorizeOptions = { ...(options ?? {}) };
                 remoteStorage.access.setStorageType(remoteStorage.remote.storageApi);
-                if (typeof authorizeOptions.scope === "undefined") {
-                    authorizeOptions.scope = remoteStorage.access.scopeParameter;
-                }
+                const authorizeOptions = normalizeStandaloneAuthorizeOptions({
+                    ...(options ?? {}),
+                    scope: options?.scope ?? remoteStorage.access.scopeParameter,
+                });
                 authorizeWithStandalonePopup(remoteStorage, authorizeOptions, {
                     popup: releaseReservedAuthPopup(),
                     emitError: (error) => emitLocal("error", error),
@@ -251,14 +272,15 @@ export function createRemoteStorageRepository() {
         client,
 
         connect(userAddress, token) {
+            const normalizedToken = token || undefined;
             // Re-enable caching in case it was reset by a previous disconnect
             remoteStorage.caching.enable(`/${APP_SCOPE}/`);
-            if (!token) {
+            if (!normalizedToken) {
                 reserveStandaloneAuthPopup();
             } else {
                 releaseReservedAuthPopup({ close: true });
             }
-            remoteStorage.connect(userAddress, token);
+            remoteStorage.connect(userAddress, normalizedToken);
         },
 
         disconnect() {

--- a/src/lib/remotestorage.test.js
+++ b/src/lib/remotestorage.test.js
@@ -170,6 +170,47 @@ describe("normalizeStandaloneAuthorizeOptions", () => {
         expect(options.clientId).toBe("https://app.example.com");
         expect(options.scope).toBe("setlist-roller:rw");
     });
+
+    it("preserves a trailing slash when the current pathname is root", () => {
+        const options = normalizeStandaloneAuthorizeOptions(
+            { authURL: "https://auth.example.com/oauth", scope: "setlist-roller:rw" },
+            {
+                location: {
+                    origin: "https://app.example.com",
+                    pathname: "/",
+                },
+            },
+        );
+
+        expect(options.redirectUri).toBe("https://app.example.com/");
+        expect(options.clientId).toBe("https://app.example.com");
+    });
+
+    it("rejects empty or non-string scopes", () => {
+        expect(() =>
+            normalizeStandaloneAuthorizeOptions(
+                { authURL: "https://auth.example.com/oauth", scope: "" },
+                {
+                    location: {
+                        origin: "https://app.example.com",
+                        pathname: "/",
+                    },
+                },
+            ),
+        ).toThrow("undefined or empty scope");
+
+        expect(() =>
+            normalizeStandaloneAuthorizeOptions(
+                { authURL: "https://auth.example.com/oauth", scope: null },
+                {
+                    location: {
+                        origin: "https://app.example.com",
+                        pathname: "/",
+                    },
+                },
+            ),
+        ).toThrow("undefined or empty scope");
+    });
 });
 
 describe("createStandaloneAuthMessageHandler", () => {

--- a/src/lib/remotestorage.test.js
+++ b/src/lib/remotestorage.test.js
@@ -15,6 +15,7 @@ import {
     createRemoteStorageRepository,
     createStandaloneAuthMessageHandler,
     isIosStandaloneAuthContext,
+    normalizeStandaloneAuthorizeOptions,
 } from "./remotestorage.js";
 
 let originalWindow;
@@ -150,6 +151,24 @@ describe("buildAuthorizeUrl", () => {
         expect(url.searchParams.get("code_challenge")).toBe("challenge");
         expect(url.searchParams.get("code_challenge_method")).toBe("S256");
         expect(url.searchParams.get("token_access_type")).toBe("offline");
+    });
+});
+
+describe("normalizeStandaloneAuthorizeOptions", () => {
+    it("fills in redirectUri and clientId from the current location", () => {
+        const options = normalizeStandaloneAuthorizeOptions(
+            { authURL: "https://auth.example.com/oauth", scope: "setlist-roller:rw" },
+            {
+                location: {
+                    origin: "https://app.example.com",
+                    pathname: "/app",
+                },
+            },
+        );
+
+        expect(options.redirectUri).toBe("https://app.example.com/app");
+        expect(options.clientId).toBe("https://app.example.com");
+        expect(options.scope).toBe("setlist-roller:rw");
     });
 });
 
@@ -376,15 +395,15 @@ describe("createRemoteStorageRepository", () => {
         expect(() =>
             repo.remoteStorage.authorize({
                 authURL: "https://auth.example.com/oauth",
-                clientId: "https://app.example.com",
-                redirectUri: "https://app.example.com",
-                scope: "setlist-roller:rw",
             }),
         ).not.toThrow();
         expect(remoteStorageMockState.instance.access.setStorageType).toHaveBeenCalledWith("webdav");
         expect(remoteStorageMockState.defaultAuthorize).not.toHaveBeenCalled();
         expect(errorHandler).toHaveBeenCalledTimes(1);
         expect(errorHandler.mock.calls[0][0].message).toContain("popup was blocked");
+        const authUrl = globalThis.window.open.mock.calls[0][0];
+        const redirectUri = new URL(authUrl).searchParams.get("redirect_uri");
+        expect(redirectUri).toMatch(/^https:\/\/app\.example\.com\/auth-relay\.html\?attempt=/);
     });
 
     it("closes the reserved popup on disconnect", () => {
@@ -578,18 +597,72 @@ describe("createRemoteStorageRepository", () => {
         repo.connect("user@example.com");
 
         expect(globalThis.window.open).toHaveBeenCalledTimes(1);
-        expect(globalThis.window.open).toHaveBeenCalledWith("", "_blank", "popup=yes,width=480,height=720");
+        const [popupUrl, popupTarget, popupFeatures] = globalThis.window.open.mock.calls[0];
+        expect(popupUrl).toBe("");
+        expect(popupTarget).toBe("_blank");
+        expect(popupFeatures).toContain("popup=yes");
+        expect(popupFeatures).toContain("width=480");
+        expect(popupFeatures).toContain("height=720");
         expect(remoteStorageMockState.instance.connect).toHaveBeenCalledWith("user@example.com", undefined);
 
         repo.remoteStorage.authorize({
             authURL: "https://auth.example.com/oauth",
-            clientId: "https://app.example.com",
-            redirectUri: "https://app.example.com",
-            scope: "setlist-roller:rw",
         });
 
         expect(globalThis.window.open).toHaveBeenCalledTimes(1);
         expect(popup.location.replace).toHaveBeenCalledTimes(1);
         expect(popup.location.replace.mock.calls[0][0]).toContain("https://auth.example.com/oauth");
+        expect(decodeURIComponent(popup.location.replace.mock.calls[0][0])).toContain(
+            "redirect_uri=https://app.example.com/auth-relay.html",
+        );
+    });
+
+    it("pre-opens a popup during tokenless switchTo and closes it on disconnect", () => {
+        const reservedPopup = {
+            closed: false,
+            location: {
+                replace: vi.fn(),
+                href: "",
+            },
+            document: {
+                write: vi.fn(),
+                close: vi.fn(),
+            },
+            close: vi.fn(),
+        };
+        globalThis.window = {
+            matchMedia: vi.fn(() => ({ matches: true })),
+            navigator: {
+                standalone: true,
+                userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)",
+                platform: "iPhone",
+                maxTouchPoints: 5,
+            },
+            location: {
+                origin: "https://app.example.com",
+                hash: "",
+            },
+            open: vi.fn(() => reservedPopup),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            setInterval: vi.fn(() => 1),
+            clearInterval: vi.fn(),
+            setTimeout: vi.fn(() => 2),
+            clearTimeout: vi.fn(),
+        };
+
+        const repo = createRemoteStorageRepository();
+
+        repo.switchTo("other@example.com");
+
+        expect(globalThis.window.open).toHaveBeenCalledTimes(1);
+        expect(remoteStorageMockState.instance.remote.configure).toHaveBeenCalledWith({ token: null });
+        expect(remoteStorageMockState.instance.connect).toHaveBeenCalledWith("other@example.com", undefined);
+
+        repo.disconnect();
+
+        expect(reservedPopup.close).toHaveBeenCalledTimes(1);
+        expect(remoteStorageMockState.instance.caching.reset).toHaveBeenCalledTimes(1);
+        expect(remoteStorageMockState.instance.disconnect).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
## Summary

Fix the iOS home-screen PWA auth regression that still persisted after `v1.6.0`/`v1.6.1` by restoring the missing `remotestoragejs` authorize defaults in the standalone override.

## Root cause

The standalone iOS override replaced `remotestoragejs`'s normal `authorize()` flow, but it did not reproduce the library's default derivation of `redirectUri` and `clientId`. In the real `connect() -> authorize({ authURL })` path, that left the popup auth URL incomplete and the app stalled on `Waiting for authorization`.

## What changed

- restored standalone auth option normalization for `redirectUri` and `clientId`
- kept the pre-opened popup reuse workaround for iOS home-screen installs
- normalized `connect()` token handling to match `switchTo()`
- added coverage for the real standalone `authorize({ authURL })` path
- added popup lifecycle tests for `switchTo()` and `disconnect()`

## Validation

- `npm run lint`
- `npm test`
- `npm run build`
