### PR TITLE
fix(mobile): prevent iOS input zoom hiding save button

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -357,7 +357,7 @@
         border: 1px solid var(--line);
         background: var(--surface);
         color: var(--ink);
-        font-size: 0.95rem;
+        font-size: 1rem;
         transition: border-color 140ms ease, box-shadow 140ms ease;
     }
 

--- a/src/app.css
+++ b/src/app.css
@@ -130,6 +130,12 @@ textarea {
     color: inherit;
 }
 
+input,
+select,
+textarea {
+    font-size: 16px;
+}
+
 button {
     cursor: pointer;
     -webkit-tap-highlight-color: transparent;

--- a/src/lib/components/songs/SongEditor.svelte
+++ b/src/lib/components/songs/SongEditor.svelte
@@ -735,13 +735,13 @@
     }
 
     .field-input.small {
-        min-height: 2.2rem;
+        min-height: 2.4rem;
         padding: 0.4rem 0.7rem;
-        font-size: 0.85rem;
+        font-size: 1rem;
     }
 
     .add-sm-btn {
-        min-height: 2.2rem;
+        min-height: 2.4rem;
         padding: 0.4rem 0.75rem;
         border-radius: var(--radius-md, 12px);
         border: none;


### PR DESCRIPTION
## Summary

On iOS Safari, focusing any input with `font-size` under 16px triggers an auto-zoom, which was pushing the SongEditor save button off the right edge of the screen and leaving the whole app stuck zoomed after blur. Raised all form controls to a 16px baseline via a defensive global rule in `app.css`, plus explicit fixes on the two known offenders (`src/App.svelte` global input, `.field-input.small` in SongEditor), and bumped `.add-sm-btn` height to match the now-taller small field so the inline-add row stays aligned.

## Test plan

- [ ] On a real iPhone (or iOS Simulator), tap the connect-screen "remoteStorage address" input — no zoom
- [ ] Open SongEditor via "+ Add" and tap the title input — no zoom, Save button stays visible top-right
- [ ] Inside a member card, use the tuning inline-add input — no zoom
- [ ] Confirm app layout returns to normal after blur (no lingering zoom)