### PR TITLE
fix: use theme-aware background for login account list

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -394,7 +394,7 @@
         align-items: center;
         border: 1px solid var(--line);
         border-radius: var(--radius-md);
-        background: rgba(255,255,255,0.6);
+        background: var(--surface);
         overflow: hidden;
     }
 


### PR DESCRIPTION
Replace hardcoded `rgba(255,255,255,0.6)` background on recent account items with `var(--surface)`, which adapts to the active theme. Previously, account items appeared too bright in dark mode.