### PR TITLE
fix: reliable account swapping + extractable registry shape

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -87,7 +87,7 @@
                     {#each store.knownAccounts as account (account.address)}
                         <div class="recent-account">
                             <button class="recent-account-btn" onclick={() => store.connectToAccount(account.address)}>
-                                <span class="recent-band">{account.bandName || "Unnamed"}</span>
+                                <span class="recent-band">{account.metadata?.bandName || "Unnamed"}</span>
                                 <span class="recent-address">{account.address}</span>
                             </button>
                             <button class="recent-forget" onclick={() => store.forgetAccount(account.address)} aria-label="Forget account">&times;</button>

--- a/src/lib/accounts.js
+++ b/src/lib/accounts.js
@@ -4,7 +4,8 @@ const STORAGE_PREFIX = "setlist-roller";
 export const KNOWN_ACCOUNTS_KEY = `${STORAGE_PREFIX}-known-accounts`;
 
 /**
- * Scope a localStorage key per user address so accounts don't leak data.
+ * Hash a per-account suffix so app-owned localStorage keys (snapshots, UI
+ * options, etc.) don't leak between accounts.
  */
 export function scopedKey(base, userAddress) {
     if (!userAddress) return `${STORAGE_PREFIX}-${base}`;
@@ -15,31 +16,67 @@ export function scopedKey(base, userAddress) {
     return `${STORAGE_PREFIX}-${base}-${(h >>> 0).toString(36)}`;
 }
 
+/**
+ * Per-account namespace for app-owned local data. The registry doesn't read
+ * these slots — the app owns their schema. Keep the surface small so it
+ * survives a future extraction into a standalone library.
+ */
+export function accountSlot(address) {
+    return {
+        address,
+        key: (base) => scopedKey(base, address),
+    };
+}
+
+// Back-compat: legacy entries stored { bandName }; new entries store
+// { metadata: { bandName, ... } }. Normalize on read.
+function normalizeEntry(entry) {
+    if (!entry || typeof entry !== "object") return null;
+    if (entry.metadata && typeof entry.metadata === "object") return entry;
+    const { bandName, ...rest } = entry;
+    return { ...rest, metadata: bandName ? { bandName } : {} };
+}
+
+// Drop empty/nullish fields from incoming metadata so callers can pass
+// partial updates without clobbering existing values.
+function pruneMetadata(metadata) {
+    if (!metadata || typeof metadata !== "object") return {};
+    const result = {};
+    for (const [k, v] of Object.entries(metadata)) {
+        if (v !== "" && v !== null && v !== undefined) result[k] = v;
+    }
+    return result;
+}
+
 export function getKnownAccountsRaw() {
     if (typeof localStorage === "undefined") return [];
     try {
         const raw = localStorage.getItem(KNOWN_ACCOUNTS_KEY);
         const list = raw ? JSON.parse(raw) : [];
-        return list.sort((a, b) => (b.lastUsed || "").localeCompare(a.lastUsed || ""));
+        return list
+            .map(normalizeEntry)
+            .filter(Boolean)
+            .sort((a, b) => (b.lastUsed || "").localeCompare(a.lastUsed || ""));
     } catch {
         return [];
     }
 }
 
 export function getKnownAccounts() {
-    return getKnownAccountsRaw().map(({ address, bandName, lastUsed }) => ({ address, bandName, lastUsed }));
+    return getKnownAccountsRaw().map(({ address, metadata, lastUsed }) => ({ address, metadata, lastUsed }));
 }
 
-export function saveKnownAccount(address, bandName, token) {
+export function saveKnownAccount(address, metadata, token) {
     if (typeof localStorage === "undefined" || !address) return;
     const list = getKnownAccountsRaw();
+    const incoming = pruneMetadata(metadata);
     const existing = list.find((a) => a.address === address);
     if (existing) {
-        existing.bandName = bandName || existing.bandName;
+        existing.metadata = { ...existing.metadata, ...incoming };
         if (token) existing.token = token;
         existing.lastUsed = nowIso();
     } else {
-        list.push({ address, bandName: bandName || "", token: token || "", lastUsed: nowIso() });
+        list.push({ address, metadata: incoming, token: token || "", lastUsed: nowIso() });
     }
     localStorage.setItem(KNOWN_ACCOUNTS_KEY, JSON.stringify(list));
 }

--- a/src/lib/accounts.test.js
+++ b/src/lib/accounts.test.js
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+    accountSlot,
     getAccountToken,
     getKnownAccounts,
     getKnownAccountsRaw,
@@ -34,7 +35,7 @@ afterEach(() => {
 });
 
 // ===================================================================
-// scopedKey
+// scopedKey / accountSlot
 // ===================================================================
 describe("scopedKey", () => {
     it("returns unscoped key when no user address", () => {
@@ -66,63 +67,80 @@ describe("scopedKey", () => {
     });
 });
 
+describe("accountSlot", () => {
+    it("derives the same key as scopedKey for the same address", () => {
+        const slot = accountSlot("alice@example.com");
+        expect(slot.address).toBe("alice@example.com");
+        expect(slot.key("snapshot")).toBe(scopedKey("snapshot", "alice@example.com"));
+    });
+
+    it("isolates keys between accounts", () => {
+        expect(accountSlot("a@x").key("snapshot")).not.toBe(accountSlot("b@x").key("snapshot"));
+    });
+});
+
 // ===================================================================
 // saveKnownAccount / getKnownAccounts / getKnownAccountsRaw
 // ===================================================================
 describe("saveKnownAccount", () => {
-    it("adds a new account", () => {
-        saveKnownAccount("alice@example.com", "The Band", "tok_alice");
+    it("adds a new account with metadata", () => {
+        saveKnownAccount("alice@example.com", { bandName: "The Band" }, "tok_alice");
         const raw = getKnownAccountsRaw();
         expect(raw).toHaveLength(1);
         expect(raw[0]).toMatchObject({
             address: "alice@example.com",
-            bandName: "The Band",
+            metadata: { bandName: "The Band" },
             token: "tok_alice",
             lastUsed: "2026-04-09T12:00:00.000Z",
         });
     });
 
-    it("upserts an existing account", () => {
-        saveKnownAccount("alice@example.com", "Old Name", "tok_1");
-        saveKnownAccount("alice@example.com", "New Name", "tok_2");
+    it("merges metadata on upsert without dropping existing fields", () => {
+        saveKnownAccount("alice@example.com", { bandName: "Old Name", color: "red" }, "tok_1");
+        saveKnownAccount("alice@example.com", { bandName: "New Name" }, "tok_2");
         const raw = getKnownAccountsRaw();
         expect(raw).toHaveLength(1);
-        expect(raw[0].bandName).toBe("New Name");
+        expect(raw[0].metadata).toEqual({ bandName: "New Name", color: "red" });
         expect(raw[0].token).toBe("tok_2");
     });
 
-    it("keeps existing bandName when new one is empty", () => {
-        saveKnownAccount("alice@example.com", "The Band", "tok_1");
-        saveKnownAccount("alice@example.com", "", "tok_2");
-        expect(getKnownAccountsRaw()[0].bandName).toBe("The Band");
+    it("ignores empty/nullish incoming metadata fields", () => {
+        saveKnownAccount("alice@example.com", { bandName: "The Band" }, "tok_1");
+        saveKnownAccount("alice@example.com", { bandName: "" }, "tok_2");
+        expect(getKnownAccountsRaw()[0].metadata.bandName).toBe("The Band");
     });
 
     it("keeps existing token when new one is falsy", () => {
-        saveKnownAccount("alice@example.com", "Band", "tok_1");
-        saveKnownAccount("alice@example.com", "Band", "");
+        saveKnownAccount("alice@example.com", { bandName: "Band" }, "tok_1");
+        saveKnownAccount("alice@example.com", { bandName: "Band" }, "");
         expect(getKnownAccountsRaw()[0].token).toBe("tok_1");
     });
 
     it("does nothing for empty address", () => {
-        saveKnownAccount("", "Band", "tok");
+        saveKnownAccount("", { bandName: "Band" }, "tok");
         expect(getKnownAccountsRaw()).toHaveLength(0);
     });
 
     it("stores multiple accounts", () => {
-        saveKnownAccount("alice@example.com", "Band A", "tok_a");
-        saveKnownAccount("bob@example.com", "Band B", "tok_b");
+        saveKnownAccount("alice@example.com", { bandName: "Band A" }, "tok_a");
+        saveKnownAccount("bob@example.com", { bandName: "Band B" }, "tok_b");
         expect(getKnownAccountsRaw()).toHaveLength(2);
+    });
+
+    it("tolerates undefined metadata", () => {
+        saveKnownAccount("alice@example.com", undefined, "tok_a");
+        expect(getKnownAccountsRaw()[0].metadata).toEqual({});
     });
 });
 
 describe("getKnownAccounts", () => {
     it("strips tokens from the returned list", () => {
-        saveKnownAccount("alice@example.com", "Band", "secret_token");
+        saveKnownAccount("alice@example.com", { bandName: "Band" }, "secret_token");
         const accounts = getKnownAccounts();
         expect(accounts).toHaveLength(1);
         expect(accounts[0]).toEqual({
             address: "alice@example.com",
-            bandName: "Band",
+            metadata: { bandName: "Band" },
             lastUsed: "2026-04-09T12:00:00.000Z",
         });
         expect(accounts[0]).not.toHaveProperty("token");
@@ -139,12 +157,28 @@ describe("getKnownAccounts", () => {
 
     it("sorts by lastUsed descending", () => {
         store[KNOWN_ACCOUNTS_KEY] = JSON.stringify([
-            { address: "old@x.com", bandName: "Old", lastUsed: "2026-01-01T00:00:00.000Z" },
-            { address: "new@x.com", bandName: "New", lastUsed: "2026-04-01T00:00:00.000Z" },
+            { address: "old@x.com", metadata: { bandName: "Old" }, lastUsed: "2026-01-01T00:00:00.000Z" },
+            { address: "new@x.com", metadata: { bandName: "New" }, lastUsed: "2026-04-01T00:00:00.000Z" },
         ]);
         const accounts = getKnownAccounts();
         expect(accounts[0].address).toBe("new@x.com");
         expect(accounts[1].address).toBe("old@x.com");
+    });
+
+    it("migrates legacy { bandName } entries to { metadata: { bandName } }", () => {
+        store[KNOWN_ACCOUNTS_KEY] = JSON.stringify([
+            { address: "legacy@x.com", bandName: "Legacy Band", token: "tok", lastUsed: "2026-01-01T00:00:00.000Z" },
+        ]);
+        const [account] = getKnownAccounts();
+        expect(account.metadata).toEqual({ bandName: "Legacy Band" });
+    });
+
+    it("migrates legacy entries that have no bandName to empty metadata", () => {
+        store[KNOWN_ACCOUNTS_KEY] = JSON.stringify([
+            { address: "legacy@x.com", token: "tok", lastUsed: "2026-01-01T00:00:00.000Z" },
+        ]);
+        const [account] = getKnownAccounts();
+        expect(account.metadata).toEqual({});
     });
 });
 
@@ -153,7 +187,7 @@ describe("getKnownAccounts", () => {
 // ===================================================================
 describe("getAccountToken", () => {
     it("returns token for a known account", () => {
-        saveKnownAccount("alice@example.com", "Band", "tok_alice");
+        saveKnownAccount("alice@example.com", { bandName: "Band" }, "tok_alice");
         expect(getAccountToken("alice@example.com")).toBe("tok_alice");
     });
 
@@ -164,6 +198,13 @@ describe("getAccountToken", () => {
     it("returns empty string when no accounts exist", () => {
         expect(getAccountToken("anyone@example.com")).toBe("");
     });
+
+    it("reads tokens from migrated legacy entries", () => {
+        store[KNOWN_ACCOUNTS_KEY] = JSON.stringify([
+            { address: "legacy@x.com", bandName: "Legacy", token: "legacy_tok", lastUsed: "2026-01-01T00:00:00.000Z" },
+        ]);
+        expect(getAccountToken("legacy@x.com")).toBe("legacy_tok");
+    });
 });
 
 // ===================================================================
@@ -171,8 +212,8 @@ describe("getAccountToken", () => {
 // ===================================================================
 describe("removeKnownAccountEntry", () => {
     it("removes the specified account", () => {
-        saveKnownAccount("alice@example.com", "Band A", "tok_a");
-        saveKnownAccount("bob@example.com", "Band B", "tok_b");
+        saveKnownAccount("alice@example.com", { bandName: "Band A" }, "tok_a");
+        saveKnownAccount("bob@example.com", { bandName: "Band B" }, "tok_b");
         removeKnownAccountEntry("alice@example.com");
         const accounts = getKnownAccountsRaw();
         expect(accounts).toHaveLength(1);
@@ -180,19 +221,19 @@ describe("removeKnownAccountEntry", () => {
     });
 
     it("does nothing for unknown address", () => {
-        saveKnownAccount("alice@example.com", "Band A", "tok_a");
+        saveKnownAccount("alice@example.com", { bandName: "Band A" }, "tok_a");
         removeKnownAccountEntry("unknown@example.com");
         expect(getKnownAccountsRaw()).toHaveLength(1);
     });
 
     it("does nothing for empty address", () => {
-        saveKnownAccount("alice@example.com", "Band A", "tok_a");
+        saveKnownAccount("alice@example.com", { bandName: "Band A" }, "tok_a");
         removeKnownAccountEntry("");
         expect(getKnownAccountsRaw()).toHaveLength(1);
     });
 
     it("handles removing the last account", () => {
-        saveKnownAccount("alice@example.com", "Band A", "tok_a");
+        saveKnownAccount("alice@example.com", { bandName: "Band A" }, "tok_a");
         removeKnownAccountEntry("alice@example.com");
         expect(getKnownAccountsRaw()).toEqual([]);
     });

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -59,7 +59,7 @@
             <div class="dropdown-current">
               <span class="active-dot"></span>
               <div class="current-info">
-                <span class="current-band">{currentAccount.bandName || "Unnamed"}</span>
+                <span class="current-band">{currentAccount.metadata?.bandName || "Unnamed"}</span>
                 <span class="current-addr">{currentAccount.address}</span>
               </div>
             </div>
@@ -70,7 +70,7 @@
             <span class="dropdown-label">Switch to</span>
             {#each otherAccounts as account (account.address)}
               <button type="button" class="dropdown-item dropdown-item--account" onclick={() => handleSwitchTo(account.address)}>
-                <span class="account-band">{account.bandName || "Unnamed"}</span>
+                <span class="account-band">{account.metadata?.bandName || "Unnamed"}</span>
                 <span class="account-addr">{account.address}</span>
               </button>
             {/each}

--- a/src/lib/remotestorage.js
+++ b/src/lib/remotestorage.js
@@ -278,14 +278,26 @@ export function createRemoteStorageRepository() {
         },
 
         /**
-         * Switch to a different account without destroying IndexedDB.
-         * Works like a page refresh — just reconfigures credentials and reconnects.
+         * Switch to a different account: disconnect cleanly, reset the local
+         * cache so the previous account's data can't leak, then connect.
+         * Resolves once `connect()` has been issued — callers should still
+         * wait for the `connected` event for sync.
+         *
+         * Avoids mutating rs.js internals; relies on the documented
+         * disconnect → connect lifecycle.
          */
-        switchTo(userAddress, token) {
-            // Clear current connection without full disconnect cleanup
-            remoteStorage.remote.configure({ token: null });
-            remoteStorage.remote.connected = false;
-            // Re-enable caching and connect to new account
+        async swap(userAddress, token) {
+            if (remoteStorage.connected) {
+                await new Promise((resolve) => {
+                    const handler = () => {
+                        remoteStorage.removeEventListener("disconnected", handler);
+                        resolve();
+                    };
+                    remoteStorage.on("disconnected", handler);
+                    remoteStorage.caching.reset();
+                    remoteStorage.disconnect();
+                });
+            }
             remoteStorage.caching.enable(`/${APP_SCOPE}/`);
             remoteStorage.connect(userAddress, normalizeBearerToken(token));
         },

--- a/src/lib/remotestorage.test.js
+++ b/src/lib/remotestorage.test.js
@@ -490,30 +490,87 @@ describe("createRemoteStorageRepository", () => {
         expect(remoteStorageMockState.instance.connect).toHaveBeenCalledWith("user@example.com", undefined);
     });
 
-    it("switches accounts in standalone mode without pre-opening a popup", () => {
-        globalThis.window = {
-            matchMedia: vi.fn(() => ({ matches: true })),
-            navigator: {
-                standalone: true,
-                userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)",
-                platform: "iPhone",
-                maxTouchPoints: 5,
-            },
-            location: { origin: "https://app.example.com", pathname: "/", hash: "" },
-            open: vi.fn(() => null),
-            addEventListener: vi.fn(),
-            removeEventListener: vi.fn(),
-            setInterval: vi.fn(),
-            clearInterval: vi.fn(),
-            setTimeout: vi.fn(),
-            clearTimeout: vi.fn(),
-        };
+    describe("swap", () => {
+        it("connects directly when no prior connection exists", async () => {
+            const repo = createRemoteStorageRepository();
+            const rs = remoteStorageMockState.instance;
+            rs.connected = false;
 
-        const repo = createRemoteStorageRepository();
-        repo.switchTo("other@example.com");
+            await repo.swap("other@example.com", "tok-2");
 
-        expect(globalThis.window.open).not.toHaveBeenCalled();
-        expect(remoteStorageMockState.instance.remote.configure).toHaveBeenCalledWith({ token: null });
-        expect(remoteStorageMockState.instance.connect).toHaveBeenCalledWith("other@example.com", undefined);
+            expect(rs.disconnect).not.toHaveBeenCalled();
+            expect(rs.caching.reset).not.toHaveBeenCalled();
+            expect(rs.caching.enable).toHaveBeenCalledWith("/setlist-roller/");
+            expect(rs.connect).toHaveBeenCalledWith("other@example.com", "tok-2");
+        });
+
+        it("disconnects, resets the cache, then connects when a prior connection exists", async () => {
+            const repo = createRemoteStorageRepository();
+            const rs = remoteStorageMockState.instance;
+            rs.connected = true;
+
+            // Capture the order of operations so we can assert disconnect →
+            // resetCache → connect happens in sequence (no library-internal
+            // mutations slipped in between).
+            const order = [];
+            rs.caching.reset.mockImplementation(() => order.push("reset"));
+            rs.disconnect.mockImplementation(() => order.push("disconnect"));
+            rs.connect.mockImplementation(() => order.push("connect"));
+
+            // Capture the `disconnected` listener so we can fire it.
+            let disconnectedHandler;
+            rs.on.mockImplementation((event, handler) => {
+                if (event === "disconnected") disconnectedHandler = handler;
+            });
+
+            const swapPromise = repo.swap("other@example.com", "tok-2");
+
+            // swap() registers the listener and triggers disconnect(), but
+            // doesn't proceed to connect() until `disconnected` fires.
+            expect(rs.on).toHaveBeenCalledWith("disconnected", expect.any(Function));
+            expect(disconnectedHandler).toBeTypeOf("function");
+            expect(rs.connect).not.toHaveBeenCalled();
+
+            disconnectedHandler();
+            await swapPromise;
+
+            expect(rs.removeEventListener).toHaveBeenCalledWith("disconnected", disconnectedHandler);
+            expect(order).toEqual(["reset", "disconnect", "connect"]);
+            expect(rs.caching.enable).toHaveBeenLastCalledWith("/setlist-roller/");
+            expect(rs.connect).toHaveBeenCalledWith("other@example.com", "tok-2");
+        });
+
+        it("does not mutate the rs.js `remote.connected` flag", async () => {
+            const repo = createRemoteStorageRepository();
+            const rs = remoteStorageMockState.instance;
+            rs.connected = true;
+
+            // Make `remote.connected` a getter so any assignment would throw.
+            const guard = vi.fn();
+            Object.defineProperty(rs.remote, "connected", {
+                configurable: true,
+                get: () => true,
+                set: guard,
+            });
+
+            let disconnectedHandler;
+            rs.on.mockImplementation((event, handler) => {
+                if (event === "disconnected") disconnectedHandler = handler;
+            });
+
+            const swapPromise = repo.swap("other@example.com", "tok-2");
+            disconnectedHandler();
+            await swapPromise;
+
+            expect(guard).not.toHaveBeenCalled();
+        });
+
+        it("normalizes non-string tokens to undefined", async () => {
+            const repo = createRemoteStorageRepository();
+            const rs = remoteStorageMockState.instance;
+            rs.connected = false;
+            await repo.swap("other@example.com", { type: "click" });
+            expect(rs.connect).toHaveBeenCalledWith("other@example.com", undefined);
+        });
     });
 });

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -481,14 +481,14 @@ export function createAppStore(repo) {
                 setlists: clone(savedSetlists),
                 members: clone(bandMembers),
             };
-            localStorage.setItem(scopedKey("snapshot", currentUserAddress), JSON.stringify(data));
+            localStorage.setItem(accountSlot(currentUserAddress).key("snapshot"), JSON.stringify(data));
         } catch { /* localStorage full — not critical */ }
     }
 
     function restoreSnapshot(address) {
         if (typeof localStorage === "undefined") return false;
         try {
-            const raw = localStorage.getItem(scopedKey("snapshot", address));
+            const raw = localStorage.getItem(accountSlot(address).key("snapshot"));
             if (!raw) return false;
             const data = JSON.parse(raw);
             if (!data.config) return false;

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -1,4 +1,4 @@
-import { getAccountToken, getKnownAccounts, removeKnownAccountEntry, saveKnownAccount, scopedKey } from "../accounts.js";
+import { accountSlot, getAccountToken, getKnownAccounts, removeKnownAccountEntry, saveKnownAccount } from "../accounts.js";
 import { CONFIG_SECTIONS } from "../config-meta.js";
 import { blankSong, DEFAULT_APP_CONFIG, normalizeAppConfig, normalizeMemberRecord, normalizeSongRecord } from "../defaults.js";
 import { buildDefaultPerformance, scoreFixedOrder } from "../generator.js";
@@ -17,7 +17,15 @@ export function normalizeAuthToken(token) {
 export function createAppStore(repo) {
     // ---- per-user localStorage scoping ----
     let currentUserAddress = "";
-    function storageKey(base) { return scopedKey(base, currentUserAddress); }
+    function storageKey(base) { return accountSlot(currentUserAddress).key(base); }
+
+    // Monotonic session id — bumped on every connect/swap. Async work that
+    // started under one session is discarded if the session has moved on.
+    let activeSession = 0;
+
+    // True while orchestrating an account swap; tells the global disconnected
+    // handler to skip its full state-wipe (we want the snapshot to stay).
+    let isSwitching = false;
 
     // ---- core state ----
     let songs = $state([]);
@@ -370,23 +378,36 @@ export function createAppStore(repo) {
     function disconnectStorage() {
         // Save current token before disconnecting so we can switch back later
         if (currentUserAddress) {
-            saveKnownAccount(currentUserAddress, appConfig?.bandName || "", repo.getToken());
+            saveKnownAccount(currentUserAddress, { bandName: appConfig?.bandName || "" }, repo.getToken());
         }
         repo.disconnect();
     }
 
-    function connectToAccount(address) {
+    async function connectToAccount(address) {
+        // Refuse if a connect/swap is already in flight — clicking switch
+        // mid-discovery used to take the wrong branch and double-connect.
+        if (connectionStatus === "connecting" || isSwitching) {
+            addToast("Already connecting — hold on.", "warning");
+            return;
+        }
+        if (!address) return;
+
         const savedToken = normalizeAuthToken(getAccountToken(address));
 
-        // 1. Save current account's data before touching state
+        // 1. Persist the current account before touching state.
         if (repo.isConnected()) {
             saveSnapshot();
             if (currentUserAddress) {
-                saveKnownAccount(currentUserAddress, appConfig?.bandName || "", repo.getToken());
+                saveKnownAccount(currentUserAddress, { bandName: appConfig?.bandName || "" }, repo.getToken());
             }
         }
 
-        // 2. Restore the target account's cached data (if any)
+        // 2. Bump the session — any in-flight async (reloadAll, worker
+        //    callbacks) from the previous account is now stale.
+        activeSession += 1;
+
+        // 3. Restore the target account's snapshot for instant UI; otherwise
+        //    blank the visible state until the connected/sync handlers fill it.
         const hasSnapshot = restoreSnapshot(address);
         if (hasSnapshot) {
             currentUserAddress = address;
@@ -394,12 +415,12 @@ export function createAppStore(repo) {
             loadUserLocalData();
             initialSyncComplete = true;
         } else {
-            // No snapshot — reset state; sync indicator shown by connected handler
             songs = [];
             appConfig = null;
             savedSetlists = [];
             bandMembers = {};
             initialSyncComplete = false;
+            currentUserAddress = "";
             connectAddress = address;
         }
 
@@ -410,22 +431,35 @@ export function createAppStore(repo) {
         selectedSongId = "";
         editorSong = null;
 
-        // 3. Switch rs.js to new account without destroying IndexedDB
         clearSyncLog();
         connectionStatus = "connecting";
         syncStatusLabel = "Switching accounts";
         pushSyncLog(`Switching to ${address}`);
-        if (repo.isConnected()) {
-            repo.switchTo(address, savedToken);
-        } else {
-            connectStorage(savedToken);
+
+        // 4. Swap the rs.js connection. `swap()` disconnects cleanly (which
+        //    fires `disconnected`; the global handler skips its wipe because
+        //    isSwitching is true) and resets the cache before reconnecting.
+        isSwitching = true;
+        try {
+            if (repo.isConnected()) {
+                await repo.swap(address, savedToken);
+            } else {
+                // Not connected — straight connect, no swap dance needed.
+                connectAddress = address;
+                connectStorage(savedToken);
+            }
+        } catch (error) {
+            addToast(error?.message || "Could not switch accounts.", "danger");
+            connectionStatus = "disconnected";
+        } finally {
+            isSwitching = false;
         }
     }
 
     function forgetAccount(address) {
         removeKnownAccountEntry(address);
         if (typeof localStorage !== "undefined") {
-            localStorage.removeItem(scopedKey("snapshot", address));
+            localStorage.removeItem(accountSlot(address).key("snapshot"));
         }
         knownAccounts = getKnownAccounts();
     }
@@ -474,7 +508,7 @@ export function createAppStore(repo) {
     }
 
     // ---- data loading ----
-    async function reloadAll({ quiet = false } = {}) {
+    async function reloadAll({ quiet = false, session = activeSession } = {}) {
         try {
             busyMessage = quiet ? "" : "Loading your songs...";
             loadError = "";
@@ -484,6 +518,11 @@ export function createAppStore(repo) {
                     pushSyncLog(message);
                 },
             });
+            // Guard against stale results landing after an account swap.
+            if (session !== activeSession) {
+                pushSyncLog("Discarded stale load (account swapped)");
+                return;
+            }
             songs = data.songs.map(normalizeSongRecord);
             bootstrapMeta = data.bootstrap;
             appConfig = data.config ? normalizeAppConfig(data.config) : null;
@@ -1139,7 +1178,7 @@ export function createAppStore(repo) {
             generationOptions = deepMerge(defaultGenerationOptions(appConfig), generationOptions);
             persistGenerationOptions();
             if (currentUserAddress && appConfig?.bandName) {
-                saveKnownAccount(currentUserAddress, appConfig.bandName, repo.getToken());
+                saveKnownAccount(currentUserAddress, { bandName: appConfig.bandName }, repo.getToken());
                 knownAccounts = getKnownAccounts();
             }
             addToast("Settings saved.");
@@ -1641,6 +1680,9 @@ export function createAppStore(repo) {
 
         const detachConnected = repo.on("connected", async () => {
             clearTimeout(safetyTimer);
+            // Each connect starts a fresh session so prior async work is
+            // discarded even on a plain (non-swap) reconnect.
+            activeSession += 1;
             connectionStatus = "connected";
             connectAddress = repo.getUserAddress() || connectAddress;
             currentUserAddress = connectAddress;
@@ -1672,11 +1714,18 @@ export function createAppStore(repo) {
                     endSync();
                 }
             }
-            saveKnownAccount(currentUserAddress, appConfig?.bandName || "", repo.getToken());
+            saveKnownAccount(currentUserAddress, { bandName: appConfig?.bandName || "" }, repo.getToken());
             knownAccounts = getKnownAccounts();
         });
 
         const detachDisconnected = repo.on("disconnected", () => {
+            // Mid-swap, the disconnected event is just an intermediate step.
+            // Don't wipe state — the snapshot we restored stays visible until
+            // the next `connected` event fills in real data.
+            if (isSwitching) {
+                pushSyncLog("Disconnected (switching accounts)");
+                return;
+            }
             terminateWorker();
             isGenerating = false;
             connectionStatus = "disconnected";
@@ -1701,17 +1750,24 @@ export function createAppStore(repo) {
             loadError = error?.message || "remoteStorage error.";
             addToast(loadError, "danger");
             pushSyncLog(loadError);
-            // Fully disconnect so the RS instance resets its auth state,
-            // allowing the user to reconnect from the login screen.
-            repo.disconnect();
+            // Only nuke the session for auth/discovery failures. SyncError and
+            // friends are typically transient (flaky network, 5xx) — let rs.js
+            // retry instead of dropping the user back to the login screen.
+            const fatal = error?.name === "Unauthorized" || error?.name === "DiscoveryError";
+            if (fatal) {
+                repo.disconnect();
+            }
         });
 
         const detachChange = repo.onChange(async (event) => {
-            if (connectionStatus === "connected" && event?.origin !== "window") {
-                beginSync(event?.origin === "remote" ? "Pulling remote changes" : "Syncing");
-                try { await reloadAll({ quiet: true }); }
-                finally { endSync(); }
-            }
+            if (connectionStatus !== "connected" || event?.origin === "window") return;
+            // Pin the session at the moment the event fired. If the user
+            // swaps accounts mid-reload, the awaited reloadAll() returns
+            // into a different session and we drop its results.
+            const session = activeSession;
+            beginSync(event?.origin === "remote" ? "Pulling remote changes" : "Syncing");
+            try { await reloadAll({ quiet: true, session }); }
+            finally { endSync(); }
         });
 
         return () => {


### PR DESCRIPTION
## Summary

- Replace `switchTo` (which mutated rs.js internals) with `swap`, using the documented disconnect → cache-reset → connect lifecycle. No more leaking the previous account's data through the shared IndexedDB cache.
- Add a session-id guard so async `reloadAll` results from the prior account can't overwrite the new account's UI after a swap.
- Stop nuking the session on every error. `repo.disconnect()` only fires for `Unauthorized` / `DiscoveryError`; transient sync errors are surfaced but rs.js gets to retry.
- Gate `connectToAccount` on `connectionStatus` so clicking switch mid-discovery can't double-connect.
- Refactor `accounts.js` from flat `{ bandName }` to opaque `{ metadata }` with read-time migration. Add `accountSlot(address).key(base)` so snapshot key derivation goes through a small interface — gives a clean seam for a future `remotestoragejs-multiuser` extraction without committing to one now.

## Why

Recent fixes (1.6.4–1.6.7) were chasing symptoms of the same root cause: account switching reached into rs.js library state directly and skipped the cache reset, so the second account briefly inherited the first account's data and any transient error tore the whole session down.

## Test plan

- [x] `npm test` — 246 passing (9 new: 6 around `accounts` metadata + migration + `accountSlot`, 3 around `swap` lifecycle order)
- [x] `npm run build` clean
- [x] `npm run lint` clean
- [ ] Manual: connect to account A → add a song → switch to account B → confirm no song A data appears → switch back → confirm song A's data is intact
- [ ] Manual: trigger a transient sync error (offline mid-sync) — confirm the user is **not** kicked back to the login screen
- [ ] Manual: click switch repeatedly while a connect is in flight — confirm it doesn't double-fire
- [ ] Manual: legacy users (with `{ bandName }` localStorage) — confirm their account list still renders the band name

## Not included (flag if wanted)

- End-to-end Playwright run with a fake remoteStorage server to make the cache-leak scenario a regression test
- Rune-store unit tests for `connectToAccount` orchestration (needs `@testing-library/svelte` setup)
- Upstream rs.js issue/PR proposing first-class user scoping (`caching.reset()` as a documented account-switch primitive, optional per-user DB names)