### PR TITLE
Fix stale roll state after rerolls and edits

### DIFF
--- a/src/lib/components/roll/RollScreen.svelte
+++ b/src/lib/components/roll/RollScreen.svelte
@@ -413,43 +413,44 @@
 
   <!-- Setlist result -->
   {#if store.generatedSetlist}
-    <section class="result-section">
-      <div class="song-list" bind:this={songListEl}>
-        {#each store.generatedSetlist.songs as song, i}
-          <div class="song-list-item" class:drag-over={dragIndex !== null && dragOverIndex === i && dragIndex !== i}>
-            <SetlistSongCard
-              {song}
-              index={i}
-              prevSong={i > 0 ? store.generatedSetlist.songs[i - 1] : null}
-              onDragStart={handleDragStart}
-              onEdit={handleEditSong}
-              onRemove={(idx) => store.removeSetlistSong(idx)}
-            />
-          </div>
-        {/each}
-      </div>
+    {#key store.setlistViewVersion}
+      <section class="result-section">
+        <div class="song-list" bind:this={songListEl}>
+          {#each store.generatedSetlist.songs as song, i (song.id)}
+            <div class="song-list-item" class:drag-over={dragIndex !== null && dragOverIndex === i && dragIndex !== i}>
+              <SetlistSongCard
+                {song}
+                index={i}
+                prevSong={i > 0 ? store.generatedSetlist.songs[i - 1] : null}
+                onDragStart={handleDragStart}
+                onEdit={handleEditSong}
+                onRemove={(idx) => store.removeSetlistSong(idx)}
+              />
+            </div>
+          {/each}
+        </div>
 
-      <div class="roadie-score">
-        <span class="roadie-label">Bass Player Anxiety</span>
-        <span class="roadie-val">{anxietyLevel.scaled}/10</span>
-        <p class="roadie-hint">{anxietyLevel.label}</p>
-      </div>
+        <div class="roadie-score">
+          <span class="roadie-label">Bass Player Anxiety</span>
+          <span class="roadie-val">{anxietyLevel.scaled}/10</span>
+          <p class="roadie-hint">{anxietyLevel.label}</p>
+        </div>
 
-      <div class="setlist-actions">
-        <button type="button" class="save-set-btn add-song-btn" onclick={() => { showAddSongPicker = true; }}>+ Add song</button>
-        {#if store.setlistLocked}
-          <div class="locked-badge">🔒 Locked in</div>
-          {#if store.setlistSaved}
-            <div class="saved-badge">✓ Saved</div>
+        <div class="setlist-actions">
+          <button type="button" class="save-set-btn add-song-btn" onclick={() => { showAddSongPicker = true; }}>+ Add song</button>
+          {#if store.setlistLocked}
+            <div class="locked-badge">🔒 Locked in</div>
+            {#if store.setlistSaved}
+              <div class="saved-badge">✓ Saved</div>
+            {:else}
+              <button type="button" class="save-set-btn secondary" onclick={handleSaveSetlist}>Save to Greatest Hits</button>
+            {/if}
           {:else}
-            <button type="button" class="save-set-btn secondary" onclick={handleSaveSetlist}>Save to Greatest Hits</button>
+            <button type="button" class="save-set-btn" onclick={handleLock}>Lock it in 🔒</button>
           {/if}
-        {:else}
-          <button type="button" class="save-set-btn" onclick={handleLock}>Lock it in 🔒</button>
-        {/if}
-      </div>
-
-    </section>
+        </div>
+      </section>
+    {/key}
   {/if}
 
   {#if store.pendingRollConfirm}

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -15,6 +15,41 @@ export function normalizeAuthToken(token) {
     return typeof token === "string" && token.length > 0 ? token : undefined;
 }
 
+export function syncSavedSongIntoSetlist(setlist, savedSong, appConfig, keyFlow = false) {
+    if (!setlist?.songs?.length || !savedSong?.id) return setlist;
+
+    let changed = false;
+    const syncedSongs = setlist.songs.map((song) => {
+        if (song.id !== savedSong.id) return song;
+
+        const nextSong = {
+            ...song,
+            name: savedSong.name,
+            cover: savedSong.cover || false,
+            instrumental: savedSong.instrumental || false,
+            key: savedSong.key || "",
+            notes: savedSong.notes || "",
+        };
+
+        if (
+            nextSong.name !== song.name ||
+            nextSong.cover !== song.cover ||
+            nextSong.instrumental !== song.instrumental ||
+            nextSong.key !== song.key ||
+            nextSong.notes !== song.notes
+        ) {
+            changed = true;
+        }
+
+        return nextSong;
+    });
+
+    if (!changed) return setlist;
+
+    const rescored = scoreFixedOrder(syncedSongs, appConfig || DEFAULT_APP_CONFIG, { keyFlow });
+    return { ...setlist, songs: rescored.songs, summary: rescored.summary };
+}
+
 export function createAppStore(repo) {
     // ---- per-user localStorage scoping ----
     let currentUserAddress = "";
@@ -25,6 +60,7 @@ export function createAppStore(repo) {
     let appConfig = $state(null);
     let bootstrapMeta = $state(null);
     let generatedSetlist = $state(null);
+    let setlistViewVersion = $state(0);
     let isGenerating = $state(false);
     let activeWorker = null;
     let generationId = 0;
@@ -230,6 +266,19 @@ export function createAppStore(repo) {
         localStorage.setItem(storageKey("ui-options"), JSON.stringify(generationOptions));
     }
 
+    function replaceGeneratedSetlist(nextSetlist) {
+        generatedSetlist = nextSetlist;
+        if (nextSetlist) setlistViewVersion += 1;
+    }
+
+    function updateCurrentSetlist(nextSetlist) {
+        generatedSetlist = nextSetlist;
+    }
+
+    function clearGeneratedSetlist() {
+        generatedSetlist = null;
+    }
+
     // Strip deprecated "energy" field and energy-related notes from saved setlist songs
     function stripEnergy(sets) {
         if (!Array.isArray(sets)) return sets;
@@ -287,7 +336,8 @@ export function createAppStore(repo) {
         clearUnscopedLocalStorage();
         const current = loadCurrentSetlist();
         const locked = current?._locked || false;
-        generatedSetlist = locked ? current : null;
+        if (locked) replaceGeneratedSetlist(current);
+        else clearGeneratedSetlist();
         setlistLocked = locked;
         setlistSaved = false;
         generationOptions = loadStoredGenerationOptions();
@@ -415,7 +465,7 @@ export function createAppStore(repo) {
         }
 
         // Clear transient state
-        generatedSetlist = null;
+        clearGeneratedSetlist();
         setlistLocked = false;
         setlistSaved = false;
         selectedSongId = "";
@@ -670,7 +720,7 @@ export function createAppStore(repo) {
                 ]), "danger");
                 return;
             }
-            generatedSetlist = result;
+            replaceGeneratedSetlist(result);
             if (opts._keepLock) {
                 setlistSaved = false;
             } else {
@@ -785,11 +835,11 @@ export function createAppStore(repo) {
     function loadSavedSetlist(id) {
         const saved = savedSetlists.find((s) => s.id === id);
         if (!saved) return;
-        generatedSetlist = {
+        replaceGeneratedSetlist({
             songs: clone(saved.songs),
             summary: clone(saved.summary),
             seed: saved.seed,
-        };
+        });
         setlistLocked = true;
         setlistSaved = true;
         persistCurrentSetlist();
@@ -802,7 +852,7 @@ export function createAppStore(repo) {
         const [moved] = songList.splice(fromIndex, 1);
         songList.splice(toIndex, 0, moved);
         const rescored = scoreFixedOrder(songList, appConfig, { keyFlow: generationOptions.keyFlow });
-        generatedSetlist = { ...generatedSetlist, songs: rescored.songs, summary: rescored.summary, _reordered: true };
+        updateCurrentSetlist({ ...generatedSetlist, songs: rescored.songs, summary: rescored.summary, _reordered: true });
         setlistSaved = false;
         persistCurrentSetlist();
     }
@@ -812,14 +862,14 @@ export function createAppStore(repo) {
         const songList = clone(generatedSetlist.songs);
         songList.splice(index, 1);
         if (!songList.length) {
-            generatedSetlist = null;
+            clearGeneratedSetlist();
             setlistLocked = false;
             setlistSaved = false;
             persistCurrentSetlist();
             return;
         }
         const rescored = scoreFixedOrder(songList, appConfig, { keyFlow: generationOptions.keyFlow });
-        generatedSetlist = { ...generatedSetlist, songs: rescored.songs, summary: rescored.summary };
+        updateCurrentSetlist({ ...generatedSetlist, songs: rescored.songs, summary: rescored.summary });
         setlistSaved = false;
         persistCurrentSetlist();
     }
@@ -847,7 +897,7 @@ export function createAppStore(repo) {
             contextNotes: [],
         });
         const rescored = scoreFixedOrder(songList, appConfig, { keyFlow: generationOptions.keyFlow });
-        generatedSetlist = { ...generatedSetlist, songs: rescored.songs, summary: rescored.summary };
+        updateCurrentSetlist({ ...generatedSetlist, songs: rescored.songs, summary: rescored.summary });
         setlistSaved = false;
         persistCurrentSetlist();
     }
@@ -1007,6 +1057,16 @@ export function createAppStore(repo) {
                 ...editorSong, updatedAt: nowIso()
             }));
             songs = songs.filter((s) => s.id !== saved.id).concat(saved).sort((a, b) => a.name.localeCompare(b.name));
+            const syncedSetlist = syncSavedSongIntoSetlist(
+                generatedSetlist,
+                saved,
+                appConfig,
+                generationOptions.keyFlow,
+            );
+            if (syncedSetlist !== generatedSetlist) {
+                updateCurrentSetlist(syncedSetlist);
+                persistCurrentSetlist();
+            }
 
             // Sync member names and instruments from the song into band members
             const dirtyMembers = new Map();
@@ -1104,7 +1164,7 @@ export function createAppStore(repo) {
             // Clear local state
             appConfig = null;
             songs = [];
-            generatedSetlist = null;
+            clearGeneratedSetlist();
             setlistLocked = false;
             setlistSaved = false;
             savedSetlists = [];
@@ -1702,7 +1762,7 @@ export function createAppStore(repo) {
             currentUserAddress = "";
             songs = [];
             appConfig = null;
-            generatedSetlist = null;
+            clearGeneratedSetlist();
             setlistLocked = false;
             setlistSaved = false;
             savedSetlists = [];
@@ -1757,6 +1817,7 @@ export function createAppStore(repo) {
         get appConfig() { return appConfig; },
         get bandMembers() { return bandMembers; },
         get generatedSetlist() { return generatedSetlist; },
+        get setlistViewVersion() { return setlistViewVersion; },
         get isGenerating() { return isGenerating; },
         get setlistLocked() { return setlistLocked; },
         get setlistSaved() { return setlistSaved; },

--- a/src/lib/stores/app.test.js
+++ b/src/lib/stores/app.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { normalizeAuthToken } from "./app.svelte.js";
+import { DEFAULT_APP_CONFIG } from "../defaults.js";
+import { normalizeAuthToken, syncSavedSongIntoSetlist } from "./app.svelte.js";
 
 describe("normalizeAuthToken", () => {
     it("keeps non-empty string tokens", () => {
@@ -11,5 +12,93 @@ describe("normalizeAuthToken", () => {
         expect(normalizeAuthToken({ type: "click" })).toBeUndefined();
         expect(normalizeAuthToken("")).toBeUndefined();
         expect(normalizeAuthToken(null)).toBeUndefined();
+    });
+});
+
+describe("syncSavedSongIntoSetlist", () => {
+    it("updates matching song metadata in the current setlist immediately", () => {
+        const setlist = {
+            seed: 42,
+            summary: { score: 999 },
+            songs: [
+                {
+                    id: "song-1",
+                    name: "Old Name",
+                    cover: false,
+                    instrumental: false,
+                    key: "C",
+                    notes: "old notes",
+                    performance: {
+                        nick: { instrument: "guitar", tuning: "Standard", capo: 0, picking: [] },
+                    },
+                },
+                {
+                    id: "song-2",
+                    name: "Keep Me",
+                    cover: false,
+                    instrumental: false,
+                    key: "G",
+                    notes: "",
+                    performance: {
+                        nick: { instrument: "guitar", tuning: "DADGAD", capo: 0, picking: [] },
+                    },
+                },
+            ],
+        };
+
+        const savedSong = {
+            id: "song-1",
+            name: "New Name",
+            cover: true,
+            instrumental: true,
+            key: "D",
+            notes: "new notes",
+        };
+
+        const result = syncSavedSongIntoSetlist(setlist, savedSong, DEFAULT_APP_CONFIG, false);
+
+        expect(result).not.toBe(setlist);
+        expect(result.songs[0]).toMatchObject({
+            id: "song-1",
+            name: "New Name",
+            cover: true,
+            instrumental: true,
+            key: "D",
+            notes: "new notes",
+        });
+        expect(result.songs[1]).toMatchObject({
+            id: "song-2",
+            name: "Keep Me",
+            key: "G",
+        });
+        expect(result.summary).toBeDefined();
+    });
+
+    it("returns the original setlist when the saved song is not present", () => {
+        const setlist = {
+            summary: { score: 1 },
+            songs: [
+                {
+                    id: "song-1",
+                    name: "Only Song",
+                    cover: false,
+                    instrumental: false,
+                    key: "C",
+                    notes: "",
+                    performance: {
+                        nick: { instrument: "guitar", tuning: "Standard", capo: 0, picking: [] },
+                    },
+                },
+            ],
+        };
+
+        const result = syncSavedSongIntoSetlist(
+            setlist,
+            { id: "song-2", name: "Different Song", notes: "no-op" },
+            DEFAULT_APP_CONFIG,
+            false,
+        );
+
+        expect(result).toBe(setlist);
     });
 });


### PR DESCRIPTION
Reset roll card state when a fresh setlist replaces the current one so rerolls and saved or rehydrated setlists no longer keep expanded edit menus open. Sync saved song metadata back into the active generated setlist so notes, key, name, and cover or instrumental changes appear immediately without rerolling. Add store tests covering the active-setlist sync behavior. Verified with npm test and npm run build.