### PR TITLE
fix(toast): stack, wrap, decouple from busy chip, type the tone

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -191,9 +191,12 @@
 {/if}
 
 {#if store.toastMessages.length > 0}
-    {@const latest = store.toastMessages[store.toastMessages.length - 1]}
-    <div class="toast-pill {latest.tone}" aria-live="polite">
-        {latest.message}
+    <div class="toast-stack" class:with-busy={!!store.busyMessage} aria-live="polite">
+        {#each store.toastMessages as toast (toast.id)}
+            <div class="toast-pill {toast.tone}">
+                {toast.message}
+            </div>
+        {/each}
     </div>
 {/if}
 
@@ -543,13 +546,30 @@
         flex-shrink: 0;
     }
 
-    /* ---- Toast pill ---- */
-    .toast-pill {
+    /* ---- Toast stack ---- */
+    .toast-stack {
         position: fixed;
         top: var(--top-bar-height);
         left: 50%;
         transform: translateX(-50%);
+        z-index: 300;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: var(--space-1);
         max-width: calc(100vw - 2rem);
+        pointer-events: none;
+    }
+
+    /* When the busy chip is showing, drop the toast stack below it so they
+       don't sit on top of each other. The chip is anchored at top-bar +
+       space-2 and is roughly space-8 tall once padding/text are accounted for. */
+    .toast-stack.with-busy {
+        top: calc(var(--top-bar-height) + var(--space-8) + var(--space-2));
+    }
+
+    .toast-pill {
+        max-width: 100%;
         padding: 5px 14px;
         font-size: 0.78rem;
         font-weight: 600;
@@ -559,11 +579,10 @@
         border: none;
         border-radius: 0 0 var(--radius-md, 12px) var(--radius-md, 12px);
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-        z-index: 300;
-        pointer-events: none;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
+        /* Allow long error/info messages to wrap instead of getting truncated
+           with an ellipsis — the user needs to read the whole error. */
+        white-space: normal;
+        overflow-wrap: anywhere;
         animation: toast-slide-down 200ms ease;
     }
 
@@ -582,7 +601,7 @@
     }
 
     @keyframes toast-slide-down {
-        from { opacity: 0; transform: translateX(-50%) translateY(-8px); }
-        to { opacity: 1; transform: translateX(-50%) translateY(0); }
+        from { opacity: 0; transform: translateY(-8px); }
+        to { opacity: 1; transform: translateY(0); }
     }
 </style>

--- a/src/lib/components/saved/SavedScreen.svelte
+++ b/src/lib/components/saved/SavedScreen.svelte
@@ -77,7 +77,7 @@
     const pdfTitle = `${bandName} - ${setName}`;
     const esc = (s) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
     const win = window.open("", "_blank", "width=800,height=600");
-    if (!win) { store.addToast("Popup blocked — please allow popups to print.", "warning"); return; }
+    if (!win) { store.toastWarn("Popup blocked — please allow popups to print."); return; }
     win.document.write(`<!DOCTYPE html>
 <html><head><title>${esc(pdfTitle)}</title>
 <style>

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -10,6 +10,20 @@ import { clone, deepMerge, formatDelimitedList, getByPath, nowIso, parseDelimite
 const STORAGE_PREFIX = "setlist-roller";
 const MAX_SAVED_SETS = 5;
 
+// Toast tone vocabulary. Values are the CSS class names that style the pill;
+// callers go through the typed toastInfo/toastWarn/toastError helpers so a
+// typo can't silently fall back to the default style.
+const TOAST_TONE = Object.freeze({
+    INFO: "info",
+    WARN: "warning",
+    DANGER: "danger",
+});
+const VALID_TOAST_TONES = new Set(Object.values(TOAST_TONE));
+// Stack cap. New toasts past this drop the oldest so each one is visible.
+const MAX_TOASTS = 3;
+// Danger gets a longer dwell so multi-line error messages can actually be read.
+const TOAST_DURATION_MS = { default: 6000, danger: 12000 };
+
 function randomFrom(arr) { return arr[Math.floor(Math.random() * arr.length)]; }
 export function normalizeAuthToken(token) {
     return typeof token === "string" && token.length > 0 ? token : undefined;
@@ -443,14 +457,22 @@ export function createAppStore(repo) {
     }
 
     // ---- toast ----
-    function addToast(message, tone = "info") {
+    function addToast(message, tone) {
+        // Unknown tones fall back to INFO instead of silently rendering as the
+        // default style with no semantic class (e.g. "warn" vs "warning").
+        const validTone = VALID_TOAST_TONES.has(tone) ? tone : TOAST_TONE.INFO;
         const id = uid("toast");
-        toastMessages = [...toastMessages, { id, message, tone }];
-        const duration = tone === "danger" ? 8000 : 6000;
+        // Cap the stack — drop oldest so a fresh toast is always visible.
+        const next = [...toastMessages, { id, message, tone: validTone }];
+        toastMessages = next.length > MAX_TOASTS ? next.slice(-MAX_TOASTS) : next;
+        const duration = validTone === TOAST_TONE.DANGER ? TOAST_DURATION_MS.danger : TOAST_DURATION_MS.default;
         setTimeout(() => {
             toastMessages = toastMessages.filter((t) => t.id !== id);
         }, duration);
     }
+    function toastInfo(message)  { addToast(message, TOAST_TONE.INFO); }
+    function toastWarn(message)  { addToast(message, TOAST_TONE.WARN); }
+    function toastError(message) { addToast(message, TOAST_TONE.DANGER); }
 
     function pushSyncLog(message) {
         if (!message) return;
@@ -642,7 +664,7 @@ export function createAppStore(repo) {
     // ---- connection ----
     function connectStorage(token) {
         if (!connectAddress.trim()) {
-            addToast("Put in a remoteStorage address first.", "danger");
+            toastError("Put in a remoteStorage address first.");
             return;
         }
         const normalizedToken = normalizeAuthToken(token);
@@ -666,7 +688,7 @@ export function createAppStore(repo) {
         // Refuse if a connect/swap is already in flight — clicking switch
         // mid-discovery used to take the wrong branch and double-connect.
         if (connectionStatus === "connecting" || isSwitching) {
-            addToast("Already connecting — hold on.", "warning");
+            toastWarn("Already connecting — hold on.");
             return;
         }
         if (!address) return;
@@ -757,7 +779,7 @@ export function createAppStore(repo) {
                 connectStorage(savedToken);
             }
         } catch (error) {
-            addToast(error?.message || "Could not switch accounts.", "danger");
+            toastError(error?.message || "Could not switch accounts.");
             connectionStatus = "disconnected";
             releaseSwitching("swap threw");
         }
@@ -892,7 +914,7 @@ export function createAppStore(repo) {
             pushSyncLog("Initial data load finished");
         } catch (error) {
             loadError = error?.message || "Could not load remote data.";
-            addToast(loadError, "danger");
+            toastError(loadError);
             pushSyncLog(loadError);
             // Stale results from an old session shouldn't flip the indicator —
             // the live session will resolve its own state.
@@ -913,7 +935,7 @@ export function createAppStore(repo) {
     async function finishFirstRun() {
         const bandName = firstRunBandName.trim();
         if (!bandName) {
-            addToast("Your band needs a name.", "danger");
+            toastError("Your band needs a name.");
             return;
         }
         try {
@@ -922,9 +944,9 @@ export function createAppStore(repo) {
             generationOptions = defaultGenerationOptions(appConfig);
             persistGenerationOptions();
             showFirstRunPrompt = false;
-            addToast(`Welcome, ${bandName}.`);
+            toastInfo(`Welcome, ${bandName}.`);
         } catch (error) {
-            addToast(error?.message || "Could not save your band name.", "danger");
+            toastError(error?.message || "Could not save your band name.");
         } finally {
             busyMessage = "";
         }
@@ -1007,13 +1029,13 @@ export function createAppStore(repo) {
     function generate(overrideOptions = {}) {
         if (isGenerating) return;
         if (!songs.length) {
-            addToast("Can't roll with no songs! Add a few first.", "danger");
+            toastError("Can't roll with no songs! Add a few first.");
             navigate("songs");
             return;
         }
         const eligibleSongs = songs.filter((s) => !s.unpracticed);
         if (!eligibleSongs.length) {
-            addToast("Every song is unpracticed. Time to rehearse!", "danger");
+            toastError("Every song is unpracticed. Time to rehearse!");
             return;
         }
 
@@ -1050,11 +1072,11 @@ export function createAppStore(repo) {
             }
             isGenerating = false;
             if (!result) {
-                addToast(randomFrom([
+                toastError(randomFrom([
                     "The generator tripped over a cable.",
                     "Something went sideways. Blame the bassist.",
                     "Critical fumble — try again?",
-                ]), "danger");
+                ]));
                 return;
             }
             replaceGeneratedSetlist(result);
@@ -1066,16 +1088,16 @@ export function createAppStore(repo) {
             }
             persistCurrentSetlist();
             if (result.summary?.minimumsRelaxed || !validateConstraintMinimums(result)) {
-                addToast("Couldn't meet every demand, but it got close.", "warning");
+                toastWarn("Couldn't meet every demand, but it got close.");
             }
             if (result.summary?.openerFilterRelaxed) {
-                addToast("No valid opener found in catalog.", "warning");
+                toastWarn("No valid opener found in catalog.");
             }
             if (result.summary?.closerFilterRelaxed) {
-                addToast("No valid closer found in catalog.", "warning");
+                toastWarn("No valid closer found in catalog.");
             }
             const n = generatedSetlist.songs.length;
-            addToast(randomFrom([
+            toastInfo(randomFrom([
                 `🎲 The dice have spoken. ${n} songs.`,
                 `${n} songs, rolled fresh. No refunds.`,
                 `Behold: ${n} tracks of pure destiny.`,
@@ -1087,11 +1109,11 @@ export function createAppStore(repo) {
             worker.terminate();
             if (worker === activeWorker) activeWorker = null;
             isGenerating = false;
-            addToast(randomFrom([
+            toastError(randomFrom([
                 "The generator tripped over a cable.",
                 "Something went sideways. Blame the bassist.",
                 "Critical fumble — try again?",
-            ]), "danger");
+            ]));
         };
     }
 
@@ -1100,7 +1122,7 @@ export function createAppStore(repo) {
         if (setlistLocked) return;
         setlistLocked = true;
         persistCurrentSetlist();
-        addToast(randomFrom([
+        toastInfo(randomFrom([
             "Setlist locked in. No take-backs.",
             "It's canon now.",
             "Sealed. This one's going on stage.",
@@ -1166,7 +1188,7 @@ export function createAppStore(repo) {
             setlistSaved = true;
             loadedSavedId = entry.id;
         } catch (error) {
-            addToast(error?.message || "Could not save setlist.", "danger");
+            toastError(error?.message || "Could not save setlist.");
         }
     }
 
@@ -1176,7 +1198,7 @@ export function createAppStore(repo) {
             savedSetlists = savedSetlists.filter((s) => s.id !== id);
             if (loadedSavedId === id) loadedSavedId = "";
         } catch (error) {
-            addToast(error?.message || "Could not remove setlist.", "danger");
+            toastError(error?.message || "Could not remove setlist.");
         }
     }
 
@@ -1188,7 +1210,7 @@ export function createAppStore(repo) {
             await withSync("Updating setlist", () => repo.putSetlist(merged));
             savedSetlists = savedSetlists.map((s) => s.id === id ? merged : s);
         } catch (error) {
-            addToast(error?.message || "Could not update setlist.", "danger");
+            toastError(error?.message || "Could not update setlist.");
         }
     }
 
@@ -1204,7 +1226,7 @@ export function createAppStore(repo) {
         setlistSaved = true;
         loadedSavedId = id;
         persistCurrentSetlist();
-        addToast(`Loaded ${saved.songs?.length || 0}-song set.`);
+        toastInfo(`Loaded ${saved.songs?.length || 0}-song set.`);
     }
 
     function reorderSetlistSong(fromIndex, toIndex) {
@@ -1410,7 +1432,7 @@ export function createAppStore(repo) {
 
     async function saveSong() {
         if (!editorSong || !String(editorSong.name || "").trim()) {
-            addToast("Songs need names.", "danger");
+            toastError("Songs need names.");
             return;
         }
         try {
@@ -1469,9 +1491,9 @@ export function createAppStore(repo) {
             }
 
             closeEditor();
-            addToast(`Saved "${saved.name}".`);
+            toastInfo(`Saved "${saved.name}".`);
         } catch (error) {
-            addToast(error?.message || "Could not save.", "danger");
+            toastError(error?.message || "Could not save.");
         } finally {
             busyMessage = "";
         }
@@ -1484,7 +1506,7 @@ export function createAppStore(repo) {
         });
         editorSong = copy;
         selectedSongId = "";
-        addToast(`Duplicated "${song.name}".`);
+        toastInfo(`Duplicated "${song.name}".`);
     }
 
     async function deleteSong(song) {
@@ -1494,9 +1516,9 @@ export function createAppStore(repo) {
             await withSync("Removing song", () => repo.deleteSong(song.id));
             songs = songs.filter((e) => e.id !== song.id);
             if (editorSong?.id === song.id) closeEditor();
-            addToast(`Deleted "${song.name}".`);
+            toastInfo(`Deleted "${song.name}".`);
         } catch (error) {
-            addToast(error?.message || "Could not delete.", "danger");
+            toastError(error?.message || "Could not delete.");
         } finally {
             busyMessage = "";
         }
@@ -1539,9 +1561,9 @@ export function createAppStore(repo) {
             navigate("roll");
             generationOptions = defaultGenerationOptions(DEFAULT_APP_CONFIG);
             persistGenerationOptions();
-            addToast("All data deleted. Name your band to start fresh.");
+            toastInfo("All data deleted. Name your band to start fresh.");
         } catch (error) {
-            addToast(error?.message || "Could not delete.", "danger");
+            toastError(error?.message || "Could not delete.");
         } finally {
             busyMessage = "";
         }
@@ -1581,9 +1603,9 @@ export function createAppStore(repo) {
                 saveKnownAccount(currentUserAddress, { bandName: appConfig.bandName }, repo.getToken());
                 knownAccounts = getKnownAccounts();
             }
-            addToast("Settings saved.");
+            toastInfo("Settings saved.");
         } catch (error) {
-            addToast(error?.message || "Could not save config.", "danger");
+            toastError(error?.message || "Could not save config.");
         } finally {
             busyMessage = "";
         }
@@ -1598,7 +1620,7 @@ export function createAppStore(repo) {
             persistGenerationOptions();
             return true;
         } catch (error) {
-            addToast(error?.message || errorMessage, "danger");
+            toastError(error?.message || errorMessage);
             return false;
         }
     }
@@ -1611,19 +1633,19 @@ export function createAppStore(repo) {
             await withSync("Saving member", () => repo.putMember(memberName, normalized));
             return true;
         } catch (error) {
-            addToast(error?.message || errorMessage, "danger");
+            toastError(error?.message || errorMessage);
             return false;
         }
     }
 
     async function addBandMember() {
         const clean = newMemberName.trim();
-        if (!clean) { addToast("Name the member first.", "danger"); return; }
-        if (bandMemberEntries.some(([n]) => n === clean)) { addToast("Already exists.", "danger"); return; }
+        if (!clean) { toastError("Name the member first."); return; }
+        if (bandMemberEntries.some(([n]) => n === clean)) { toastError("Already exists."); return; }
         if (await persistMemberEdit(clean, { instruments: [] }, "Could not add member.")) {
             expandedBandMember = clean;
             newMemberName = "";
-            addToast(`Added "${clean}".`);
+            toastInfo(`Added "${clean}".`);
         }
     }
 
@@ -1641,9 +1663,9 @@ export function createAppStore(repo) {
             next[clean] = data;
             bandMembers = next;
             if (expandedBandMember === oldName) expandedBandMember = clean;
-            addToast(`Renamed "${oldName}" to "${clean}".`);
+            toastInfo(`Renamed "${oldName}" to "${clean}".`);
         } catch (error) {
-            addToast(error?.message || "Could not rename member.", "danger");
+            toastError(error?.message || "Could not rename member.");
         }
     }
 
@@ -1690,22 +1712,22 @@ export function createAppStore(repo) {
             delete next[memberName];
             bandMembers = next;
             if (expandedBandMember === memberName) expandedBandMember = "";
-            addToast(`Removed "${memberName}".`);
+            toastInfo(`Removed "${memberName}".`);
         } catch (error) {
-            addToast(error?.message || "Could not remove member.", "danger");
+            toastError(error?.message || "Could not remove member.");
         }
     }
 
     async function addBandMemberInstrument(memberName) {
         const draft = (newInstrumentByMember[memberName] || "").trim();
-        if (!draft) { addToast("Type an instrument name first.", "danger"); return; }
+        if (!draft) { toastError("Type an instrument name first."); return; }
         const member = bandMembers[memberName] || { instruments: [] };
         const current = member.instruments || [];
-        if (current.some((i) => i.name === draft)) { addToast("Already on this member.", "danger"); return; }
+        if (current.some((i) => i.name === draft)) { toastError("Already on this member."); return; }
         const updated = { ...member, instruments: current.concat({ name: draft, tunings: [], defaultTuning: "", techniques: [], defaultTechnique: "" }) };
         if (await persistMemberEdit(memberName, updated)) {
             newInstrumentByMember = { ...newInstrumentByMember, [memberName]: "" };
-            addToast(`Added ${draft} for ${memberName}.`);
+            toastInfo(`Added ${draft} for ${memberName}.`);
         }
     }
 
@@ -1722,7 +1744,7 @@ export function createAppStore(repo) {
         }
         const member = bandMembers[memberName] || { instruments: [] };
         const updated = { ...member, instruments: (member.instruments || []).filter((i) => i.name !== instrumentName) };
-        if (await persistMemberEdit(memberName, updated)) addToast(`Removed ${instrumentName} from ${memberName}.`);
+        if (await persistMemberEdit(memberName, updated)) toastInfo(`Removed ${instrumentName} from ${memberName}.`);
     }
 
     function tuningDraftKey(memberName, instrumentName) {
@@ -1749,16 +1771,16 @@ export function createAppStore(repo) {
     async function addTuningChoice(memberName, instrumentName) {
         const draftKey = tuningDraftKey(memberName, instrumentName);
         const clean = (newTuningByInstrument[draftKey] || "").trim();
-        if (!clean) { addToast("Type a tuning name first.", "danger"); return; }
+        if (!clean) { toastError("Type a tuning name first."); return; }
         await ensureBandInstrument(memberName, instrumentName);
         const member = bandMembers[memberName] || { instruments: [] };
         const currentInstruments = member.instruments || [];
         const current = currentInstruments.find((i) => i.name === instrumentName);
-        if ((current?.tunings || []).includes(clean)) { addToast("Already exists.", "danger"); return; }
+        if ((current?.tunings || []).includes(clean)) { toastError("Already exists."); return; }
         const updated = { ...member, instruments: currentInstruments.map((i) => i.name !== instrumentName ? i : { ...i, tunings: (i.tunings || []).concat(clean) }) };
         if (await persistMemberEdit(memberName, updated)) {
             newTuningByInstrument = { ...newTuningByInstrument, [draftKey]: "" };
-            addToast(`Added "${clean}" to ${instrumentName}.`);
+            toastInfo(`Added "${clean}" to ${instrumentName}.`);
         }
         return clean;
     }
@@ -1778,7 +1800,7 @@ export function createAppStore(repo) {
             ...i, tunings: (i.tunings || []).filter((t) => t !== tuning),
             defaultTuning: i.defaultTuning === tuning ? "" : (i.defaultTuning || "")
         }) };
-        if (await persistMemberEdit(memberName, updated)) addToast(`Removed "${tuning}" from ${instrumentName}.`);
+        if (await persistMemberEdit(memberName, updated)) toastInfo(`Removed "${tuning}" from ${instrumentName}.`);
     }
 
     async function setMemberDefaultInstrument(memberName, instrumentName) {
@@ -1786,7 +1808,7 @@ export function createAppStore(repo) {
         if (!member) return;
         const updated = { ...member, defaultInstrument: instrumentName };
         if (await persistMemberEdit(memberName, updated)) {
-            addToast(instrumentName ? `Default instrument set to "${instrumentName}".` : `Cleared default instrument.`);
+            toastInfo(instrumentName ? `Default instrument set to "${instrumentName}".` : `Cleared default instrument.`);
         }
     }
 
@@ -1795,7 +1817,7 @@ export function createAppStore(repo) {
         const currentInstruments = member.instruments || [];
         const updated = { ...member, instruments: currentInstruments.map((i) => i.name !== instrumentName ? i : { ...i, defaultTuning }) };
         if (await persistMemberEdit(memberName, updated)) {
-            addToast(defaultTuning ? `Default set to "${defaultTuning}".` : `Cleared default tuning.`);
+            toastInfo(defaultTuning ? `Default set to "${defaultTuning}".` : `Cleared default tuning.`);
         }
     }
 
@@ -1806,16 +1828,16 @@ export function createAppStore(repo) {
     async function addTechniqueChoice(memberName, instrumentName) {
         const draftKey = techniqueDraftKey(memberName, instrumentName);
         const clean = (newTechniqueByInstrument[draftKey] || "").trim();
-        if (!clean) { addToast("Type a technique name first.", "danger"); return; }
+        if (!clean) { toastError("Type a technique name first."); return; }
         await ensureBandInstrument(memberName, instrumentName);
         const member = bandMembers[memberName] || { instruments: [] };
         const currentInstruments = member.instruments || [];
         const current = currentInstruments.find((i) => i.name === instrumentName);
-        if ((current?.techniques || []).includes(clean)) { addToast("Already exists.", "danger"); return; }
+        if ((current?.techniques || []).includes(clean)) { toastError("Already exists."); return; }
         const updated = { ...member, instruments: currentInstruments.map((i) => i.name !== instrumentName ? i : { ...i, techniques: (i.techniques || []).concat(clean) }) };
         if (await persistMemberEdit(memberName, updated)) {
             newTechniqueByInstrument = { ...newTechniqueByInstrument, [draftKey]: "" };
-            addToast(`Added "${clean}" technique to ${instrumentName}.`);
+            toastInfo(`Added "${clean}" technique to ${instrumentName}.`);
         }
         return clean;
     }
@@ -1835,7 +1857,7 @@ export function createAppStore(repo) {
             ...i, techniques: (i.techniques || []).filter((t) => t !== technique),
             defaultTechnique: i.defaultTechnique === technique ? "" : (i.defaultTechnique || "")
         }) };
-        if (await persistMemberEdit(memberName, updated)) addToast(`Removed "${technique}" technique from ${instrumentName}.`);
+        if (await persistMemberEdit(memberName, updated)) toastInfo(`Removed "${technique}" technique from ${instrumentName}.`);
     }
 
     async function setInstrumentDefaultTechnique(memberName, instrumentName, defaultTechnique) {
@@ -1843,7 +1865,7 @@ export function createAppStore(repo) {
         const currentInstruments = member.instruments || [];
         const updated = { ...member, instruments: currentInstruments.map((i) => i.name !== instrumentName ? i : { ...i, defaultTechnique }) };
         if (await persistMemberEdit(memberName, updated)) {
-            addToast(defaultTechnique ? `Default technique set to "${defaultTechnique}".` : `Cleared default technique.`);
+            toastInfo(defaultTechnique ? `Default technique set to "${defaultTechnique}".` : `Cleared default technique.`);
         }
     }
 
@@ -1876,7 +1898,7 @@ export function createAppStore(repo) {
         link.click();
         link.remove();
         URL.revokeObjectURL(url);
-        addToast("Exported the whole catalog.");
+        toastInfo("Exported the whole catalog.");
     }
 
     function normalizeImportPayload(payload) {
@@ -1914,7 +1936,7 @@ export function createAppStore(repo) {
     }
 
     async function importFromFile() {
-        if (!importFile) { addToast("Choose a JSON file first.", "danger"); return; }
+        if (!importFile) { toastError("Choose a JSON file first."); return; }
         try {
             busyMessage = "Importing...";
             const text = await importFile.text();
@@ -1953,9 +1975,9 @@ export function createAppStore(repo) {
             const parts = [`${ws} song${ws === 1 ? "" : "s"}`];
             if (imported.savedSetlists?.length) parts.push(`${imported.savedSetlists.length} saved setlist${imported.savedSetlists.length === 1 ? "" : "s"}`);
             if (imported.bandMembers) parts.push(`${Object.keys(imported.bandMembers).length} member${Object.keys(imported.bandMembers).length === 1 ? "" : "s"}`);
-            addToast(`Imported ${parts.join(", ")}.`);
+            toastInfo(`Imported ${parts.join(", ")}.`);
         } catch (error) {
-            addToast(error?.message || "Import failed.", "danger");
+            toastError(error?.message || "Import failed.");
         } finally {
             busyMessage = "";
         }
@@ -2141,7 +2163,7 @@ export function createAppStore(repo) {
                     await runMigrations({ skipReload: true });
                 } catch (err) {
                     console.error("Migration failed:", err);
-                    addToast("Data migration encountered an error. Some data may need re-syncing.", "danger");
+                    toastError("Data migration encountered an error. Some data may need re-syncing.");
                     pushSyncLog("Data migration encountered an error");
                 }
             } else {
@@ -2152,7 +2174,7 @@ export function createAppStore(repo) {
                     await runMigrations();
                 } catch (err) {
                     console.error("Migration/reload failed:", err);
-                    addToast("Data sync encountered an error. Some data may need re-syncing.", "danger");
+                    toastError("Data sync encountered an error. Some data may need re-syncing.");
                     pushSyncLog("Initial sync encountered an error");
                 } finally {
                     endSync();
@@ -2204,7 +2226,7 @@ export function createAppStore(repo) {
 
         const detachError = repo.on("error", (error) => {
             loadError = error?.message || "remoteStorage error.";
-            addToast(loadError, "danger");
+            toastError(loadError);
             pushSyncLog(loadError);
             // Surface the error in the pill/skeleton state. Without this,
             // setting `loadError` alone keeps maybeMarkSynced blocked while
@@ -2417,7 +2439,9 @@ export function createAppStore(repo) {
         exportAllData,
         importFromFile,
         performanceSummary,
-        addToast,
+        toastInfo,
+        toastWarn,
+        toastError,
         songsUsingMember,
         songsUsingInstrument,
         songsUsingTuning,


### PR DESCRIPTION
## Summary

Fixes the four toast bugs from the comprehensive review.

- **#55** — render a stack (capped at 3) instead of only the latest. Earlier toasts no longer disappear silently when a new one arrives; overflow drops the oldest so each fresh toast is visible.
- **#56** — drop `nowrap` / `text-overflow: ellipsis` on the pill so long errors (e.g. `"Could not save setlist: quota exceeded for IndexedDB..."`) wrap instead of truncating. Danger dwell extended from 8s to 12s.
- **#64** — when `busyMessage` is set, the toast stack drops below the busy chip via a `with-busy` modifier so they don't overlap.
- **#73** — typed `TOAST_TONE` constants and `toastInfo` / `toastWarn` / `toastError` helpers replace the stringly-typed second arg. Internal `addToast` validates the tone and falls back to `INFO` rather than silently losing the semantic class on a typo. All 63 call sites migrated; `addToast` is no longer part of the public store API.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 262/262 passing
- [x] `npm run lint` — clean (biome)
- [ ] manual: trigger a save that emits multiple toasts in succession → confirm up to 3 stack, oldest drops on overflow
- [ ] manual: force a long error message → confirm it wraps and stays readable for 12s
- [ ] manual: trigger a save while a toast is visible → confirm the toast sits below the busy chip, no overlap