### PR TITLE
fix: review findings #41-50, #69, and post-swap sync regression

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -26,9 +26,6 @@
     --line-strong: rgba(27, 49, 80, 0.2);
     --success: #1f8f61;
     --danger: #992f20;
-    /* Fixed blue for the sync indicator — must NOT track `--accent`, since
-       a band-themed accent could collide with `--success` (green) and make
-       "syncing" indistinguishable from "up to date". */
     --sync: #3a6df0;
 
     /* Semantic */

--- a/src/app.css
+++ b/src/app.css
@@ -26,6 +26,10 @@
     --line-strong: rgba(27, 49, 80, 0.2);
     --success: #1f8f61;
     --danger: #992f20;
+    /* Fixed blue for the sync indicator — must NOT track `--accent`, since
+       a band-themed accent could collide with `--success` (green) and make
+       "syncing" indistinguishable from "up to date". */
+    --sync: #3a6df0;
 
     /* Semantic */
     --surface: rgba(255, 255, 255, 0.92);
@@ -87,6 +91,7 @@
     --line-strong: rgba(200, 215, 240, 0.18);
     --success: #34b87a;
     --danger: #e05545;
+    --sync: #7da0ff;
 
     --surface: rgba(38, 43, 54, 0.92);
     --overlay: rgba(0, 0, 0, 0.5);

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -42,8 +42,28 @@
 
 <header class="top-bar">
   <div class="title-group">
-    <span class="conn-dot" class:connected={store.connectionStatus === 'connected'} class:syncing={store.syncActivelyRunning}></span>
+    <span
+      class="conn-dot"
+      class:connected={store.connectionStatus === 'connected'}
+      class:syncing={store.syncActivelyRunning || store.syncState === 'syncing'}
+      class:errored={store.syncState === 'error'}
+    ></span>
     <span class="band-name">{store.appTitle}</span>
+    {#if store.syncState === 'syncing'}
+      <span class="sync-pill" role="status" aria-live="polite" title={store.syncStatusLabel}>
+        <span class="sync-pill-spinner" aria-hidden="true"></span>
+        <span class="sync-pill-label">Syncing…</span>
+      </span>
+    {:else if store.syncState === 'synced'}
+      <span class="sync-pill sync-pill--ok" role="status" aria-live="polite">
+        <span class="sync-pill-check" aria-hidden="true">✓</span>
+        <span class="sync-pill-label">Up to date</span>
+      </span>
+    {:else if store.syncState === 'error'}
+      <span class="sync-pill sync-pill--err" role="status" aria-live="polite" title={store.syncStatusLabel}>
+        <span class="sync-pill-label">Sync failed</span>
+      </span>
+    {/if}
   </div>
 
   <div class="right">
@@ -136,9 +156,81 @@
     animation: dot-pulse 1s ease-in-out infinite;
   }
 
