### PR TITLE
fix: keep all inputs at 16px+ to stop iOS focus-zoom

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Project rules
+
+Notes for anyone (human or AI) writing code in this repo.
+
+## CSS / UI
+
+### Inputs must never be smaller than 16px on iOS
+
+iOS Safari auto-zooms when you focus an `<input>`, `<select>`, or `<textarea>`
+whose computed `font-size` is below 16px, and it does **not** zoom back out
+cleanly afterwards. The user is left with a permanently magnified app until
+they pinch-out manually.
+
+**Rule:** every focusable text-style control must have a computed
+`font-size >= 16px`. This applies to:
+
+- `<input>` (text, search, email, url, tel, number, password, date, time, etc.)
+- `<select>`
+- `<textarea>`
+- Anything with `contenteditable`
+
+Range, checkbox, radio, file, color, button, submit, reset inputs do **not**
+trigger the zoom and can be smaller — but it's safest to default to 16px and
+only step down when you have a clear visual reason.
+
+**How:**
+
+- The base rule lives in `src/app.css`:
+  ```css
+  input, select, textarea { font-size: 16px; }
+  ```
+- Don't override it lower in component styles. If you must change the size,
+  keep it `>= 16px` and add a comment noting why.
+- Prefer `font-size: 16px` over `1rem`. If we ever change the root font-size,
+  rem-based controls drift below 16px silently.
+- Visually-hidden checkboxes inside custom chip/toggle components are exempt
+  (they never receive direct focus that triggers zoom), but the visible label
+  text still follows normal type rules.
+
+When adding a new input, take 30 seconds to confirm the rendered size in
+DevTools' computed styles panel. The bug is silent on desktop and only shows
+up the first time someone opens the app on an actual iPhone.

--- a/src/app.css
+++ b/src/app.css
@@ -132,6 +132,16 @@ textarea {
     color: inherit;
 }
 
+/*
+ * iOS Safari auto-zooms when you focus an input whose computed font-size is
+ * below 16px, and never zooms back out cleanly. Every input, select, and
+ * textarea in this app MUST stay at >= 16px on focus — including any
+ * component-level overrides. Use `font-size: 16px` (not rem) so future
+ * root-font tweaks can't drop a control below the threshold.
+ *
+ * Lint check: any `.foo input { font-size: ... }` rule that resolves to
+ * < 16px must be raised to 16px and have a comment pointing here.
+ */
 input,
 select,
 textarea {

--- a/src/lib/components/band/BandScreen.svelte
+++ b/src/lib/components/band/BandScreen.svelte
@@ -640,7 +640,8 @@
     .text-input.small {
         min-height: 2.2rem;
         padding: 0.4rem 0.7rem;
-        font-size: 0.85rem;
+        /* iOS zooms inputs <16px on focus — keep at 16px to prevent zoom. */
+        font-size: 16px;
     }
 
     .select-input {
@@ -649,7 +650,8 @@
         border-radius: var(--radius-md, 16px);
         border: 1px solid var(--line, rgba(27, 49, 80, 0.12));
         background: var(--surface);
-        font-size: 0.9rem;
+        /* iOS zooms selects <16px on focus — keep at 16px to prevent zoom. */
+        font-size: 16px;
         font-weight: 600;
         color: var(--ink, #182230);
         cursor: pointer;

--- a/src/lib/components/roll/RollScreen.svelte
+++ b/src/lib/components/roll/RollScreen.svelte
@@ -968,7 +968,8 @@
     border: 1px solid var(--line);
     border-radius: var(--radius-md, 12px);
     background: var(--surface);
-    font-size: 0.85rem;
+    /* iOS zooms inputs <16px on focus — keep at 16px to prevent zoom. */
+    font-size: 16px;
     font-weight: 600;
     -moz-appearance: textfield;
   }
@@ -1256,7 +1257,8 @@
     padding: 0.5rem 0.75rem;
     border: 1px solid var(--line, rgba(27, 49, 80, 0.12));
     border-radius: var(--radius-md, 12px);
-    font-size: 0.88rem;
+    /* iOS zooms inputs <16px on focus — keep at 16px to prevent zoom. */
+    font-size: 16px;
     outline: none;
     box-sizing: border-box;
   }

--- a/src/lib/components/saved/SavedScreen.svelte
+++ b/src/lib/components/saved/SavedScreen.svelte
@@ -451,7 +451,8 @@
     border: 1px solid var(--line-strong);
     border-radius: var(--radius-md, 12px);
     background: var(--paper-strong);
-    font-size: 0.85rem;
+    /* iOS zooms inputs <16px on focus — keep at 16px to prevent zoom. */
+    font-size: 16px;
     font-weight: 600;
     color: var(--ink, #182230);
   }
@@ -463,7 +464,6 @@
   }
 
   .edit-input.date {
-    font-size: 0.8rem;
     color: var(--muted, #617086);
   }
 


### PR DESCRIPTION
## Summary
- Fixes the iOS Safari focus-zoom that was triggered by editing a setlist name on the Saved screen — and 6 other inputs with the same latent bug. iOS auto-zooms inputs whose computed `font-size` is <16px on focus and never zooms back out cleanly, leaving the whole app magnified.
- Raises every offending control to `16px`, with a comment pointing back to the rule in each spot.
- Adds `AGENTS.md` documenting the >=16px rule for future work, and strengthens the base CSS rule in `src/app.css` with an explanatory comment.

## Inputs raised to 16px
| File | Selector | Was |
|---|---|---|
| `SavedScreen.svelte` | `.edit-input` (setlist name + date) | `0.85rem` / `0.8rem` |
| `RollScreen.svelte` | `.adv-field input` (max covers, max instrumentals, seed) | `0.85rem` |
| `RollScreen.svelte` | `.add-song-search` | `0.88rem` |
| `BandScreen.svelte` | `.text-input.small` (new tuning, new technique) | `0.85rem` |
| `BandScreen.svelte` | `.select-input` (default instrument, import mode, advanced config dropdowns) | `0.9rem` |

Inputs that were already correct (1rem / 16px+) were left alone: the connect/first-run inputs, songs search, song editor fields, the number stepper, and the visually-hidden checkbox inside `ChipToggle`.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [x] `npm run test` — 262/262 pass
- [ ] Manual: open the app on iOS Safari, focus the setlist-name editor, the roll-settings number fields, the add-song search, and a Band screen `<select>`. Confirm none of them trigger zoom.