### PR TITLE
feat: add multi-select key filter to songs page

### DIFF
--- a/src/lib/components/songs/SongsScreen.svelte
+++ b/src/lib/components/songs/SongsScreen.svelte
@@ -1,5 +1,6 @@
 <script>
     import { getContext } from "svelte";
+    import ChipToggle from "../shared/ChipToggle.svelte";
     import SongEditor from "./SongEditor.svelte";
 
     const store = getContext("app");
@@ -66,6 +67,27 @@
             {/each}
         </div>
     </div>
+
+    {#if store.usedKeys.length > 0}
+        <div class="key-filter-section">
+            <div class="key-filter-header">
+                <span class="key-filter-label">Key</span>
+                {#if store.songKeyFilters.size > 0}
+                    <button type="button" class="key-clear-btn" onclick={() => store.clearKeyFilters()}>
+                        Clear
+                    </button>
+                {/if}
+            </div>
+            <div class="key-chips">
+                {#each store.usedKeys as key}
+                    <ChipToggle
+                        checked={store.songKeyFilters.has(key)}
+                        onchange={() => store.toggleKeyFilter(key)}
+                    >{key}</ChipToggle>
+                {/each}
+            </div>
+        </div>
+    {/if}
 
     {#if store.emptyCatalog}
         <div class="empty-state">
@@ -241,6 +263,42 @@
     .seg-btn.active {
         background: var(--accent-soft, rgba(225, 91, 55, 0.12));
         color: var(--accent-strong, #c64724);
+    }
+
+    .key-filter-section {
+        display: grid;
+        gap: 0.4rem;
+    }
+
+    .key-filter-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+    }
+
+    .key-filter-label {
+        font-size: 0.82rem;
+        font-weight: 700;
+        color: var(--muted, #6b7a8d);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+    }
+
+    .key-clear-btn {
+        font-size: 0.78rem;
+        font-weight: 600;
+        color: var(--accent-strong, #c64724);
+        background: none;
+        border: none;
+        cursor: pointer;
+        padding: 0.2rem 0.4rem;
+        touch-action: manipulation;
+    }
+
+    .key-chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
     }
 
     .empty-state {

--- a/src/lib/keys.js
+++ b/src/lib/keys.js
@@ -108,6 +108,30 @@ export function keyDistance(keyA, keyB) {
  * @param {number} weight - key flow weight (penalty multiplier)
  * @returns {{ score: number, dir: number }}
  */
+/**
+ * Sort an array of key strings in chromatic order (major then minor).
+ * Keys not in the canonical list are placed at the end.
+ */
+export function sortKeys(keys) {
+    const order = [...MAJOR_KEYS, ...MINOR_KEYS];
+    return [...keys].sort((a, b) => {
+        const ai = order.indexOf(a);
+        const bi = order.indexOf(b);
+        return (ai === -1 ? order.length : ai) - (bi === -1 ? order.length : bi);
+    });
+}
+
+/**
+ * Remove entries from a Set that are not present in validKeys.
+ * Returns null if nothing was pruned, or a new Set if entries were removed.
+ */
+export function pruneStaleKeys(filterSet, validKeys) {
+    if (filterSet.size === 0) return null;
+    const valid = new Set(validKeys);
+    const pruned = new Set([...filterSet].filter((k) => valid.has(k)));
+    return pruned.size !== filterSet.size ? pruned : null;
+}
+
 export function scoreKeyTransition(prevKey, nextKey, prevDir, weight) {
     const dist = keyDistance(prevKey, nextKey);
     if (dist === null) return { score: 0, dir: prevDir };

--- a/src/lib/keys.test.js
+++ b/src/lib/keys.test.js
@@ -7,7 +7,9 @@ import {
     MAJOR_KEYS,
     MINOR_KEYS,
     parseKey,
+    pruneStaleKeys,
     scoreKeyTransition,
+    sortKeys,
 } from "./keys.js";
 
 describe("parseKey", () => {
@@ -191,6 +193,46 @@ describe("scoreKeyTransition", () => {
         const result = scoreKeyTransition("C", "Am", 3, 2); // relative major/minor = distance 0
         expect(result.score).toBe(0);
         expect(result.dir).toBe(3); // preserved
+    });
+});
+
+describe("sortKeys", () => {
+    it("sorts canonical keys in chromatic major-then-minor order", () => {
+        expect(sortKeys(["Am", "G", "C", "Em"])).toEqual(["C", "G", "Em", "Am"]);
+    });
+
+    it("places non-canonical keys at the end", () => {
+        expect(sortKeys(["Db", "C", "G"])).toEqual(["C", "G", "Db"]);
+    });
+
+    it("handles an empty array", () => {
+        expect(sortKeys([])).toEqual([]);
+    });
+
+    it("does not mutate the input", () => {
+        const input = ["G", "C"];
+        sortKeys(input);
+        expect(input).toEqual(["G", "C"]);
+    });
+});
+
+describe("pruneStaleKeys", () => {
+    it("returns null when nothing to prune", () => {
+        expect(pruneStaleKeys(new Set(["C", "G"]), ["C", "G", "Am"])).toBeNull();
+    });
+
+    it("returns null for an empty filter set", () => {
+        expect(pruneStaleKeys(new Set(), ["C"])).toBeNull();
+    });
+
+    it("removes keys not in the valid list", () => {
+        const result = pruneStaleKeys(new Set(["C", "G", "Am"]), ["C"]);
+        expect(result).toEqual(new Set(["C"]));
+    });
+
+    it("returns empty set when all keys are stale", () => {
+        const result = pruneStaleKeys(new Set(["G"]), ["C", "Am"]);
+        expect(result).toEqual(new Set());
     });
 });
 

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -3,7 +3,7 @@ import { CONFIG_SECTIONS } from "../config-meta.js";
 import { blankSong, DEFAULT_APP_CONFIG, normalizeAppConfig, normalizeMemberRecord, normalizeSongRecord } from "../defaults.js";
 import { buildDefaultPerformance, scoreFixedOrder } from "../generator.js";
 import GeneratorWorker from "../generator.worker.js?worker";
-import { MAJOR_KEYS, MINOR_KEYS } from "../keys.js";
+import { pruneStaleKeys, sortKeys } from "../keys.js";
 import { migrator } from "../migrations.js";
 import { clone, deepMerge, formatDelimitedList, getByPath, nowIso, parseDelimitedList, setByPath, titleForBand, tryParseJson, uid } from "../utils.js";
 
@@ -96,11 +96,13 @@ export function createAppStore(repo) {
     let instrumentTypeCount = $derived(allInstrumentNamesList.length);
     let visibleSongs = $derived(computeVisibleSongs());
     let usedKeys = $derived(
-        [...new Set(songs.map((s) => s.key).filter(Boolean))].sort((a, b) => {
-            const order = [...MAJOR_KEYS, ...MINOR_KEYS];
-            return order.indexOf(a) - order.indexOf(b);
-        }),
+        sortKeys([...new Set(songs.map((s) => s.key).filter(Boolean))]),
     );
+
+    $effect(() => {
+        const pruned = pruneStaleKeys(songKeyFilters, usedKeys);
+        if (pruned) songKeyFilters = pruned;
+    });
 
     // ---- helpers ----
 

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -4,6 +4,7 @@ import { blankSong, DEFAULT_APP_CONFIG, normalizeAppConfig, normalizeMemberRecor
 import { buildDefaultPerformance, scoreFixedOrder } from "../generator.js";
 import GeneratorWorker from "../generator.worker.js?worker";
 import { migrator } from "../migrations.js";
+import { MAJOR_KEYS, MINOR_KEYS } from "../keys.js";
 import { clone, deepMerge, formatDelimitedList, getByPath, nowIso, parseDelimitedList, setByPath, titleForBand, tryParseJson, uid } from "../utils.js";
 
 const STORAGE_PREFIX = "setlist-roller";
@@ -63,6 +64,7 @@ export function createAppStore(repo) {
     let editReturnView = $state("");
     let songSearch = $state("");
     let songFilter = $state("all");
+    let songKeyFilters = $state(new Set());
 
     // ---- band editing ----
     let expandedBandMember = $state("");
@@ -93,6 +95,12 @@ export function createAppStore(repo) {
     let allInstrumentNamesList = $derived(buildAllInstrumentNames());
     let instrumentTypeCount = $derived(allInstrumentNamesList.length);
     let visibleSongs = $derived(computeVisibleSongs());
+    let usedKeys = $derived(
+        [...new Set(songs.map((s) => s.key).filter(Boolean))].sort((a, b) => {
+            const order = [...MAJOR_KEYS, ...MINOR_KEYS];
+            return order.indexOf(a) - order.indexOf(b);
+        }),
+    );
 
     // ---- helpers ----
 
@@ -201,6 +209,7 @@ export function createAppStore(repo) {
             if (songFilter === "originals" && song.cover) return false;
             if (songFilter === "incomplete" && !isSongIncomplete(song)) return false;
             if (songFilter === "unpracticed" && !song.unpracticed) return false;
+            if (songKeyFilters.size > 0 && !songKeyFilters.has(song.key)) return false;
             if (!query) return true;
             return [song.name, song.key, ...Object.keys(song.members || {})]
                 .join(" ").toLowerCase().includes(query);
@@ -1767,6 +1776,15 @@ export function createAppStore(repo) {
         set songSearch(v) { songSearch = v; },
         get songFilter() { return songFilter; },
         set songFilter(v) { songFilter = v; },
+        get songKeyFilters() { return songKeyFilters; },
+        get usedKeys() { return usedKeys; },
+        toggleKeyFilter(key) {
+            const next = new Set(songKeyFilters);
+            if (next.has(key)) next.delete(key);
+            else next.add(key);
+            songKeyFilters = next;
+        },
+        clearKeyFilters() { songKeyFilters = new Set(); },
         get expandedBandMember() { return expandedBandMember; },
         set expandedBandMember(v) { expandedBandMember = v; },
         get newMemberName() { return newMemberName; },

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -3,8 +3,8 @@ import { CONFIG_SECTIONS } from "../config-meta.js";
 import { blankSong, DEFAULT_APP_CONFIG, normalizeAppConfig, normalizeMemberRecord, normalizeSongRecord } from "../defaults.js";
 import { buildDefaultPerformance, scoreFixedOrder } from "../generator.js";
 import GeneratorWorker from "../generator.worker.js?worker";
-import { migrator } from "../migrations.js";
 import { MAJOR_KEYS, MINOR_KEYS } from "../keys.js";
+import { migrator } from "../migrations.js";
 import { clone, deepMerge, formatDelimitedList, getByPath, nowIso, parseDelimitedList, setByPath, titleForBand, tryParseJson, uid } from "../utils.js";
 
 const STORAGE_PREFIX = "setlist-roller";


### PR DESCRIPTION
## Summary
- Adds a key filter section to the songs page with multi-select chip toggles
- Only keys present in the song catalog are displayed, sorted chromatically (major then minor)
- Composes with existing type, status, and search filters (all AND together)
- Includes a "Clear" button that appears when any keys are selected
- Reuses the existing `ChipToggle` shared component for consistent styling

## Test plan
- [ ] Open the songs page and verify key chips appear for keys in the catalog
- [ ] Select multiple keys and confirm only matching songs are shown
- [ ] Combine key filter with type/status/search filters
- [ ] Tap "Clear" to reset key selection
- [ ] Add/edit/delete a song's key and verify chips update reactively
- [ ] Verify dark mode styling