### PR TITLE
fix: force WebKit compositor update after login on iOS PWA

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -38,8 +38,10 @@
     $effect(() => {
         if (store.initialSyncComplete && isIosStandaloneAuthContext()) {
             requestAnimationFrame(() => {
-                window.scrollTo(0, 1);
-                requestAnimationFrame(() => window.scrollTo(0, 0));
+                const x = window.scrollX;
+                const y = window.scrollY;
+                window.scrollTo(x, y + 1);
+                requestAnimationFrame(() => window.scrollTo(x, y));
             });
         }
     });

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,7 +8,7 @@
     import SavedScreen from "./lib/components/saved/SavedScreen.svelte";
     import SongsScreen from "./lib/components/songs/SongsScreen.svelte";
     import { generateDieSvgString, updatePwaIcons } from "./lib/pwa-icon.js";
-    import { createRemoteStorageRepository } from "./lib/remotestorage.js";
+    import { createRemoteStorageRepository, isIosStandaloneAuthContext } from "./lib/remotestorage.js";
     import { createAppStore } from "./lib/stores/app.svelte.js";
     import { DEFAULT_DIE_COLOR, hexToRgb } from "./lib/utils.js";
 
@@ -29,6 +29,19 @@
 
     $effect(() => {
         void updatePwaIcons(dieColor).catch((e) => console.error("PWA icon update failed", e));
+    });
+
+    // iOS standalone PWA: after the sync-shell → app-shell DOM swap,
+    // WebKit's compositor has stale hit-test regions for the new
+    // fixed-position elements (TopBar, BottomNav). A micro-scroll
+    // forces the compositor to rebuild its layer hit-test tree.
+    $effect(() => {
+        if (store.initialSyncComplete && isIosStandaloneAuthContext()) {
+            requestAnimationFrame(() => {
+                window.scrollTo(0, 1);
+                requestAnimationFrame(() => window.scrollTo(0, 0));
+            });
+        }
     });
 </script>
 


### PR DESCRIPTION
## Summary
- After OAuth login on an iOS standalone PWA, the TopBar and BottomNav fixed-position elements are visible but don't respond to taps
- Root cause: WebKit's compositor retains stale hit-test regions after Svelte swaps the sync-shell for the app-shell DOM
- Fix: an `$effect` performs an imperceptible 1px micro-scroll nudge (gated to iOS standalone only) when `initialSyncComplete` becomes true, forcing the compositor to rebuild its layer hit-test tree