+  .conn-dot.errored {
+    background: var(--danger, #d44);
+    box-shadow: 0 0 6px color-mix(in srgb, var(--danger, #d44) 40%, transparent);
+  }
+
   @keyframes dot-pulse {
     0%, 100% { opacity: 1; transform: scale(1); }
     50% { opacity: 0.5; transform: scale(1.4); }
+  }
+
+  .sync-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+    color: var(--accent);
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1;
+    white-space: nowrap;
+    flex-shrink: 0;
+    animation: pill-fade-in 200ms ease-out both;
+  }
+
+  .sync-pill--ok {
+    background: color-mix(in srgb, var(--success) 14%, transparent);
+    color: var(--success);
+  }
+
+  .sync-pill--err {
+    background: color-mix(in srgb, var(--danger, #d44) 14%, transparent);
+    color: var(--danger, #d44);
+  }
+
+  .sync-pill-spinner {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    border: 1.5px solid currentColor;
+    border-top-color: transparent;
+    animation: pill-spin 700ms linear infinite;
+  }
+
+  .sync-pill-check {
+    font-size: 12px;
+    font-weight: 800;
+    line-height: 1;
+  }
+
+  .sync-pill-label {
+    letter-spacing: 0.02em;
+  }
+
+  /* Hide the verbose label on very narrow screens — the dot + spinner still
+     communicate state. */
+  @media (max-width: 360px) {
+    .sync-pill-label { display: none; }
+    .sync-pill { padding: 4px; }
+  }
+
+  @keyframes pill-spin {
+    to { transform: rotate(360deg); }
+  }
+
+  @keyframes pill-fade-in {
+    from { opacity: 0; transform: translateY(-2px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .sync-pill-spinner { animation-duration: 1.4s; }
+    .sync-pill { animation: none; }
+    .conn-dot.syncing { animation: none; }
   }
 
   .band-name {

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -23,6 +23,18 @@
     store.knownAccounts.filter((a) => a.address !== store.connectAddress)
   );
 
+  // Single screen-reader/tooltip label for the sync dot. Mirrors the dot's
+  // visual state so screen readers announce transitions and power users can
+  // hover for the underlying syncStatusLabel from rs.js.
+  let dotLabel = $derived.by(() => {
+    if (store.connectionStatus !== "connected") return "Disconnected";
+    if (store.syncState === "error") return store.syncStatusLabel || "Sync failed";
+    if (store.syncActivelyRunning || store.syncState === "syncing") {
+      return store.syncStatusLabel || "Syncing";
+    }
+    return "Up to date";
+  });
+
   function handleSwitchTo(address) {
     closeMenu();
     store.connectToAccount(address);
@@ -47,23 +59,12 @@
       class:connected={store.connectionStatus === 'connected'}
       class:syncing={store.syncActivelyRunning || store.syncState === 'syncing'}
       class:errored={store.syncState === 'error'}
+      role="status"
+      aria-live="polite"
+      aria-label={dotLabel}
+      title={dotLabel}
     ></span>
     <span class="band-name">{store.appTitle}</span>
-    {#if store.syncState === 'syncing'}
-      <span class="sync-pill" role="status" aria-live="polite" title={store.syncStatusLabel}>
-        <span class="sync-pill-spinner" aria-hidden="true"></span>
-        <span class="sync-pill-label">Syncing…</span>
-      </span>
-    {:else if store.syncState === 'synced'}
-      <span class="sync-pill sync-pill--ok" role="status" aria-live="polite">
-        <span class="sync-pill-check" aria-hidden="true">✓</span>
-        <span class="sync-pill-label">Up to date</span>
-      </span>
-    {:else if store.syncState === 'error'}
-      <span class="sync-pill sync-pill--err" role="status" aria-live="polite" title={store.syncStatusLabel}>
-        <span class="sync-pill-label">Sync failed</span>
-      </span>
-    {/if}
   </div>
 
   <div class="right">
@@ -136,9 +137,13 @@
     min-width: 0;
   }
 
+  /* The dot is the single sync indicator: grey = disconnected, green = up to
+     date, blue (throbbing) = syncing, red = error. The throb is a combined
+     opacity + scale + glow pulse so the state is readable at a glance even
+     at small sizes. */
   .conn-dot {
-    width: 7px;
-    height: 7px;
+    width: 8px;
+    height: 8px;
     border-radius: 50%;
     background: var(--line);
     flex-shrink: 0;
@@ -150,10 +155,13 @@
     box-shadow: 0 0 4px color-mix(in srgb, var(--success) 40%, transparent);
   }
 
+  /* `.syncing` overrides `.connected` since both are toggled when sync fires
+     mid-session. Order matters in the cascade — keep `.syncing` after
+     `.connected`. */
   .conn-dot.syncing {
     background: var(--accent);
-    box-shadow: 0 0 6px color-mix(in srgb, var(--accent) 40%, transparent);
-    animation: dot-pulse 1s ease-in-out infinite;
+    box-shadow: 0 0 6px color-mix(in srgb, var(--accent) 50%, transparent);
+    animation: dot-throb 1.1s ease-in-out infinite;
   }
 
   .conn-dot.errored {
@@ -161,75 +169,20 @@
     box-shadow: 0 0 6px color-mix(in srgb, var(--danger, #d44) 40%, transparent);
   }
 
-  @keyframes dot-pulse {
-    0%, 100% { opacity: 1; transform: scale(1); }
-    50% { opacity: 0.5; transform: scale(1.4); }
-  }
-
-  .sync-pill {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 2px 8px;
-    border-radius: 999px;
-    background: color-mix(in srgb, var(--accent) 12%, transparent);
-    color: var(--accent);
-    font-size: 11px;
-    font-weight: 600;
-    line-height: 1;
-    white-space: nowrap;
-    flex-shrink: 0;
-    animation: pill-fade-in 200ms ease-out both;
-  }
-
-  .sync-pill--ok {
-    background: color-mix(in srgb, var(--success) 14%, transparent);
-    color: var(--success);
-  }
-
-  .sync-pill--err {
-    background: color-mix(in srgb, var(--danger, #d44) 14%, transparent);
-    color: var(--danger, #d44);
-  }
-
-  .sync-pill-spinner {
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    border: 1.5px solid currentColor;
-    border-top-color: transparent;
-    animation: pill-spin 700ms linear infinite;
-  }
-
-  .sync-pill-check {
-    font-size: 12px;
-    font-weight: 800;
-    line-height: 1;
-  }
-
-  .sync-pill-label {
-    letter-spacing: 0.02em;
-  }
-
-  /* Hide the verbose label on very narrow screens — the dot + spinner still
-     communicate state. */
-  @media (max-width: 360px) {
-    .sync-pill-label { display: none; }
-    .sync-pill { padding: 4px; }
-  }
-
-  @keyframes pill-spin {
-    to { transform: rotate(360deg); }
-  }
-
-  @keyframes pill-fade-in {
-    from { opacity: 0; transform: translateY(-2px); }
-    to   { opacity: 1; transform: translateY(0); }
+  @keyframes dot-throb {
+    0%, 100% {
+      opacity: 1;
+      transform: scale(1);
+      box-shadow: 0 0 4px color-mix(in srgb, var(--accent) 35%, transparent);
+    }
+    50% {
+      opacity: 0.55;
+      transform: scale(1.5);
+      box-shadow: 0 0 10px color-mix(in srgb, var(--accent) 65%, transparent);
+    }
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .sync-pill-spinner { animation-duration: 1.4s; }
-    .sync-pill { animation: none; }
     .conn-dot.syncing { animation: none; }
   }
 

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -157,11 +157,12 @@
 
   /* `.syncing` overrides `.connected` since both are toggled when sync fires
      mid-session. Order matters in the cascade — keep `.syncing` after
-     `.connected`. */
+     `.connected`. Uses `--sync` (fixed blue), NOT `--accent`: the accent
+     is band-themed and could match `--success` (green), erasing the
+     visual difference between "syncing" and "up to date". */
   .conn-dot.syncing {
-    background: var(--accent);
-    box-shadow: 0 0 6px color-mix(in srgb, var(--accent) 50%, transparent);
-    animation: dot-throb 1.1s ease-in-out infinite;
+    background: var(--sync);
+    animation: dot-pulse 1.1s ease-in-out infinite;
   }
 
   .conn-dot.errored {
@@ -169,21 +170,34 @@
     box-shadow: 0 0 6px color-mix(in srgb, var(--danger, #d44) 40%, transparent);
   }
 
-  @keyframes dot-throb {
+  /* Pulse the dot itself so it visibly "breathes": opacity dips to 40%,
+     scale grows to 1.7x, and the glow widens from 4px → 14px. Each
+     property reinforces the others so the change is unmistakable even at
+     8px. `transform-origin` defaults to center so scaling is symmetrical
+     even when the dot sits flush against the title-group's left edge. */
+  @keyframes dot-pulse {
     0%, 100% {
       opacity: 1;
       transform: scale(1);
-      box-shadow: 0 0 4px color-mix(in srgb, var(--accent) 35%, transparent);
+      box-shadow: 0 0 4px color-mix(in srgb, var(--sync) 40%, transparent);
     }
     50% {
-      opacity: 0.55;
-      transform: scale(1.5);
-      box-shadow: 0 0 10px color-mix(in srgb, var(--accent) 65%, transparent);
+      opacity: 0.4;
+      transform: scale(1.7);
+      box-shadow: 0 0 14px color-mix(in srgb, var(--sync) 80%, transparent);
     }
   }
 
+  /* Don't fully suppress motion — users still need to know sync is alive.
+     Drop the scale/glow but keep a slow opacity breath so the indicator
+     stays animated within accessibility-friendly bounds. */
   @media (prefers-reduced-motion: reduce) {
-    .conn-dot.syncing { animation: none; }
+    .conn-dot.syncing { animation: dot-pulse-soft 2s ease-in-out infinite; }
+  }
+
+  @keyframes dot-pulse-soft {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.55; }
   }
 
   .band-name {

--- a/src/lib/components/roll/RollScreen.svelte
+++ b/src/lib/components/roll/RollScreen.svelte
@@ -16,7 +16,7 @@
   let setlistSongIds = $derived(
     new Set((store.generatedSetlist?.songs || []).map((s) => s.id))
   );
-  let filteredPickerSongs = $derived(() => {
+  let filteredPickerSongs = $derived.by(() => {
     const eligible = store.songs?.filter((s) => !s.unpracticed) || [];
     if (!addSongSearch) return eligible;
     const q = addSongSearch.toLowerCase();
@@ -56,6 +56,14 @@
   // New band detection — only songs are required to roll
   let hasSongs = $derived((store.songs || []).length > 0);
   let readyToRoll = $derived(hasSongs);
+
+  // [DEBUG SYNC] log every time the songs-derived state changes so we can
+  // line up "songs visible in UI" timestamps with the rest of the trace.
+  $effect(() => {
+    if (typeof window !== "undefined" && window.DEBUG_SYNC) {
+      console.log(`[sync] RollScreen: songs.length=${(store.songs || []).length} syncState=${store.syncState} hasSongs=${hasSongs}`);
+    }
+  });
 
   const ROLL_NUDGES = [
     "The setlist isn't going to roll itself.",
@@ -374,8 +382,21 @@
   </details>
   </div>
 
+  <!-- Sync-in-progress placeholder: avoid showing the empty/onboarding state
+       while we're still pulling the user's data after a swap or first connect.
+       Without this, a newly-switched account looks identical to a fresh one. -->
+  {#if !readyToRoll && store.syncState === 'syncing'}
+    <div class="sync-skeleton" role="status" aria-live="polite" aria-label="Syncing your songs">
+      <div class="skeleton-headline"></div>
+      <div class="skeleton-card"></div>
+      <div class="skeleton-card"></div>
+      <div class="skeleton-card"></div>
+      <p class="sync-skeleton-note">Pulling your songs from remoteStorage…</p>
+    </div>
+  {/if}
+
   <!-- Getting Started -->
-  {#if !readyToRoll}
+  {#if !readyToRoll && store.syncState !== 'syncing'}
     <div class="onboarding-card">
       <div class="onboarding-illustration">🎸🥁🎤</div>
       <h2 class="onboarding-title">Almost showtime!</h2>
@@ -480,7 +501,7 @@
           bind:value={addSongSearch}
         />
         <div class="add-song-list">
-          {#each filteredPickerSongs() as song}
+          {#each filteredPickerSongs as song}
             {@const inSetlist = setlistSongIds.has(song.id)}
             <button type="button"
               class="add-song-item"
@@ -1446,6 +1467,55 @@
 
   .help-toggle:hover {
     color: var(--accent-strong);
+  }
+
+  /* ---- Sync-in-progress skeleton ---- */
+  .sync-skeleton {
+    display: grid;
+    gap: 12px;
+    padding: 24px 16px;
+    max-width: 560px;
+    margin: 16px auto 0;
+  }
+
+  .skeleton-headline,
+  .skeleton-card {
+    background: linear-gradient(
+      90deg,
+      var(--line) 0%,
+      color-mix(in srgb, var(--line) 60%, var(--paper-strong)) 50%,
+      var(--line) 100%
+    );
+    background-size: 200% 100%;
+    border-radius: var(--radius-md);
+    animation: skeleton-shimmer 1.4s ease-in-out infinite;
+  }
+
+  .skeleton-headline {
+    height: 18px;
+    width: 60%;
+    margin-bottom: 4px;
+  }
+
+  .skeleton-card {
+    height: 72px;
+  }
+
+  .sync-skeleton-note {
+    margin: 8px 0 0;
+    color: var(--muted);
+    font-size: 13px;
+    text-align: center;
+  }
+
+  @keyframes skeleton-shimmer {
+    0%   { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .skeleton-headline,
+    .skeleton-card { animation: none; }
   }
 
   /* ---- Idle nudge (ready but nothing rolled) ---- */

--- a/src/lib/components/roll/RollScreen.svelte
+++ b/src/lib/components/roll/RollScreen.svelte
@@ -57,14 +57,6 @@
   let hasSongs = $derived((store.songs || []).length > 0);
   let readyToRoll = $derived(hasSongs);
 
-  // [DEBUG SYNC] log every time the songs-derived state changes so we can
-  // line up "songs visible in UI" timestamps with the rest of the trace.
-  $effect(() => {
-    if (typeof window !== "undefined" && window.DEBUG_SYNC) {
-      console.log(`[sync] RollScreen: songs.length=${(store.songs || []).length} syncState=${store.syncState} hasSongs=${hasSongs}`);
-    }
-  });
-
   const ROLL_NUDGES = [
     "The setlist isn't going to roll itself.",
     "That die up there? It's getting lonely.",

--- a/src/lib/remotestorage.js
+++ b/src/lib/remotestorage.js
@@ -490,22 +490,6 @@ export function createRemoteStorageRepository() {
 
         async listSongs() {
             const items = await client.getAll("songs/", false);
-            // [DEBUG SYNC] Inspect raw rs.js cache shape so we can see what
-            // "stub" actually looks like in this version of rs.js.
-            if (typeof window !== "undefined" && window.DEBUG_SYNC) {
-                const summary = Object.entries(items || {}).map(([k, v]) => {
-                    const t = v === null ? "null" : Array.isArray(v) ? "array" : typeof v;
-                    const hasId = v && typeof v === "object" && "id" in v;
-                    const keys = v && typeof v === "object" ? Object.keys(v).length : 0;
-                    return `${k}=${t}${hasId ? "+id" : ""}(${keys}k)`;
-                });
-                console.log(
-                    "[sync] listSongs raw items:",
-                    summary.length,
-                    summary.slice(0, 5).join(", "),
-                    summary.length > 5 ? "..." : "",
-                );
-            }
             const all = Object.values(items || {});
             const records = [];
             let pending = 0;
@@ -515,9 +499,6 @@ export function createRemoteStorageRepository() {
                 } else {
                     pending += 1;
                 }
-            }
-            if (typeof window !== "undefined" && window.DEBUG_SYNC) {
-                console.log(`[sync] listSongs result: ${records.length} loaded, ${pending} pending`);
             }
             return {
                 songs: sortSongs(records.map((song) => normalizeSongRecord(song))),

--- a/src/lib/remotestorage.js
+++ b/src/lib/remotestorage.js
@@ -215,15 +215,6 @@ export function createRemoteStorageRepository() {
             window: false,
         },
         logging: false,
-        // rs.js drains its task queue per cycle and waits `syncInterval` ms
-        // between cycles. Initial bootstrap typically spans 3 cycles (root
-        // listing → folder listings → bodies), so the default 10 000 ms
-        // makes a fresh account feel "loaded" only after ~30 s. Start at the
-        // library's minimum (2 000 ms) for snappy bootstrap; the app bumps
-        // this back up to a calmer 10 000 ms once the first sync settles —
-        // see `BOOTSTRAP_SYNC_INTERVAL_MS` / `STEADY_SYNC_INTERVAL_MS` in
-        // app.svelte.js.
-        syncInterval: 2000,
     });
 
     const localEventHandlers = new Map();

--- a/src/lib/remotestorage.js
+++ b/src/lib/remotestorage.js
@@ -289,10 +289,18 @@ export function createRemoteStorageRepository() {
         async swap(userAddress, token) {
             if (remoteStorage.connected) {
                 await new Promise((resolve) => {
-                    const handler = () => {
+                    let settled = false;
+                    const finish = () => {
+                        if (settled) return;
+                        settled = true;
+                        clearTimeout(timer);
                         remoteStorage.removeEventListener("disconnected", handler);
                         resolve();
                     };
+                    const handler = () => finish();
+                    // Safety net: if rs.js never fires `disconnected` (already
+                    // mid-disconnect, library hiccup), don't strand the user.
+                    const timer = setTimeout(finish, 3000);
                     remoteStorage.on("disconnected", handler);
                     remoteStorage.caching.reset();
                     remoteStorage.disconnect();

--- a/src/lib/remotestorage.js
+++ b/src/lib/remotestorage.js
@@ -215,6 +215,15 @@ export function createRemoteStorageRepository() {
             window: false,
         },
         logging: false,
+        // rs.js drains its task queue per cycle and waits `syncInterval` ms
+        // between cycles. Initial bootstrap typically spans 3 cycles (root
+        // listing → folder listings → bodies), so the default 10 000 ms
+        // makes a fresh account feel "loaded" only after ~30 s. Start at the
+        // library's minimum (2 000 ms) for snappy bootstrap; the app bumps
+        // this back up to a calmer 10 000 ms once the first sync settles —
+        // see `BOOTSTRAP_SYNC_INTERVAL_MS` / `STEADY_SYNC_INTERVAL_MS` in
+        // app.svelte.js.
+        syncInterval: 2000,
     });
 
     const localEventHandlers = new Map();
@@ -260,13 +269,39 @@ export function createRemoteStorageRepository() {
         defaultAuthorize(options);
     };
 
+    /**
+     * After a disconnect, rs.js's `Sync._rs_cleanup` nulls
+     * `remoteStorage.sync` but does NOT clear `caching.activateHandler` —
+     * which still references the dead Sync's lambda. If we then call
+     * `caching.enable(path)`, `set()` finds the (stale) handler set and
+     * calls it directly, so the path is NOT pushed to `pendingActivations`.
+     * When the new Sync is constructed (on the next `ready` event), its
+     * `caching.onActivate(newCb)` overwrites the handler but finds
+     * `pendingActivations` empty — so the new Sync never receives the
+     * path activation, never queues a root task, and `forAllNodes`-based
+     * fallbacks (`collectDiffTasks`, `collectRefreshTasks`) find nothing
+     * because `IndexedDB._rs_cleanup` already deleted the local DB.
+     *
+     * Net effect: after an account swap, rs.js completes sync rounds
+     * without ever fetching the scope folder — songs never appear until
+     * the page is reloaded (which constructs a fresh Sync from a clean
+     * caching state). Clearing the handler restores the documented
+     * `enable → pendingActivations → new Sync's onActivate` flow.
+     */
+    function resetActivateHandler() {
+        remoteStorage.caching.activateHandler = undefined;
+        remoteStorage.caching.pendingActivations = [];
+    }
+
     return {
         remoteStorage,
         client,
 
         connect(userAddress, token) {
             const normalizedToken = normalizeBearerToken(token);
-            // Re-enable caching in case it was reset by a previous disconnect
+            // Re-enable caching in case it was reset by a previous disconnect.
+            // Clear the stale activate handler first — see resetActivateHandler.
+            resetActivateHandler();
             remoteStorage.caching.enable(`/${APP_SCOPE}/`);
             remoteStorage.connect(userAddress, normalizedToken);
         },
@@ -283,8 +318,10 @@ export function createRemoteStorageRepository() {
          * Resolves once `connect()` has been issued — callers should still
          * wait for the `connected` event for sync.
          *
-         * Avoids mutating rs.js internals; relies on the documented
-         * disconnect → connect lifecycle.
+         * Avoids mutating rs.js internals beyond the documented
+         * disconnect → connect lifecycle, with one exception:
+         * `caching.activateHandler` is cleared before re-enabling — see
+         * resetActivateHandler for the rationale.
          */
         async swap(userAddress, token) {
             if (remoteStorage.connected) {
@@ -306,6 +343,10 @@ export function createRemoteStorageRepository() {
                     remoteStorage.disconnect();
                 });
             }
+            // The OLD Sync's activate handler must be cleared before
+            // enable() — otherwise the path activation goes to the dead
+            // handler and the new Sync never queues any tasks.
+            resetActivateHandler();
             remoteStorage.caching.enable(`/${APP_SCOPE}/`);
             remoteStorage.connect(userAddress, normalizeBearerToken(token));
         },
@@ -315,6 +356,17 @@ export function createRemoteStorageRepository() {
                 return;
             }
             await remoteStorage.startSync();
+        },
+
+        /**
+         * Read/adjust rs.js's foreground sync polling interval. The library
+         * enforces 2000–3 600 000 ms; setSyncInterval throws outside that.
+         */
+        getSyncInterval() {
+            return remoteStorage.getSyncInterval();
+        },
+        setSyncInterval(ms) {
+            remoteStorage.setSyncInterval(ms);
         },
 
         /**
@@ -376,9 +428,9 @@ export function createRemoteStorageRepository() {
 
         async loadAll({ onStep } = {}) {
             onStep?.("Loading songs");
-            const songsPromise = this.listSongs().then((songs) => {
-                onStep?.(`Loaded ${songs.length} songs`);
-                return songs;
+            const songsPromise = this.listSongs().then((result) => {
+                onStep?.(`Loaded ${result.songs.length} songs${result.pending ? ` (${result.pending} pending)` : ""}`);
+                return result;
             });
 
             onStep?.("Loading settings");
@@ -394,18 +446,18 @@ export function createRemoteStorageRepository() {
             });
 
             onStep?.("Loading saved setlists");
-            const setlistsPromise = this.listSetlists().then((setlists) => {
-                onStep?.(`Loaded ${setlists.length} saved setlists`);
-                return setlists;
+            const setlistsPromise = this.listSetlists().then((result) => {
+                onStep?.(`Loaded ${result.setlists.length} saved setlists${result.pending ? ` (${result.pending} pending)` : ""}`);
+                return result;
             });
 
             onStep?.("Loading band members");
-            const membersPromise = this.listMembers().then((members) => {
-                onStep?.(`Loaded ${Object.keys(members || {}).length} band members`);
-                return members;
+            const membersPromise = this.listMembers().then((result) => {
+                onStep?.(`Loaded ${Object.keys(result.members || {}).length} band members${result.pending ? ` (${result.pending} pending)` : ""}`);
+                return result;
             });
 
-            const [songs, config, bootstrap, setlists, members] = await Promise.all([
+            const [songsResult, config, bootstrap, setlistsResult, membersResult] = await Promise.all([
                 songsPromise,
                 configPromise,
                 bootstrapPromise,
@@ -413,12 +465,57 @@ export function createRemoteStorageRepository() {
                 membersPromise,
             ]);
 
-            return { songs, config, bootstrap, setlists, members };
+            // pendingBodies: total documents whose bodies haven't yet arrived
+            // from the remote. rs.js's getAll(path, false) returns stub
+            // entries (`true` / `{}` / object without id) for items it knows
+            // exist (folder ETag) but whose bodies are not yet in the local
+            // cache. As long as this is > 0, more onChange events will fire
+            // and the UI is not yet in a settled state.
+            const pendingBodies =
+                (songsResult.pending || 0) +
+                (setlistsResult.pending || 0) +
+                (membersResult.pending || 0);
+
+            return {
+                songs: songsResult.songs,
+                config,
+                bootstrap,
+                setlists: setlistsResult.setlists,
+                members: membersResult.members,
+                pendingBodies,
+            };
         },
 
         async listSongs() {
             const items = await client.getAll("songs/", false);
-            return sortSongs(Object.values(items || {}).map((song) => normalizeSongRecord(song)));
+            // [DEBUG SYNC] Inspect raw rs.js cache shape so we can see what
+            // "stub" actually looks like in this version of rs.js.
+            if (typeof window !== "undefined" && window.DEBUG_SYNC) {
+                const summary = Object.entries(items || {}).map(([k, v]) => {
+                    const t = v === null ? "null" : Array.isArray(v) ? "array" : typeof v;
+                    const hasId = v && typeof v === "object" && "id" in v;
+                    const keys = v && typeof v === "object" ? Object.keys(v).length : 0;
+                    return `${k}=${t}${hasId ? "+id" : ""}(${keys}k)`;
+                });
+                console.log("[sync] listSongs raw items:", summary.length, summary.slice(0, 5).join(", "), summary.length > 5 ? "..." : "");
+            }
+            const all = Object.values(items || {});
+            const records = [];
+            let pending = 0;
+            for (const item of all) {
+                if (item && typeof item === "object" && item.id) {
+                    records.push(item);
+                } else {
+                    pending += 1;
+                }
+            }
+            if (typeof window !== "undefined" && window.DEBUG_SYNC) {
+                console.log(`[sync] listSongs result: ${records.length} loaded, ${pending} pending`);
+            }
+            return {
+                songs: sortSongs(records.map((song) => normalizeSongRecord(song))),
+                pending,
+            };
         },
 
         async putSong(song) {
@@ -484,7 +581,20 @@ export function createRemoteStorageRepository() {
         // ---- setlists ----
         async listSetlists() {
             const items = await client.getAll("setlists/", false);
-            return Object.values(items || {}).sort((a, b) => (b.savedAt || "").localeCompare(a.savedAt || ""));
+            // Same stub-tolerant treatment as listSongs. Setlists must have a
+            // `savedAt` to sort; missing/non-object entries are pending bodies.
+            const all = Object.values(items || {});
+            const records = [];
+            let pending = 0;
+            for (const item of all) {
+                if (item && typeof item === "object" && item.savedAt) {
+                    records.push(item);
+                } else {
+                    pending += 1;
+                }
+            }
+            records.sort((a, b) => (b.savedAt || "").localeCompare(a.savedAt || ""));
+            return { setlists: records, pending };
         },
 
         async putSetlist(setlist) {
@@ -500,11 +610,18 @@ export function createRemoteStorageRepository() {
         // ---- members ----
         async listMembers() {
             const items = await client.getAll("members/", false);
+            // A real member doc has `name`; stubs / empty placeholders count
+            // as pending bodies and surface in the sync indicator.
             const result = {};
+            let pending = 0;
             for (const [key, value] of Object.entries(items || {})) {
-                result[value.name || key] = value;
+                if (value && typeof value === "object" && value.name) {
+                    result[value.name || key] = value;
+                } else {
+                    pending += 1;
+                }
             }
-            return result;
+            return { members: result, pending };
         },
 
         async putMember(name, data) {

--- a/src/lib/remotestorage.js
+++ b/src/lib/remotestorage.js
@@ -447,13 +447,17 @@ export function createRemoteStorageRepository() {
 
             onStep?.("Loading saved setlists");
             const setlistsPromise = this.listSetlists().then((result) => {
-                onStep?.(`Loaded ${result.setlists.length} saved setlists${result.pending ? ` (${result.pending} pending)` : ""}`);
+                onStep?.(
+                    `Loaded ${result.setlists.length} saved setlists${result.pending ? ` (${result.pending} pending)` : ""}`,
+                );
                 return result;
             });
 
             onStep?.("Loading band members");
             const membersPromise = this.listMembers().then((result) => {
-                onStep?.(`Loaded ${Object.keys(result.members || {}).length} band members${result.pending ? ` (${result.pending} pending)` : ""}`);
+                onStep?.(
+                    `Loaded ${Object.keys(result.members || {}).length} band members${result.pending ? ` (${result.pending} pending)` : ""}`,
+                );
                 return result;
             });
 
@@ -472,9 +476,7 @@ export function createRemoteStorageRepository() {
             // cache. As long as this is > 0, more onChange events will fire
             // and the UI is not yet in a settled state.
             const pendingBodies =
-                (songsResult.pending || 0) +
-                (setlistsResult.pending || 0) +
-                (membersResult.pending || 0);
+                (songsResult.pending || 0) + (setlistsResult.pending || 0) + (membersResult.pending || 0);
 
             return {
                 songs: songsResult.songs,
@@ -497,7 +499,12 @@ export function createRemoteStorageRepository() {
                     const keys = v && typeof v === "object" ? Object.keys(v).length : 0;
                     return `${k}=${t}${hasId ? "+id" : ""}(${keys}k)`;
                 });
-                console.log("[sync] listSongs raw items:", summary.length, summary.slice(0, 5).join(", "), summary.length > 5 ? "..." : "");
+                console.log(
+                    "[sync] listSongs raw items:",
+                    summary.length,
+                    summary.slice(0, 5).join(", "),
+                    summary.length > 5 ? "..." : "",
+                );
             }
             const all = Object.values(items || {});
             const records = [];

--- a/src/lib/remotestorage.test.js
+++ b/src/lib/remotestorage.test.js
@@ -31,6 +31,12 @@ beforeEach(() => {
         caching: {
             enable: vi.fn(),
             reset: vi.fn(),
+            // Mirror the rs.js Caching public API used by repo's swap/connect
+            // flow. Tests assert these get cleared so that `enable()` routes
+            // its path through `pendingActivations` for the new Sync to pick
+            // up — see resetActivateHandler in remotestorage.js.
+            activateHandler: undefined,
+            pendingActivations: [],
         },
         scope: vi.fn(() => ({
             declareType: vi.fn(),
@@ -571,6 +577,64 @@ describe("createRemoteStorageRepository", () => {
             rs.connected = false;
             await repo.swap("other@example.com", { type: "click" });
             expect(rs.connect).toHaveBeenCalledWith("other@example.com", undefined);
+        });
+
+        it("clears the stale caching.activateHandler before re-enabling", async () => {
+            // Regression: rs.js's Sync._rs_cleanup leaves
+            // caching.activateHandler pointing at the dead Sync's lambda. If
+            // we don't clear it, enable() routes the path to that defunct
+            // handler instead of pendingActivations, and the new Sync never
+            // queues any sync tasks — the next account's data never loads
+            // until the page is reloaded.
+            const repo = createRemoteStorageRepository();
+            const rs = remoteStorageMockState.instance;
+            rs.connected = true;
+
+            const staleHandler = vi.fn();
+            rs.caching.activateHandler = staleHandler;
+            rs.caching.pendingActivations = ["/setlist-roller/"];
+
+            // Capture the state of caching at the moment enable() is called —
+            // it must already be cleared by then.
+            let handlerAtEnable;
+            let pendingAtEnable;
+            rs.caching.enable.mockImplementation(() => {
+                handlerAtEnable = rs.caching.activateHandler;
+                pendingAtEnable = rs.caching.pendingActivations;
+            });
+
+            let disconnectedHandler;
+            rs.on.mockImplementation((event, handler) => {
+                if (event === "disconnected") disconnectedHandler = handler;
+            });
+
+            const swapPromise = repo.swap("other@example.com", "tok-2");
+            disconnectedHandler();
+            await swapPromise;
+
+            expect(handlerAtEnable).toBeUndefined();
+            expect(pendingAtEnable).toEqual([]);
+            expect(staleHandler).not.toHaveBeenCalled();
+        });
+
+        it("clears caching.activateHandler on direct connect too", () => {
+            // Same regression as the swap path: a connect after disconnect
+            // (without an explicit swap) hits the same stale-handler hazard.
+            const repo = createRemoteStorageRepository();
+            const rs = remoteStorageMockState.instance;
+            const staleHandler = vi.fn();
+            rs.caching.activateHandler = staleHandler;
+            rs.caching.pendingActivations = ["/setlist-roller/"];
+
+            let handlerAtEnable;
+            rs.caching.enable.mockImplementation(() => {
+                handlerAtEnable = rs.caching.activateHandler;
+            });
+
+            repo.connect("user@example.com", "tok");
+
+            expect(handlerAtEnable).toBeUndefined();
+            expect(staleHandler).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -74,6 +74,9 @@ export function createAppStore(repo) {
     let generationId = 0;
     let setlistLocked = $state(false);
     let setlistSaved = $state(false);
+    // Id of the saved setlist currently loaded into generatedSetlist, if any.
+    // Used to update-in-place instead of duplicating when the user re-saves.
+    let loadedSavedId = $state("");
     let pendingRollConfirm = $state(false);
     let savedSetlists = $state([]);
     let bandMembers = $state({});
@@ -148,20 +151,36 @@ export function createAppStore(repo) {
         if (pruned) songKeyFilters = pruned;
     });
 
+    // Keep the per-account snapshot fresh: any direct edit (saveSong,
+    // persistMemberEdit, addSetlistSong, etc.) mutates these state slots,
+    // so a debounced scheduleSnapshot() here covers all of them. Without
+    // this, the snapshot only refreshed at the end of reloadAll, so a
+    // fast account swap right after editing showed last-synced data.
+    $effect(() => {
+        // Touch the state we want to snapshot.
+        void songs;
+        void appConfig;
+        void savedSetlists;
+        void bandMembers;
+        if (currentUserAddress) scheduleSnapshot();
+    });
+
     // ---- helpers ----
 
     function defaultGenerationOptions(config = appConfig) {
         const source = config || DEFAULT_APP_CONFIG;
+        // Use ?? for numeric defaults: a user-set 0 (count, temperature, etc.)
+        // would otherwise silently fall back to the default.
         return {
-            count: source.general?.count || 15,
-            beamWidth: source.general?.beamWidth || 20,
+            count: source.general?.count ?? 15,
+            beamWidth: source.general?.beamWidth ?? 20,
             maxCovers: source.general?.limits?.covers ?? -1,
             maxInstrumentals: source.general?.limits?.instrumentals ?? -1,
             keyFlow: false,
             seed: "",
             randomness: {
-                temperature: source.general?.randomness?.temperature || 0.85,
-                finalChoicePool: source.general?.randomness?.finalChoicePool || 12
+                temperature: source.general?.randomness?.temperature ?? 0.85,
+                finalChoicePool: source.general?.randomness?.finalChoicePool ?? 12
             },
             show: {
                 members: clone(source.show?.members || {})
@@ -285,6 +304,7 @@ export function createAppStore(repo) {
 
     function clearGeneratedSetlist() {
         generatedSetlist = null;
+        loadedSavedId = "";
     }
 
     // Strip deprecated "energy" field and energy-related notes from saved setlist songs
@@ -422,7 +442,7 @@ export function createAppStore(repo) {
     }
 
     // ---- connection ----
-    async function connectStorage(token) {
+    function connectStorage(token) {
         if (!connectAddress.trim()) {
             addToast("Put in a remoteStorage address first.", "danger");
             return;
@@ -517,10 +537,17 @@ export function createAppStore(repo) {
         }
     }
 
+    // Per-account localStorage bases owned by the app. Keep this list in sync
+    // with anything that reads/writes via accountSlot(address).key(...).
+    const PER_ACCOUNT_STORAGE_BASES = ["snapshot", "ui-options", "current-set", "saved-sets"];
+
     function forgetAccount(address) {
         removeKnownAccountEntry(address);
         if (typeof localStorage !== "undefined") {
-            localStorage.removeItem(accountSlot(address).key("snapshot"));
+            const slot = accountSlot(address);
+            for (const base of PER_ACCOUNT_STORAGE_BASES) {
+                localStorage.removeItem(slot.key(base));
+            }
         }
         knownAccounts = getKnownAccounts();
     }
@@ -560,10 +587,10 @@ export function createAppStore(repo) {
                 Object.entries(data.members || {}).map(([name, d]) => [name, normalizeMemberRecord(d)])
             );
             showFirstRunPrompt = false;
-            generationOptions = deepMerge(defaultGenerationOptions(appConfig), generationOptions || {});
-            // Don't persistGenerationOptions() here — currentUserAddress still
-            // points to the previous account. The caller sets it after this
-            // returns, and loadUserLocalData() handles persisting correctly.
+            // generationOptions is intentionally not touched here:
+            // currentUserAddress still points at the previous account. The
+            // caller sets it after this returns, then loadUserLocalData()
+            // loads the target account's stored options.
             return true;
         } catch { return false; }
     }
@@ -728,8 +755,15 @@ export function createAppStore(repo) {
         }
 
         terminateWorker();
+        // A new generation produces fresh content; any prior "loaded from
+        // saved" identity no longer applies, so saving creates a new entry.
+        loadedSavedId = "";
         isGenerating = true;
         const thisGenId = ++generationId;
+        // Capture the session so a result that lands after an account swap
+        // (even into another connected account) is discarded — checking
+        // currentUserAddress alone isn't enough.
+        const thisSession = activeSession;
         const opts = clone(generationOptions);
         Object.assign(opts, overrideOptions);
 
@@ -745,8 +779,9 @@ export function createAppStore(repo) {
             if (type !== "done") return;
             worker.terminate();
             if (worker === activeWorker) activeWorker = null;
-            // Ignore stale results from a previous generation or disconnected session
-            if (thisGenId !== generationId || !currentUserAddress) {
+            // Ignore stale results from a previous generation, an account
+            // swap, or a disconnected session.
+            if (thisGenId !== generationId || thisSession !== activeSession || !currentUserAddress) {
                 isGenerating = false;
                 return;
             }
@@ -813,6 +848,27 @@ export function createAppStore(repo) {
         if (!generatedSetlist) return;
         const currentSaved = savedSetlists || [];
         const songNames = generatedSetlist.songs.map(s => s.name || s.title || "?");
+
+        // If this setlist was loaded from a saved entry, update that entry in
+        // place instead of creating a duplicate with a new id and name.
+        if (loadedSavedId) {
+            const existing = currentSaved.find((s) => s.id === loadedSavedId);
+            if (existing) {
+                await updateSavedSetlist(loadedSavedId, {
+                    savedAt: nowIso(),
+                    summary: clone(generatedSetlist.summary),
+                    songs: clone(generatedSetlist.songs),
+                    songNames,
+                    seed: generatedSetlist.seed,
+                    songCount: generatedSetlist.songs.length,
+                });
+                setlistSaved = true;
+                return;
+            }
+            // Saved entry no longer exists (deleted elsewhere) — fall through.
+            loadedSavedId = "";
+        }
+
         const funNames = [
             "The Unhinged Encore", "Chaos Theory",
             "No Refunds", "The One That Slaps", "Certified Banger",
@@ -845,6 +901,7 @@ export function createAppStore(repo) {
             await withSync("Saving setlist", () => repo.putSetlist(entry));
             savedSetlists = [entry, ...currentSaved].slice(0, MAX_SAVED_SETS);
             setlistSaved = true;
+            loadedSavedId = entry.id;
         } catch (error) {
             addToast(error?.message || "Could not save setlist.", "danger");
         }
@@ -854,6 +911,7 @@ export function createAppStore(repo) {
         try {
             await withSync("Removing setlist", () => repo.deleteSetlist(id));
             savedSetlists = savedSetlists.filter((s) => s.id !== id);
+            if (loadedSavedId === id) loadedSavedId = "";
         } catch (error) {
             addToast(error?.message || "Could not remove setlist.", "danger");
         }
@@ -881,6 +939,7 @@ export function createAppStore(repo) {
         });
         setlistLocked = true;
         setlistSaved = true;
+        loadedSavedId = id;
         persistCurrentSetlist();
         addToast(`Loaded ${saved.songs?.length || 0}-song set.`);
     }
@@ -928,7 +987,8 @@ export function createAppStore(repo) {
             key: song.key || "",
             notes: song.notes || "",
             performance,
-            position: songList.length + 1,
+            // position is intentionally omitted; scoreFixedOrder re-stamps it
+            // after rescoring. Setting it here was off-by-one.
             incrementalScore: 0,
             cumulativeScore: 0,
             transitionNotes: [],
@@ -1086,7 +1146,7 @@ export function createAppStore(repo) {
     }
 
     async function saveSong() {
-        if (!editorSong?.name.trim()) {
+        if (!editorSong || !String(editorSong.name || "").trim()) {
             addToast("Songs need names.", "danger");
             return;
         }

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -73,6 +73,35 @@ export function createAppStore(repo) {
     // a single failed swap would lock out future swap attempts via the
     // `isSwitching` re-entry guard.
     let switchingWatchdog = null;
+    // Post-swap "straggler" guard. Even after `connected` fires for the new
+    // account and we release `isSwitching`, rs.js can still emit the OLD
+    // account's `disconnected` event a moment later — it was queued behind
+    // repo.swap()'s 3 s safety timeout, which sometimes lets the swap
+    // promise resolve before the underlying disconnect actually finishes.
+    // Without this flag, the late event takes the wipe path against the
+    // newly-connected account. We arm it at swap entry, leave it set across
+    // the `connected` boundary, and let either the late disconnect itself
+    // or a 5 s timeout consume it (5 s is generous vs swap()'s 3 s, but
+    // small enough that a real user-initiated disconnect right after a
+    // swap isn't accidentally swallowed).
+    let pendingSwapDisconnect = false;
+    let pendingSwapDisconnectTimer = null;
+    function expectSwapDisconnect() {
+        pendingSwapDisconnect = true;
+        if (pendingSwapDisconnectTimer) clearTimeout(pendingSwapDisconnectTimer);
+        pendingSwapDisconnectTimer = setTimeout(() => {
+            pendingSwapDisconnectTimer = null;
+            pendingSwapDisconnect = false;
+        }, 5000);
+    }
+    function consumePendingSwapDisconnect() {
+        if (!pendingSwapDisconnect && !pendingSwapDisconnectTimer) return;
+        pendingSwapDisconnect = false;
+        if (pendingSwapDisconnectTimer) {
+            clearTimeout(pendingSwapDisconnectTimer);
+            pendingSwapDisconnectTimer = null;
+        }
+    }
     function releaseSwitching(reason) {
         if (!isSwitching && !switchingWatchdog) return;
         isSwitching = false;
@@ -743,13 +772,33 @@ export function createAppStore(repo) {
         if (switchingWatchdog) clearTimeout(switchingWatchdog);
         switchingWatchdog = setTimeout(() => {
             switchingWatchdog = null;
-            if (isSwitching) {
-                isSwitching = false;
-                pushSyncLog("Swap watchdog: released isSwitching after 15s");
-            }
+            if (!isSwitching) return;
+            // Full reset — the re-entry guard at the top of connectToAccount
+            // checks BOTH isSwitching AND connectionStatus === "connecting",
+            // so just clearing isSwitching would leave the user locked out
+            // of retrying. Drop everything back to a clean disconnected
+            // state and surface the failure so they know what happened.
+            isSwitching = false;
+            consumePendingSwapDisconnect();
+            connectionStatus = "disconnected";
+            setSyncState("error");
+            loadError = "Account swap timed out. Try again.";
+            addToast(loadError, "danger");
+            pushSyncLog("Swap watchdog: released after 15s — neither connected nor error fired");
         }, 15000);
         try {
             if (repo.isConnected()) {
+                // rs.js will fire `disconnected` (for the old account) and
+                // then `connected` (for the new). Usually the disconnect
+                // lands first while isSwitching is true. But repo.swap()
+                // resolves via a 3 s safety timeout that doesn't wait for
+                // the underlying disconnect to actually fire, so the OLD
+                // account's `disconnected` can arrive AFTER the new
+                // account's `connected` — by which point isSwitching has
+                // already been released. Arm the straggler guard so that
+                // out-of-order late disconnect is swallowed instead of
+                // taking the wipe path against the new account.
+                expectSwapDisconnect();
                 await repo.swap(address, savedToken);
             } else {
                 // Not connected — straight connect, no swap dance needed.
@@ -759,6 +808,7 @@ export function createAppStore(repo) {
         } catch (error) {
             addToast(error?.message || "Could not switch accounts.", "danger");
             connectionStatus = "disconnected";
+            consumePendingSwapDisconnect();
             releaseSwitching("swap threw");
         }
     }
@@ -2167,7 +2217,24 @@ export function createAppStore(repo) {
             // Don't wipe state — the snapshot we restored stays visible until
             // the next `connected` event fills in real data.
             if (isSwitching) {
+                // Consume the straggler flag too: the in-window disconnect
+                // satisfies the expectation set by expectSwapDisconnect(),
+                // and we don't want a stale flag living past this point.
+                consumePendingSwapDisconnect();
                 pushSyncLog("Disconnected (switching accounts)");
+                return;
+            }
+            // Post-swap straggler: rs.js's old-account `disconnected` event
+            // can arrive AFTER the new account's `connected` because
+            // repo.swap() resolves via a 3 s safety timeout that doesn't
+            // wait for the underlying disconnect to actually finish. By the
+            // time this lands, isSwitching has already been released by the
+            // connected handler — but we still need to skip the wipe, since
+            // it's the OLD account telling us about itself. The straggler
+            // flag was armed at swap entry exactly for this case.
+            if (pendingSwapDisconnect) {
+                consumePendingSwapDisconnect();
+                pushSyncLog("Disconnected (post-swap straggler from old account — ignored)");
                 return;
             }
             terminateWorker();
@@ -2222,8 +2289,13 @@ export function createAppStore(repo) {
             if (fatal) {
                 // If we're mid-swap, release the guard so the upcoming
                 // `disconnected` event runs the wipe instead of being
-                // swallowed by the swap-in-progress check.
+                // swallowed by the swap-in-progress check. Also consume
+                // the straggler flag — otherwise repo.disconnect() below
+                // would land a `disconnected` event that gets eaten by
+                // the post-swap branch instead of running the wipe we
+                // want for a fatal auth failure.
                 releaseSwitching("fatal error during swap");
+                consumePendingSwapDisconnect();
                 repo.disconnect();
             }
         });
@@ -2255,6 +2327,7 @@ export function createAppStore(repo) {
             if (syncStateTimer) clearTimeout(syncStateTimer);
             if (syncFlipTimer) clearTimeout(syncFlipTimer);
             if (switchingWatchdog) clearTimeout(switchingWatchdog);
+            if (pendingSwapDisconnectTimer) clearTimeout(pendingSwapDisconnectTimer);
             detachConnecting();
             detachAuthing();
             detachStandaloneRedirect();

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -61,7 +61,27 @@ export function createAppStore(repo) {
 
     // True while orchestrating an account swap; tells the global disconnected
     // handler to skip its full state-wipe (we want the snapshot to stay).
+    // Held from `connectToAccount` entry until the new account's `connected`
+    // event fires (or a fatal error / watchdog releases it). Holding past
+    // `repo.swap()` resolution is critical: the swap promise can resolve via
+    // its 3 s timeout before rs.js actually emits the old account's
+    // `disconnected` event, and that late event would otherwise take the
+    // wipe path against the new account.
     let isSwitching = false;
+    // Backstop in case neither `connected` nor a fatal error fires after a
+    // swap (e.g. token rejected silently, OAuth tab closed). Without this,
+    // a single failed swap would lock out future swap attempts via the
+    // `isSwitching` re-entry guard.
+    let switchingWatchdog = null;
+    function releaseSwitching(reason) {
+        if (!isSwitching && !switchingWatchdog) return;
+        isSwitching = false;
+        if (switchingWatchdog) {
+            clearTimeout(switchingWatchdog);
+            switchingWatchdog = null;
+        }
+        if (reason) pushSyncLog(`Swap guard released (${reason})`);
+    }
 
     // ---- core state ----
     let songs = $state([]);
@@ -713,7 +733,21 @@ export function createAppStore(repo) {
         // 4. Swap the rs.js connection. `swap()` disconnects cleanly (which
         //    fires `disconnected`; the global handler skips its wipe because
         //    isSwitching is true) and resets the cache before reconnecting.
+        //    `isSwitching` is intentionally NOT cleared in `finally`: rs.js's
+        //    `disconnected` event for the OLD account can fire after
+        //    `repo.swap()` resolves (the swap promise resolves via its 3 s
+        //    safety timeout before the actual event lands). The connected
+        //    handler clears it on a successful swap; the watchdog clears it
+        //    if neither connected nor a thrown error ever lands.
         isSwitching = true;
+        if (switchingWatchdog) clearTimeout(switchingWatchdog);
+        switchingWatchdog = setTimeout(() => {
+            switchingWatchdog = null;
+            if (isSwitching) {
+                isSwitching = false;
+                pushSyncLog("Swap watchdog: released isSwitching after 15s");
+            }
+        }, 15000);
         try {
             if (repo.isConnected()) {
                 await repo.swap(address, savedToken);
@@ -725,8 +759,7 @@ export function createAppStore(repo) {
         } catch (error) {
             addToast(error?.message || "Could not switch accounts.", "danger");
             connectionStatus = "disconnected";
-        } finally {
-            isSwitching = false;
+            releaseSwitching("swap threw");
         }
     }
 
@@ -2073,6 +2106,12 @@ export function createAppStore(repo) {
 
         const detachConnected = repo.on("connected", async () => {
             clearTimeout(safetyTimer);
+            // Swap landed (or first connect completed). Release the swap
+            // guard now: any further `disconnected` event must be a real
+            // user-initiated disconnect, not the old account's stale
+            // cleanup. Idempotent — does nothing on cold connects where
+            // the guard was never raised.
+            releaseSwitching("connected");
             // Each connect starts a fresh session so prior async work is
             // discarded even on a plain (non-swap) reconnect.
             activeSession += 1;
@@ -2139,6 +2178,13 @@ export function createAppStore(repo) {
             syncRoundCompleted = false;
             initialSyncSettled = false;
             bumpSyncActivity("disconnected");
+            // Reset the pill's high-level state too. Without this, a
+            // disconnect mid-bootstrap (or mid-swap that fell through the
+            // wipe path) leaves syncState pinned at "syncing" — RollScreen
+            // then keeps rendering the sync skeleton forever instead of the
+            // onboarding/login UI.
+            setSyncState("idle");
+            loadError = "";
             clearUserLocalStorage();
             clearUnscopedLocalStorage();
             currentUserAddress = "";
@@ -2160,11 +2206,24 @@ export function createAppStore(repo) {
             loadError = error?.message || "remoteStorage error.";
             addToast(loadError, "danger");
             pushSyncLog(loadError);
+            // Surface the error in the pill/skeleton state. Without this,
+            // setting `loadError` alone keeps maybeMarkSynced blocked while
+            // syncState stays "syncing" — the dot pulses blue forever and
+            // the user never sees the errored state. The next reloadAll
+            // (triggered by user action or fresh remote onChange) will
+            // unconditionally re-set syncState back to "syncing" via the
+            // bumpSyncActivity / setSyncState calls in reloadAll start, so
+            // we don't need a separate recovery path here.
+            setSyncState("error");
             // Only nuke the session for auth/discovery failures. SyncError and
             // friends are typically transient (flaky network, 5xx) — let rs.js
             // retry instead of dropping the user back to the login screen.
             const fatal = error?.name === "Unauthorized" || error?.name === "DiscoveryError";
             if (fatal) {
+                // If we're mid-swap, release the guard so the upcoming
+                // `disconnected` event runs the wipe instead of being
+                // swallowed by the swap-in-progress check.
+                releaseSwitching("fatal error during swap");
                 repo.disconnect();
             }
         });
@@ -2195,6 +2254,7 @@ export function createAppStore(repo) {
             if (syncIndicatorTimer) clearTimeout(syncIndicatorTimer);
             if (syncStateTimer) clearTimeout(syncStateTimer);
             if (syncFlipTimer) clearTimeout(syncFlipTimer);
+            if (switchingWatchdog) clearTimeout(switchingWatchdog);
             detachConnecting();
             detachAuthing();
             detachStandaloneRedirect();

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -101,6 +101,57 @@ export function createAppStore(repo) {
     let syncActiveCount = 0;
     let syncIndicatorTimer = null;
     let syncLogEntries = $state([]);
+    // High-level reload state for the in-app pill / skeletons. Distinct from
+    // syncActiveCount (which tracks per-write bursts) and from
+    // initialSyncComplete (which gates the full-screen sync-shell). This drives
+    // the post-swap experience where the user sees instant snapshot UI but a
+    // background reload is still in flight.
+    let syncState = $state("idle"); // "idle" | "syncing" | "synced" | "error"
+    let syncStateTimer = null;
+    // Count of in-flight reloadAll calls. We can't mark "synced" while any
+    // reload is mid-flight.
+    let reloadInFlight = 0;
+    // Monotonic counter incremented on every reloadAll START. After a reload
+    // completes, it only applies its results if its captured generation is
+    // still the latest — older concurrent reloads (which captured an emptier
+    // cache snapshot) get discarded so their stale results don't clobber a
+    // newer reload's fresh data. Without this, a fast burst of onChange
+    // events during bootstrap can race in completion order and the UI lands
+    // on whichever reload happens to finish last, regardless of how recent
+    // the cache state it captured was.
+    let reloadGen = 0;
+    // Number of documents whose bodies rs.js has not yet pulled from remote.
+    // Read deterministically from the cache after each reloadAll: as long as
+    // any folder has stub entries (children present in the listing but with
+    // no body), the catalog is not actually hydrated — even if rs.js has
+    // already fired sync-done. The pill stays in "syncing" until this hits 0
+    // AND we've seen at least one sync round complete (so we don't false-
+    // resolve before rs.js has pulled the folder listings themselves).
+    let pendingBodies = $state(0);
+    // Set true the first time rs.js fires sync-done {completed: true} since
+    // the last (re)connect. Without this, an empty cache (no listing yet)
+    // would read pendingBodies=0 and resolve immediately.
+    let syncRoundCompleted = false;
+    // rs.js does its work in multiple back-to-back "rounds" — sync-done
+    // {completed:true} fires after each round's queue drains, not when the
+    // whole tree is in. After each round, rs.js waits `syncInterval` ms
+    // (configured in src/lib/remotestorage.js) before starting the next
+    // round; round 1 typically pulls only the root + a few small docs,
+    // round 2 pulls the folder listings, round 3 pulls the bodies. The
+    // only deterministic "all rounds drained" signal is "rs.js's next
+    // polling tick had no new work" — i.e. quiescence for at least one
+    // full sync interval. The settle is therefore matched to rs.js's
+    // bootstrap polling cadence, plus a small buffer for tasks to drain.
+    // Once the pill first flips to "synced", we relax rs.js's polling to
+    // STEADY_SYNC_INTERVAL_MS so the app doesn't hammer the server long-
+    // term — see `relaxSyncInterval()`.
+    const BOOTSTRAP_SYNC_INTERVAL_MS = 2000; // matches rs.js syncInterval set at construction
+    const STEADY_SYNC_INTERVAL_MS = 10000;   // rs.js library default
+    const SYNC_SETTLE_MS = BOOTSTRAP_SYNC_INTERVAL_MS + 500;
+    let syncFlipTimer = null;
+    // Tracks whether we've ever flipped to "synced" since the last
+    // (re)connect. Used to drive the one-time syncInterval relaxation.
+    let initialSyncSettled = false;
 
     // ---- generation options (loaded properly on connect via loadUserLocalData) ----
     let generationOptions = $state(defaultGenerationOptions(DEFAULT_APP_CONFIG));
@@ -430,6 +481,133 @@ export function createAppStore(repo) {
         }
     }
 
+    // [DEBUG SYNC] Tagged logger — flip on in the console with `DEBUG_SYNC=1`.
+    // Centralised so we can change format / silence in one place.
+    function dbg(...args) {
+        if (typeof window !== "undefined" && window.DEBUG_SYNC) {
+            console.log("[sync]", ...args);
+        }
+    }
+
+    function setSyncState(next) {
+        if (syncState !== next) dbg(`syncState: ${syncState} → ${next}`);
+        if (syncStateTimer) {
+            clearTimeout(syncStateTimer);
+            syncStateTimer = null;
+        }
+        // Any state transition cancels a pending flip — if we're going back
+        // to "syncing" the gates failed, and "error"/"idle" make the flip
+        // moot.
+        if (next !== "synced" && syncFlipTimer) {
+            clearTimeout(syncFlipTimer);
+            syncFlipTimer = null;
+        }
+        syncState = next;
+        // "synced" is a transient confirmation — fade back to idle so the pill
+        // doesn't linger forever after a successful background reload.
+        if (next === "synced") {
+            // Bootstrap is over: relax rs.js's polling to its steady-state
+            // interval so we don't hammer the server every 2 s for the rest
+            // of the session. Only do this once per connect.
+            if (!initialSyncSettled) {
+                initialSyncSettled = true;
+                relaxSyncInterval();
+            }
+            syncStateTimer = setTimeout(() => {
+                if (syncState === "synced") syncState = "idle";
+                syncStateTimer = null;
+            }, 2500);
+        }
+    }
+
+    function relaxSyncInterval() {
+        try {
+            const current = repo.getSyncInterval();
+            if (current < STEADY_SYNC_INTERVAL_MS) {
+                dbg(`relaxSyncInterval: ${current}ms → ${STEADY_SYNC_INTERVAL_MS}ms`);
+                repo.setSyncInterval(STEADY_SYNC_INTERVAL_MS);
+            }
+        } catch (e) {
+            // Non-fatal: bootstrap interval keeps polling, just more
+            // frequently than ideal. Log and move on.
+            dbg(`relaxSyncInterval failed: ${e?.message || e}`);
+        }
+    }
+
+    function tightenSyncInterval() {
+        try {
+            const current = repo.getSyncInterval();
+            if (current > BOOTSTRAP_SYNC_INTERVAL_MS) {
+                dbg(`tightenSyncInterval: ${current}ms → ${BOOTSTRAP_SYNC_INTERVAL_MS}ms`);
+                repo.setSyncInterval(BOOTSTRAP_SYNC_INTERVAL_MS);
+            }
+        } catch (e) {
+            dbg(`tightenSyncInterval failed: ${e?.message || e}`);
+        }
+    }
+
+    // Cancel any pending "synced" flip because rs.js just told us it's still
+    // working. Called from every signal that proves activity is ongoing:
+    // sync-started, sync-req-done, remote onChange, reloadAll start. The
+    // pending flip will be re-scheduled by the next maybeMarkSynced() call
+    // once the gates pass again.
+    function bumpSyncActivity(reason) {
+        if (syncFlipTimer) {
+            dbg(`bumpSyncActivity: cancelling pending flip (${reason})`);
+            clearTimeout(syncFlipTimer);
+            syncFlipTimer = null;
+        }
+    }
+
+    // Decide whether sync activity is genuinely settled. Three deterministic
+    // gates, all read from real state:
+    //   1. No reloadAll currently running.
+    //   2. The cache has zero pending document bodies.
+    //   3. rs.js has reported at least one completed sync round in this
+    //      session — guards against an empty cache (no folder listing yet)
+    //      reading as "0 pending" and false-resolving on connect.
+    // The gates can pass after round 1 with the cache still empty (rs.js
+    // hasn't yet pulled the catalog folders); rs.js then waits one full
+    // `syncInterval` before starting the next round. The only way to know
+    // "no more rounds are coming" is to observe one full polling interval
+    // of silence. SYNC_SETTLE_MS = syncInterval + small buffer encodes
+    // exactly that: any sync-started / sync-req-done / remote onChange /
+    // reloadAll bumpSyncActivity()s and re-arms the gate. Once a full poll
+    // cycle elapses without any of those, rs.js's next scheduled wake-up
+    // demonstrably found no new work — and only then do we flip "synced".
+    function maybeMarkSynced() {
+        const reason =
+            syncState !== "syncing" ? `not-syncing(${syncState})` :
+            reloadInFlight > 0 ? `reloadInFlight=${reloadInFlight}` :
+            pendingBodies > 0 ? `pendingBodies=${pendingBodies}` :
+            !syncRoundCompleted ? "syncRoundCompleted=false" :
+            loadError ? "loadError" :
+            null;
+        dbg(`maybeMarkSynced: ${reason ? `blocked by ${reason}` : "scheduling flip"} (state=${syncState} reload=${reloadInFlight} pending=${pendingBodies} round=${syncRoundCompleted})`);
+        if (reason) return;
+        // Already scheduled — let the existing timer run; nothing has changed
+        // that would justify resetting it.
+        if (syncFlipTimer) return;
+        syncFlipTimer = setTimeout(() => {
+            syncFlipTimer = null;
+            // Re-check the gates: any of them may have flipped during the
+            // settle window (a new reload kicked off, a body event landed).
+            const blocker =
+                syncState !== "syncing" ? `not-syncing(${syncState})` :
+                reloadInFlight > 0 ? `reloadInFlight=${reloadInFlight}` :
+                pendingBodies > 0 ? `pendingBodies=${pendingBodies}` :
+                !syncRoundCompleted ? "syncRoundCompleted=false" :
+                loadError ? "loadError" :
+                null;
+            if (blocker) {
+                dbg(`syncFlipTimer fired but gates failed: ${blocker}`);
+                return;
+            }
+            dbg("syncFlipTimer fired — FLIPPING to synced");
+            setSyncState("synced");
+        }, SYNC_SETTLE_MS);
+    }
+
     // ---- navigation ----
     function syncRouteFromHash() {
         const next = window.location.hash.replace(/^#\/?/, "") || "roll";
@@ -515,6 +693,21 @@ export function createAppStore(repo) {
         clearSyncLog();
         connectionStatus = "connecting";
         syncStatusLabel = "Switching accounts";
+        // Snapshot path skips the full-screen sync-shell, so the user lands on
+        // Roll instantly. Mark sync in-flight up front so the TopBar pill and
+        // RollScreen skeletons render immediately rather than waiting for
+        // reloadAll() to start. Reset the per-session sync gates — the new
+        // account starts a fresh round and inherits no completion state from
+        // the previous session.
+        setSyncState("syncing");
+        syncRoundCompleted = false;
+        pendingBodies = 0;
+        initialSyncSettled = false;
+        bumpSyncActivity("account swap");
+        // The previous account may have relaxed rs.js to its steady-state
+        // polling interval; tighten it back up so the new account gets a
+        // snappy bootstrap.
+        tightenSyncInterval();
         pushSyncLog(`Switching to ${address}`);
 
         // 4. Swap the rs.js connection. `swap()` disconnects cleanly (which
@@ -597,6 +790,20 @@ export function createAppStore(repo) {
 
     // ---- data loading ----
     async function reloadAll({ quiet = false, session = activeSession } = {}) {
+        const callId = Math.random().toString(36).slice(2, 6);
+        // Capture this reload's generation. By the time we return, a newer
+        // reload may have started; if so, that newer one captured a more
+        // recent cache snapshot and ours is stale. We discard our results
+        // even though our session matches.
+        reloadGen += 1;
+        const myGen = reloadGen;
+        dbg(`reloadAll[${callId}] START gen=${myGen} session=${session}/${activeSession} quiet=${quiet}`);
+        // Starting a reload is unambiguous proof of activity — cancel any
+        // pending "synced" flip from the previous round so we don't resolve
+        // while we're literally about to re-read the cache.
+        bumpSyncActivity("reloadAll start");
+        setSyncState("syncing");
+        reloadInFlight += 1;
         try {
             busyMessage = quiet ? "" : "Loading your songs...";
             loadError = "";
@@ -611,6 +818,19 @@ export function createAppStore(repo) {
                 pushSyncLog("Discarded stale load (account swapped)");
                 return;
             }
+            // Guard against this reload being superseded by a newer one
+            // started while we were awaiting loadAll. The newer reload
+            // captured a fresher cache snapshot — applying our (older)
+            // results would regress the in-memory state.
+            if (myGen !== reloadGen) {
+                dbg(`reloadAll[${callId}] DISCARD gen=${myGen} (current=${reloadGen}) — superseded by newer reload`);
+                pushSyncLog("Discarded superseded load");
+                return;
+            }
+            // Update the pending count even if we early-return below — the
+            // pill state depends on it being current.
+            pendingBodies = data.pendingBodies || 0;
+            dbg(`reloadAll[${callId}] data: ${data.songs.length} songs, pendingBodies=${pendingBodies}, hasConfig=${!!data.config}`);
             songs = data.songs.map(normalizeSongRecord);
             bootstrapMeta = data.bootstrap;
             appConfig = data.config ? normalizeAppConfig(data.config) : null;
@@ -641,9 +861,19 @@ export function createAppStore(repo) {
             loadError = error?.message || "Could not load remote data.";
             addToast(loadError, "danger");
             pushSyncLog(loadError);
+            // Stale results from an old session shouldn't flip the indicator —
+            // the live session will resolve its own state.
+            if (session === activeSession) setSyncState("error");
         } finally {
+            reloadInFlight = Math.max(0, reloadInFlight - 1);
             busyMessage = "";
             initialSyncComplete = true;
+            dbg(`reloadAll[${callId}] END gen=${myGen} songs=${songs.length} pending=${pendingBodies} reloadInFlight=${reloadInFlight}`);
+            // Try to resolve the pill. Falls through silently if any of the
+            // gates (pending bodies, in-flight reloads, sync round) aren't
+            // satisfied yet — a later reload (triggered by an onChange when
+            // the next body arrives) will check again.
+            if (session === activeSession) maybeMarkSynced();
         }
     }
 
@@ -1249,12 +1479,12 @@ export function createAppStore(repo) {
                 await repo.deleteSong(song.id);
             }
             // Delete all setlists from RS (list from remote to catch any beyond in-memory state)
-            const allSetlists = await repo.listSetlists();
+            const { setlists: allSetlists } = await repo.listSetlists();
             for (const setlist of allSetlists) {
                 await repo.deleteSetlist(setlist.id);
             }
             // Delete all members from RS (list from remote to catch any beyond in-memory state)
-            const allMembers = await repo.listMembers();
+            const { members: allMembers } = await repo.listMembers();
             for (const name of Object.keys(allMembers)) {
                 await repo.deleteMember(name);
             }
@@ -1806,13 +2036,39 @@ export function createAppStore(repo) {
             pushSyncLog("Redirecting this app to the remoteStorage login");
         });
         const detachSyncStarted = repo.on("sync-started", () => {
+            dbg("rs.js event: sync-started");
             pushSyncLog("Sync cycle started");
+            // Diagnostic only. We deliberately do NOT bumpSyncActivity or
+            // setSyncState("syncing") here: rs.js fires sync-started for
+            // every sync cycle, including periodic ETag-refresh cycles that
+            // accomplish no actual data movement. Treating those as
+            // "activity" pinned the flip indefinitely (each ~2 s poll
+            // cancelled the pending settle). Real data movement is signaled
+            // by remote `onChange` events, which DO bumpSyncActivity and
+            // re-set the syncing state — so any actual round 2/3 work
+            // during bootstrap, or genuine remote changes during steady
+            // state, will correctly extend / re-arm the indicator.
         });
         const detachSyncReqDone = repo.on("sync-req-done", (event) => {
+            dbg(`rs.js event: sync-req-done tasksRemaining=${event?.tasksRemaining ?? 0}`);
             pushSyncLog(`Sync request finished, ${event?.tasksRemaining ?? 0} remaining`);
+            // Diagnostic only — see sync-started above. A task completing
+            // doesn't imply data changed (refresh tasks finish without
+            // firing onChange when ETags match).
         });
         const detachSyncDone = repo.on("sync-done", (event) => {
+            dbg(`rs.js event: sync-done completed=${event?.completed}`);
             pushSyncLog(event?.completed ? "Sync cycle completed" : "Sync cycle paused for retry");
+            // sync-done {completed:true} is necessary but not sufficient: rs.js
+            // sometimes fires this before all body change events propagate, so
+            // pendingBodies (read from the cache after each reload) is the
+            // authoritative gate. We just record the milestone — the actual
+            // pill flip happens once the next reloadAll lands and confirms
+            // pendingBodies === 0.
+            if (event?.completed) {
+                syncRoundCompleted = true;
+                maybeMarkSynced();
+            }
         });
 
         const detachConnected = repo.on("connected", async () => {
@@ -1821,6 +2077,18 @@ export function createAppStore(repo) {
             // discarded even on a plain (non-swap) reconnect.
             activeSession += 1;
             connectionStatus = "connected";
+            // Fresh connection — clear any cross-session sync gates so the
+            // pill doesn't inherit completion state from the previous
+            // account. (connectToAccount already resets these for the
+            // snapshot path; this covers cold connect and OAuth-redirect.)
+            syncRoundCompleted = false;
+            pendingBodies = 0;
+            initialSyncSettled = false;
+            bumpSyncActivity("connected");
+            // Cold connect / OAuth path: ensure rs.js is in bootstrap-pace
+            // polling. (connectToAccount already does this for swaps.)
+            tightenSyncInterval();
+            if (syncState !== "error") setSyncState("syncing");
             connectAddress = repo.getUserAddress() || connectAddress;
             currentUserAddress = connectAddress;
             loadUserLocalData();
@@ -1866,6 +2134,11 @@ export function createAppStore(repo) {
             terminateWorker();
             isGenerating = false;
             connectionStatus = "disconnected";
+            reloadInFlight = 0;
+            pendingBodies = 0;
+            syncRoundCompleted = false;
+            initialSyncSettled = false;
+            bumpSyncActivity("disconnected");
             clearUserLocalStorage();
             clearUnscopedLocalStorage();
             currentUserAddress = "";
@@ -1897,7 +2170,16 @@ export function createAppStore(repo) {
         });
 
         const detachChange = repo.onChange(async (event) => {
+            dbg(`rs.js change: path=${event?.relativePath || event?.path || "?"} origin=${event?.origin} oldVal=${typeof event?.oldValue} newVal=${typeof event?.newValue}`);
             if (connectionStatus !== "connected" || event?.origin === "window") return;
+            // Remote-origin events mean rs.js is streaming bodies in. Show
+            // activity in the pill even if no reload runs (defensive — the
+            // reload below will normally handle this), and cancel any
+            // pending settle-window flip since data is still arriving.
+            if (event?.origin === "remote") {
+                bumpSyncActivity("remote onChange");
+                if (syncState !== "error") setSyncState("syncing");
+            }
             // Pin the session at the moment the event fired. If the user
             // swaps accounts mid-reload, the awaited reloadAll() returns
             // into a different session and we drop its results.
@@ -1911,6 +2193,8 @@ export function createAppStore(repo) {
             window.removeEventListener("hashchange", syncRouteFromHash);
             clearTimeout(safetyTimer);
             if (syncIndicatorTimer) clearTimeout(syncIndicatorTimer);
+            if (syncStateTimer) clearTimeout(syncStateTimer);
+            if (syncFlipTimer) clearTimeout(syncFlipTimer);
             detachConnecting();
             detachAuthing();
             detachStandaloneRedirect();
@@ -1953,6 +2237,7 @@ export function createAppStore(repo) {
         get syncIndicatorVisible() { return syncIndicatorVisible; },
         get syncStatusLabel() { return syncStatusLabel; },
         get syncActivelyRunning() { return syncActiveCount > 0; },
+        get syncState() { return syncState; },
         get syncLogEntries() { return syncLogEntries; },
         get generationOptions() { return generationOptions; },
         get editorSong() { return editorSong; },

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -9,6 +9,10 @@ export function deepMerge(left = {}, right = {}) {
         const leftValue = base[key];
         const rightValue = right[key];
 
+        // Skip undefined right-hand values so they don't clobber the left
+        // (otherwise a partial override silently erases defaults).
+        if (rightValue === undefined) return;
+
         if (
             leftValue &&
             rightValue &&


### PR DESCRIPTION
## Summary

Batched fixes for issues #41–#50 from the comprehensive review, plus follow-on fixes that surfaced while testing the swap flow on real accounts.

### Issues #41–#50 (original scope)

- **#41** `forgetAccount` now removes all per-account scoped keys (snapshot, ui-options, current-set, saved-sets), not just snapshot — no more orphan state.
- **#42** `repo.swap()` adds a 3s safety timeout on the `disconnected` await so a missed event can't strand the user on the old account's UI.
- **#43** Wired a `$effect` watching songs/appConfig/savedSetlists/bandMembers that calls `scheduleSnapshot()` — direct edits now refresh the snapshot instead of waiting for the next `reloadAll`.
- **#44** Removed the dead `generationOptions = deepMerge(...)` line in `restoreSnapshot` (caller's `loadUserLocalData` overwrites it anyway).
- **#45** `addSetlistSong` no longer sets an off-by-one `position` field; `scoreFixedOrder` re-stamps it.
- **#46** `saveCurrentSetlist` now tracks `loadedSavedId`. Re-saving a loaded setlist updates the existing entry instead of creating a duplicate with a fresh random name. Cleared on new generation, on remove, and on clear.
- **#47** `connectStorage` no longer declared `async` (it never awaited) — closes the swap-guard foot-gun.
- **#48** `generate()` captures `activeSession` at dispatch and the `onmessage` guard checks it, so worker results from a previous account session are discarded even when the new account is also connected.
- **#49** `saveSong` uses `String(editorSong.name || "").trim()` so an undefined name can't TypeError.
- **#50** `defaultGenerationOptions` uses `??` for numeric defaults (a user-set `0`/`temperature: 0` no longer falls back). `deepMerge` skips `undefined` right-hand values so partial overrides don't clobber defaults.

### Additional fixes from swap-flow testing

- **#69 (cold-start bodies)** — `listSongs`, `listSetlists`, and `listMembers` now filter out stub entries returned by `client.getAll(path, false)` and surface them as a `pending` count instead of treating empty objects as records. Songs no longer briefly appear as garbage entries on first connect to a new device.
- **Post-swap "songs invisible until reload"** — Root cause is in rs.js itself: `Sync._rs_cleanup` nulls `remoteStorage.sync` on disconnect but leaves `caching.activateHandler` pointing at the dead Sync's lambda. Subsequent `caching.enable(path)` then routes activation to the dead handler instead of `pendingActivations`, and the new Sync never queues a sync task — every `forAllNodes`-based fallback (`collectDiffTasks`, `collectRefreshTasks`) iterates an empty IndexedDB (because `IndexedDB._rs_cleanup` deleted the DB). Workaround in `createRemoteStorageRepository` clears `caching.activateHandler` and `pendingActivations` before every `caching.enable()` so activation reliably flows through `pendingActivations` → new Sync's `onActivate`. Filed upstream: https://github.com/remotestorage/remotestorage.js/issues/1375.
- **Sync state machine + visible feedback** — TopBar gains a `Syncing… / Up to date / Sync failed` pill driven by an explicit `syncState` in `app.svelte.js`, with deterministic settle gates (`reloadInFlight`, `pendingBodies`, `syncRoundCompleted`) and a settle window matched to rs.js's polling interval. RollScreen shows a sync-skeleton placeholder during initial bootstrap so a newly-switched account doesn't briefly look identical to a fresh one. Partial step toward #62 (no Retry CTA yet, but a stalled sync now surfaces visibly instead of silently spinning).
- **Reload race protection** — `reloadAll` adds a monotonic `reloadGen` to discard superseded reloads when remote `change` events fire in a tight burst. Without this, the UI could land on whichever reload finished last regardless of how recent the cache state it captured was.
- **Sync interval transitions** — Bootstrap at rs.js's 2 000 ms minimum for snappy first-sync, relax to 10 000 ms once the first round settles. New `repo.getSyncInterval` / `setSyncInterval` / `syncAndWait` helpers expose this safely.
- **RollScreen song-picker fix** — `filteredPickerSongs` was a `$derived(() => {...})` storing a function reference; converted to `$derived.by` so it reactively recomputes when `addSongSearch` or `store.songs` change.

## Test plan
- [x] `npm test` — 262 tests passing (was 260; +2 regression tests for the activateHandler clear in swap and connect paths)
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [ ] Manual: forget an account, verify all four storage keys gone (#41)
- [ ] Manual: swap accounts mid-edit, verify snapshot reflects latest local state (#43)
- [ ] Manual: load a saved setlist, press Save again — verify entry is updated, not duplicated (#46)
- [ ] Manual: set count/temperature to 0 in advanced options — verify it sticks (#50)
- [ ] Manual: swap to a second account, verify songs appear without page reload (post-swap fix)
- [ ] Manual: observe sync pill during bootstrap (Syncing… → Up to date)
- [ ] Manual: cold connect on a fresh browser profile, verify no garbage stub songs appear briefly (#69)