### PR TITLE
fix: hard-enforce notGoodOpener and notGoodCloser flags

### DIFF
--- a/src/lib/generator.js
+++ b/src/lib/generator.js
@@ -736,31 +736,48 @@ class SetList {
         this._minimumPotentialTotals = minimumPotentialContext.totals;
         this._minimumGroupCapabilitiesBySongId = minimumPotentialContext.groupCapabilitiesBySongId;
         this._minimumsRelaxed = false;
+        this._openerFilterRelaxed = false;
+        this._closerFilterRelaxed = false;
         let states = [this._initialState()];
 
         for (let position = 1; position <= this._count; position += 1) {
             const nextStates = [];
             const fallbackStates = [];
 
-            for (let si = 0; si < states.length; si++) {
-                const state = states[si];
-                for (let ci = 0; ci < catalog.length; ci++) {
-                    const song = catalog[ci];
-                    if (state.usedIds[song.id]) {
-                        continue;
-                    }
+            const expand = (relaxPositionFilter) => {
+                for (let si = 0; si < states.length; si++) {
+                    const state = states[si];
+                    for (let ci = 0; ci < catalog.length; ci++) {
+                        const song = catalog[ci];
+                        if (state.usedIds[song.id]) {
+                            continue;
+                        }
 
-                    const result = this._buildNextState(state, song, position);
-                    if (!result) {
-                        continue;
-                    }
-                    if (result.feasibleState) {
-                        nextStates.push(result.feasibleState);
-                    }
-                    if (result.fallbackState) {
-                        fallbackStates.push(result.fallbackState);
+                        const result = this._buildNextState(state, song, position, relaxPositionFilter);
+                        if (!result) {
+                            continue;
+                        }
+                        if (result.feasibleState) {
+                            nextStates.push(result.feasibleState);
+                        }
+                        if (result.fallbackState) {
+                            fallbackStates.push(result.fallbackState);
+                        }
                     }
                 }
+            };
+
+            expand(false);
+
+            const isEdgeSlot = position === 1 || position === this._count;
+            if (isEdgeSlot && !nextStates.length && !fallbackStates.length) {
+                if (position === 1) {
+                    this._openerFilterRelaxed = true;
+                }
+                if (position === this._count) {
+                    this._closerFilterRelaxed = true;
+                }
+                expand(true);
             }
 
             const pool = nextStates.length ? nextStates : fallbackStates;
@@ -908,13 +925,15 @@ class SetList {
     }
 
     _reorderRun(runItems, startPosition) {
+        const lastPosition = startPosition + runItems.length - 1;
         const remaining = runItems.slice();
-        const ordered = [];
+        const ordered = new Array(runItems.length);
         const temperature = clampFloat(this._randomness.blockShuffleTemperature, 1.4, 0.01);
 
-        for (let offset = 0; offset < runItems.length; offset += 1) {
-            const _position = startPosition + offset;
-            const ranked = remaining
+        const pickForPosition = (position) => {
+            const eligible = remaining.filter((item) => this._positionAllowsSong(position, item));
+            const pool = eligible.length ? eligible : remaining;
+            const ranked = pool
                 .map((item) => {
                     const score = this._songBias(item.id);
                     return { item, score };
@@ -936,11 +955,36 @@ class SetList {
             }
 
             const chosen = ranked[chosenIndex].item;
-            ordered.push(chosen);
             remaining.splice(remaining.indexOf(chosen), 1);
+            return chosen;
+        };
+
+        // Reserve edge positions first so flagged songs don't get forced into them.
+        if (startPosition === 1) {
+            ordered[0] = pickForPosition(1);
+        }
+        if (lastPosition === this._count && lastPosition !== startPosition) {
+            ordered[lastPosition - startPosition] = pickForPosition(this._count);
+        }
+
+        for (let offset = 0; offset < runItems.length; offset += 1) {
+            if (ordered[offset] !== undefined) {
+                continue;
+            }
+            ordered[offset] = pickForPosition(startPosition + offset);
         }
 
         return ordered;
+    }
+
+    _positionAllowsSong(position, item) {
+        if (position === 1 && item.notGoodOpener && !this._openerFilterRelaxed) {
+            return false;
+        }
+        if (position === this._count && item.notGoodCloser && !this._closerFilterRelaxed) {
+            return false;
+        }
+        return true;
     }
 
     _performanceSignature(performance) {
@@ -1025,11 +1069,22 @@ class SetList {
                 changes: state.changeTotals,
                 anxiety,
                 minimumsRelaxed: Boolean(this._minimumsRelaxed),
+                openerFilterRelaxed: Boolean(this._openerFilterRelaxed),
+                closerFilterRelaxed: Boolean(this._closerFilterRelaxed),
             },
         };
     }
 
-    _buildNextState(state, song, position) {
+    _buildNextState(state, song, position, relaxPositionFilter = false) {
+        if (!relaxPositionFilter) {
+            if (position === 1 && song.notGoodOpener) {
+                return null;
+            }
+            if (position === this._count && song.notGoodCloser) {
+                return null;
+            }
+        }
+
         const nextCoverCount = state.coverCount + (song.cover ? 1 : 0);
         const nextInstrumentalCount = state.instrumentalCount + (song.instrumental ? 1 : 0);
 

--- a/src/lib/generator.test.js
+++ b/src/lib/generator.test.js
@@ -512,7 +512,7 @@ describe("generateSetlist — cover and instrumental limits", () => {
 // Position rules
 // ===================================================================
 describe("generateSetlist — position rules", () => {
-    it("avoids notGoodOpener in first position (across seeds)", () => {
+    it("never places notGoodOpener in first position (across seeds)", () => {
         const songs = [
             makeSong("Opener", { notGoodOpener: true }),
             ...simpleCatalog(14).map((s, i) => ({
@@ -526,12 +526,12 @@ describe("generateSetlist — position rules", () => {
         for (let seed = 1; seed <= 20; seed++) {
             const result = generateSetlist(songs, config, deterministicOptions({ count: 10, seed }));
             if (result.songs[0]?.name === "Opener") openerFirst++;
+            expect(result.summary.openerFilterRelaxed).toBe(false);
         }
-        // Should very rarely be first (position penalty makes it expensive)
-        expect(openerFirst).toBeLessThanOrEqual(2);
+        expect(openerFirst).toBe(0);
     });
 
-    it("avoids notGoodCloser in last position (across seeds)", () => {
+    it("never places notGoodCloser in last position (across seeds)", () => {
         const songs = [
             makeSong("Closer", { notGoodCloser: true }),
             ...simpleCatalog(14).map((s, i) => ({
@@ -546,8 +546,35 @@ describe("generateSetlist — position rules", () => {
             const result = generateSetlist(songs, config, deterministicOptions({ count: 10, seed }));
             const last = result.songs[result.songs.length - 1];
             if (last?.name === "Closer") closerLast++;
+            expect(result.summary.closerFilterRelaxed).toBe(false);
         }
-        expect(closerLast).toBeLessThanOrEqual(2);
+        expect(closerLast).toBe(0);
+    });
+
+    it("relaxes opener filter and flags summary when every song is notGoodOpener", () => {
+        const songs = simpleCatalog(10).map((s, i) => ({
+            ...s,
+            id: `flagged-${i}`,
+            name: `Flagged ${i + 1}`,
+            notGoodOpener: true,
+        }));
+        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 10, seed: 1 }));
+        expect(result.songs.length).toBe(10);
+        expect(result.summary.openerFilterRelaxed).toBe(true);
+        expect(result.summary.closerFilterRelaxed).toBe(false);
+    });
+
+    it("relaxes closer filter and flags summary when every song is notGoodCloser", () => {
+        const songs = simpleCatalog(10).map((s, i) => ({
+            ...s,
+            id: `flagged-${i}`,
+            name: `Flagged ${i + 1}`,
+            notGoodCloser: true,
+        }));
+        const result = generateSetlist(songs, makeConfig(), deterministicOptions({ count: 10, seed: 1 }));
+        expect(result.songs.length).toBe(10);
+        expect(result.summary.closerFilterRelaxed).toBe(true);
+        expect(result.summary.openerFilterRelaxed).toBe(false);
     });
 
     it("avoids covers in first two positions", () => {

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -681,6 +681,12 @@ export function createAppStore(repo) {
             if (result.summary?.minimumsRelaxed || !validateConstraintMinimums(result)) {
                 addToast("Couldn't meet every demand, but it got close.", "warning");
             }
+            if (result.summary?.openerFilterRelaxed) {
+                addToast("No valid opener in catalog — used a flagged song.", "warning");
+            }
+            if (result.summary?.closerFilterRelaxed) {
+                addToast("No valid closer in catalog — used a flagged song.", "warning");
+            }
             const n = generatedSetlist.songs.length;
             addToast(randomFrom([
                 `🎲 The dice have spoken. ${n} songs.`,

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -682,10 +682,10 @@ export function createAppStore(repo) {
                 addToast("Couldn't meet every demand, but it got close.", "warning");
             }
             if (result.summary?.openerFilterRelaxed) {
-                addToast("No valid opener in catalog — used a flagged song.", "warning");
+                addToast("No valid opener found in catalog.", "warning");
             }
             if (result.summary?.closerFilterRelaxed) {
-                addToast("No valid closer in catalog — used a flagged song.", "warning");
+                addToast("No valid closer found in catalog.", "warning");
             }
             const n = generatedSetlist.songs.length;
             addToast(randomFrom([


### PR DESCRIPTION
## Summary
- Songs flagged as "not a good opener" or "not a good closer" were soft preferences — under some seeds they still landed in the edge slots.
- Reject flagged songs in the beam search, and reserve edge positions during compatible-run diversification so a flagged song can't be forced into the opener/closer slot when it's the last remaining song in a run.
- If the catalog has no valid opener/closer, fall back to a flagged song and surface a warning toast via new `openerFilterRelaxed`/`closerFilterRelaxed` summary flags.

## Test plan
- [x] `npm test` — 249 tests pass; tightened existing assertions from `≤2 violations` to `toBe(0)` and added two fallback tests.
- [x] `npm run lint` — clean.
- [ ] Manual: mark a song "not a good opener", generate 10+ times, confirm it never appears first; repeat for closer; flag every song in a small catalog and confirm the warning toast appears.