### PR TITLE
Propagate die color to all app accent surfaces

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -10,7 +10,7 @@
     import { generateDieSvgString, updatePwaIcons } from "./lib/pwa-icon.js";
     import { createRemoteStorageRepository, isIosStandaloneAuthContext } from "./lib/remotestorage.js";
     import { createAppStore } from "./lib/stores/app.svelte.js";
-    import { DEFAULT_DIE_COLOR, hexToRgb } from "./lib/utils.js";
+    import { DEFAULT_DIE_COLOR, darkenHex, hexToRgb, hexToRgba } from "./lib/utils.js";
 
     const repo = createRemoteStorageRepository();
     const store = createAppStore(repo);
@@ -22,6 +22,7 @@
 
     let dieColor = $derived(store.appConfig?.ui?.dieColor || DEFAULT_DIE_COLOR);
     let dieColorRgb = $derived(hexToRgb(dieColor));
+    let customDieColor = $derived(store.appConfig?.ui?.dieColor || null);
 
     let faviconHref = $derived(
         `data:image/svg+xml,${encodeURIComponent(generateDieSvgString(dieColor))}`
@@ -29,6 +30,21 @@
 
     $effect(() => {
         void updatePwaIcons(dieColor).catch((e) => console.error("PWA icon update failed", e));
+    });
+
+    $effect(() => {
+        const root = document.documentElement;
+        if (customDieColor) {
+            root.style.setProperty("--accent", customDieColor);
+            root.style.setProperty("--accent-strong", darkenHex(customDieColor, 0.85));
+            root.style.setProperty("--accent-soft", hexToRgba(customDieColor, 0.12));
+            root.style.setProperty("--accent-line", hexToRgba(customDieColor, 0.24));
+        } else {
+            root.style.removeProperty("--accent");
+            root.style.removeProperty("--accent-strong");
+            root.style.removeProperty("--accent-soft");
+            root.style.removeProperty("--accent-line");
+        }
     });
 
     // iOS standalone PWA: after the sync-shell → app-shell DOM swap,

--- a/src/lib/components/band/BandScreen.svelte
+++ b/src/lib/components/band/BandScreen.svelte
@@ -685,7 +685,7 @@
     }
 
     .member-row:active {
-        background: rgba(225, 91, 55, 0.06);
+        background: var(--accent-soft);
     }
 
     .member-info {

--- a/src/lib/components/layout/BottomNav.svelte
+++ b/src/lib/components/layout/BottomNav.svelte
@@ -10,8 +10,6 @@
     { id: "band", label: "Band", icon: "\u2699" },
     { id: "help", label: "Help", icon: "?" },
   ];
-
-  let dieColor = $derived(store.appConfig?.ui?.dieColor || null);
 </script>
 
 <nav class="bottom-nav">
@@ -19,7 +17,6 @@
     <button type="button"
       class="tab"
       class:active={store.activeView === tab.id}
-      style={tab.id === "roll" && dieColor && store.activeView === "roll" ? `--tab-active: ${dieColor}` : ""}
       onclick={() => store.navigate(tab.id)}
     >
       <span class="tab-icon">{tab.icon}</span>
@@ -69,7 +66,7 @@
   }
 
   .tab.active {
-    color: var(--tab-active, var(--accent));
+    color: var(--accent);
   }
 
   .tab-icon {

--- a/src/lib/components/saved/SavedScreen.svelte
+++ b/src/lib/components/saved/SavedScreen.svelte
@@ -333,12 +333,12 @@
   }
 
   .saved-card:hover {
-    border-color: var(--accent, #e15b37);
-    box-shadow: 0 2px 8px rgba(225, 91, 55, 0.1);
+    border-color: var(--accent);
+    box-shadow: 0 2px 8px var(--accent-soft);
   }
 
   .saved-card:active {
-    background: rgba(225, 91, 55, 0.04);
+    background: var(--accent-soft);
   }
 
   .saved-top {
@@ -458,8 +458,8 @@
 
   .edit-input:focus {
     outline: none;
-    border-color: var(--accent, #e15b37);
-    box-shadow: 0 0 0 2px rgba(225, 91, 55, 0.12);
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px var(--accent-soft);
   }
 
   .edit-input.date {

--- a/src/lib/components/songs/SongsScreen.svelte
+++ b/src/lib/components/songs/SongsScreen.svelte
@@ -356,7 +356,7 @@
     }
 
     .song-row:active {
-        background: rgba(225, 91, 55, 0.06);
+        background: var(--accent-soft);
     }
 
     .song-top {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -133,6 +133,14 @@ export function hexToRgb(hex) {
     return `${parseHexChannel(hex, 1)}, ${parseHexChannel(hex, 3)}, ${parseHexChannel(hex, 5)}`;
 }
 
+export function hexToRgba(hex, alpha) {
+    if (typeof hex !== "string" || !/^#[0-9a-fA-F]{6}$/.test(hex)) {
+        return hexToRgba(DEFAULT_DIE_COLOR, alpha);
+    }
+    const a = Number.isFinite(alpha) ? Math.min(1, Math.max(0, alpha)) : 1;
+    return `rgba(${parseHexChannel(hex, 1)}, ${parseHexChannel(hex, 3)}, ${parseHexChannel(hex, 5)}, ${a})`;
+}
+
 export function darkenHex(hex, factor) {
     if (typeof hex !== "string" || !/^#[0-9a-fA-F]{6}$/.test(hex)) {
         return darkenHex(DEFAULT_DIE_COLOR, factor);


### PR DESCRIPTION
## Summary
- The band-selected die color now drives the \`--accent\`, \`--accent-strong\`, \`--accent-soft\`, and \`--accent-line\` CSS custom properties at the document root, so every accent surface (buttons, borders, focus rings, active-row highlights, stat numbers, etc.) re-tints together instead of only the roll button and roll-tab icon.
- A new \`hexToRgba\` utility joins \`hexToRgb\` / \`darkenHex\` and is used to derive the soft/line tints from the chosen hex.
- Replaced five hardcoded \`rgba(225, 91, 55, …)\` values in BandScreen, SongsScreen, and SavedScreen with \`var(--accent-soft)\` / \`var(--accent)\` so they follow the override; also removed the now-redundant \`--tab-active\` path in BottomNav.

## Test plan
- [ ] \`npm run dev\`, then on Band → Die color pick a distinctly different swatch (e.g. teal \`#14b8a6\`)
- [ ] Confirm instant re-tint on: roll button, roll-tab icon, stat numbers, secondary buttons, member/song row active states, saved-card hover border + shadow, edit-input focus ring
- [ ] Reset swatch → defaults return (check in both light and dark OS modes)
- [ ] \`npm run lint\` and \`npm test\` stay green