### PR TITLE
fix: make TopBar menu button tappable on mobile PWA

### DIFF
--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -112,6 +112,8 @@
     display: flex;
     align-items: center;
     gap: 8px;
+    overflow: hidden;
+    min-width: 0;
   }
 
   .conn-dot {
@@ -155,6 +157,8 @@
     align-items: center;
     justify-content: flex-end;
     gap: 8px;
+    position: relative;
+    z-index: 1;
   }
 
   .menu-wrapper {
@@ -175,6 +179,7 @@
     color: var(--ink);
     border-radius: var(--radius-md);
     -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
   }
 
   .menu-btn:active {
@@ -213,6 +218,7 @@
     color: var(--ink);
     text-align: left;
     -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
   }
 
   .dropdown-item:active {


### PR DESCRIPTION
Fixes the three-dot menu button in the top-right corner not responding to taps on mobile PWA. Adds `touch-action: manipulation` to the menu button and dropdown items (matching every other button in the app), constrains the title-group overflow so long band names can't intercept touches, and ensures the menu area stacks above the title.