### PR TITLE
fix: account for safe-area-inset-top in top bar height

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -515,7 +515,7 @@
     /* ---- Toast pill ---- */
     .toast-pill {
         position: fixed;
-        top: calc(env(safe-area-inset-top, 0px) + 48px);
+        top: var(--top-bar-height);
         left: 50%;
         transform: translateX(-50%);
         max-width: calc(100vw - 2rem);

--- a/src/app.css
+++ b/src/app.css
@@ -62,7 +62,7 @@
     --space-8: 2rem;
 
     /* Layout */
-    --top-bar-height: 48px;
+    --top-bar-height: calc(48px + env(safe-area-inset-top, 0px));
     --bottom-nav-height: 56px;
     --safe-bottom: env(safe-area-inset-bottom, 0px);
 }

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -93,7 +93,7 @@
     top: 0;
     left: 0;
     right: 0;
-    min-height: var(--top-bar-height);
+    height: var(--top-bar-height);
     padding-top: env(safe-area-inset-top, 0px);
     display: grid;
     grid-template-columns: 1fr auto 1fr;

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -93,7 +93,7 @@
     top: 0;
     left: 0;
     right: 0;
-    height: 48px;
+    min-height: var(--top-bar-height);
     padding-top: env(safe-area-inset-top, 0px);
     display: grid;
     grid-template-columns: 1fr auto 1fr;

--- a/src/lib/components/roll/RollScreen.svelte
+++ b/src/lib/components/roll/RollScreen.svelte
@@ -520,7 +520,7 @@
   /* Hero */
   .hero {
     position: sticky;
-    top: 48px;
+    top: var(--top-bar-height);
     z-index: 50;
     background: var(--paper, rgba(255, 255, 255, 0.96));
     backdrop-filter: blur(16px);
@@ -530,7 +530,7 @@
     padding: 0.6rem;
     display: grid;
     gap: 0.5rem;
-    max-height: calc(100vh - 48px - var(--bottom-nav-height, 56px) - var(--safe-bottom, 0px) - 1rem);
+    max-height: calc(100vh - var(--top-bar-height) - var(--bottom-nav-height, 56px) - var(--safe-bottom, 0px) - 1rem);
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
   }


### PR DESCRIPTION
On notched iPhones, `--top-bar-height` was a fixed `48px` that didn't include `env(safe-area-inset-top)`, so screen content rendered behind the fixed TopBar. This updates the variable to `calc(48px + env(safe-area-inset-top, 0px))` and replaces all hardcoded `48px` top-bar references with the variable, so the layout correctly accounts for the safe area on all devices.