### PR TITLE
fix: prevent beam collapse from biasing opener toward one key

### DIFF
--- a/src/lib/generator.js
+++ b/src/lib/generator.js
@@ -694,6 +694,7 @@ class SetList {
             coverCount: 0,
             instrumentalCount: 0,
             lastItem: null,
+            firstSongId: null,
             rankScore: 0,
             _tiebreaker: 0,
             propChangeCounts: zeroMap(this._propNames),
@@ -792,6 +793,7 @@ class SetList {
         const pool = nextStates.slice(0, poolSize);
         const selected = [];
         const lastSongCounts = {};
+        const firstSongCounts = {};
         const temperature = clampFloat(this._randomness.beamTemperature, 1.1, 0.01);
         const maxStatesPerLastSong = clampInteger(this._randomness.maxStatesPerLastSong, 24, 1);
 
@@ -815,13 +817,21 @@ class SetList {
 
             const chosen = pool.splice(chosenIndex, 1)[0];
             const lastSongId = chosen.lastItem ? chosen.lastItem.id : "none";
-            const used = lastSongCounts[lastSongId] || 0;
+            const lastUsed = lastSongCounts[lastSongId] || 0;
 
-            if (used >= maxStatesPerLastSong) {
+            if (lastUsed >= maxStatesPerLastSong) {
                 continue;
             }
 
-            lastSongCounts[lastSongId] = used + 1;
+            const firstSongId = chosen.firstSongId || "none";
+            const firstUsed = firstSongCounts[firstSongId] || 0;
+
+            if (firstUsed >= maxStatesPerLastSong) {
+                continue;
+            }
+
+            lastSongCounts[lastSongId] = lastUsed + 1;
+            firstSongCounts[firstSongId] = firstUsed + 1;
             selected.push(chosen);
         }
 
@@ -1052,6 +1062,7 @@ class SetList {
                 coverCount: nextCoverCount,
                 instrumentalCount: nextInstrumentalCount,
                 lastItem: variantState.item,
+                firstSongId: state.firstSongId || song.id,
                 rankScore: newScore + this._randomJitter(this._randomness.stateJitter),
                 _tiebreaker: this._rng(),
                 propChangeCounts: variantState.propChangeCounts,

--- a/src/lib/generator.test.js
+++ b/src/lib/generator.test.js
@@ -1753,3 +1753,72 @@ describe("notes field", () => {
         expect(result.songs[0].notes).toBe("");
     });
 });
+
+describe("generateSetlist — opener diversity", () => {
+    it("does not collapse opener onto a single song when one tuning is in the minority", () => {
+        // 5 songs in Drop D tuning (key of D), 15 songs in Standard tuning (various keys)
+        const dropDSongs = Array.from({ length: 5 }, (_, i) =>
+            makeSong(`Drop Song ${i + 1}`, {
+                key: "D",
+                members: {
+                    nick: {
+                        instruments: [{ name: "guitar", tuning: ["Drop D"], capo: 0, picking: [] }],
+                    },
+                },
+            }),
+        );
+        const standardSongs = Array.from({ length: 15 }, (_, i) =>
+            makeSong(`Standard Song ${i + 1}`, {
+                key: ["G", "A", "C", "E", "F", "Bb", "Eb", "Ab", "B", "F#", "Bm", "Em", "Am", "Dm", "Cm"][i],
+                members: {
+                    nick: {
+                        instruments: [{ name: "guitar", tuning: ["Standard"], capo: 0, picking: [] }],
+                    },
+                },
+            }),
+        );
+        const songs = [...dropDSongs, ...standardSongs];
+        const config = makeConfig();
+
+        const keyCounts = {};
+        const seeds = 30;
+        for (let seed = 1; seed <= seeds; seed++) {
+            const result = generateSetlist(songs, config, {
+                count: 9,
+                seed,
+                beamWidth: 64,
+                randomness: { temperature: 1.6 },
+            });
+            const key = result.songs[0]?.key || "unknown";
+            keyCounts[key] = (keyCounts[key] || 0) + 1;
+        }
+        const maxCount = Math.max(...Object.values(keyCounts));
+        // No single key should dominate the opener across 30 seeds
+        expect(maxCount / seeds).toBeLessThanOrEqual(0.6);
+    });
+
+    it("key flow does not bias opener selection toward central keys", () => {
+        // D is central on the circle of fifths for guitar keys — it should not dominate
+        // the opener even with key flow enabled
+        const keys = ["D", "D", "D", "G", "G", "G", "A", "A", "E", "E", "C", "C", "F", "Bb", "F#"];
+        const songs = keys.map((key, i) => makeSong(`Song ${i + 1}`, { key, members: {} }));
+        const config = makeConfig();
+
+        const keyCounts = {};
+        const seeds = 30;
+        for (let seed = 1; seed <= seeds; seed++) {
+            const result = generateSetlist(songs, config, {
+                count: 9,
+                seed,
+                beamWidth: 64,
+                keyFlow: true,
+                randomness: { temperature: 1.2 },
+            });
+            const key = result.songs[0]?.key || "unknown";
+            keyCounts[key] = (keyCounts[key] || 0) + 1;
+        }
+        const dCount = keyCounts.D || 0;
+        // D is 3/15 = 20% of catalog, should not appear as opener more than 50%
+        expect(dCount / seeds).toBeLessThanOrEqual(0.5);
+    });
+});


### PR DESCRIPTION
## Summary

- Track `firstSongId` in beam states and cap how many states can share the same opener during beam selection, mirroring the existing `maxStatesPerLastSong` mechanism
- Prevents cumulative scoring advantages at later positions (tuning transitions, key flow, chaos adjustments) from crowding out opener diversity
- Adds two regression tests: one for tuning-bias-driven collapse and one for key-flow-driven collapse

## Test plan

- [x] All 64 existing + new tests pass
- [x] Lint passes
- [ ] Manual testing: roll multiple setlists for a band with guitar-key-heavy catalog, verify opener key diversity