### PR TITLE
fix(a11y): address review findings #57-58

### DIFF
--- a/src/lib/components/layout/BottomNav.svelte
+++ b/src/lib/components/layout/BottomNav.svelte
@@ -19,7 +19,7 @@
       class:active={store.activeView === tab.id}
       onclick={() => store.navigate(tab.id)}
     >
-      <span class="tab-icon">{tab.icon}</span>
+      <span class="tab-icon" aria-hidden="true">{tab.icon}</span>
       <span class="tab-label">{tab.label}</span>
     </button>
   {/each}

--- a/src/lib/components/layout/BottomSheet.svelte
+++ b/src/lib/components/layout/BottomSheet.svelte
@@ -1,13 +1,109 @@
 <script>
+  import { tick } from "svelte";
+
   let { open = false, onclose, title = "", children } = $props();
+
+  let sheetEl = $state();
+  let previousFocus = null;
+
+  // Focusable elements inside the sheet, used for both initial focus and the
+  // Tab-cycle trap. Excludes anything explicitly opted-out via tabindex="-1".
+  function getFocusableElements() {
+    if (!sheetEl) return [];
+    return [
+      ...sheetEl.querySelectorAll(
+        'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    ];
+  }
+
+  function handleKeydown(e) {
+    if (!open) return;
+
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onclose?.();
+      return;
+    }
+
+    if (e.key === "Tab") {
+      const focusable = getFocusableElements();
+      // Empty sheet: pin focus on the dialog container so Tab can't escape.
+      if (focusable.length === 0) {
+        e.preventDefault();
+        if (sheetEl) sheetEl.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      // If focus has somehow leaked outside the sheet, pull it back in.
+      if (!sheetEl?.contains(active)) {
+        e.preventDefault();
+        first.focus();
+        return;
+      }
+
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+
+  // While open: listen for Escape/Tab on window, move focus into the sheet,
+  // and restore focus to the previously focused element on close.
+  $effect(() => {
+    if (!open) return;
+
+    previousFocus = document.activeElement;
+    window.addEventListener("keydown", handleKeydown);
+
+    tick().then(() => {
+      if (!open) return;
+      const focusable = getFocusableElements();
+      if (focusable.length > 0) {
+        focusable[0].focus();
+      } else if (sheetEl) {
+        sheetEl.focus();
+      }
+    });
+
+    return () => {
+      window.removeEventListener("keydown", handleKeydown);
+      if (
+        previousFocus &&
+        typeof previousFocus.focus === "function" &&
+        document.body.contains(previousFocus)
+      ) {
+        previousFocus.focus();
+      }
+      previousFocus = null;
+    };
+  });
 </script>
 
 {#if open}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="overlay" class:visible={open} onclick={onclose} onkeydown={() => {}}>
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div class="sheet" onclick={(e) => e.stopPropagation()} onkeydown={() => {}}>
-      <div class="handle-area" onclick={onclose} onkeydown={() => {}}>
+  <div class="overlay" class:visible={open} onclick={onclose}>
+    <div
+      class="sheet"
+      bind:this={sheetEl}
+      role="dialog"
+      aria-modal="true"
+      aria-label={title || "Bottom sheet"}
+      tabindex="-1"
+      onclick={(e) => e.stopPropagation()}
+    >
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div class="handle-area" onclick={onclose}>
         <div class="handle"></div>
       </div>
 
@@ -54,6 +150,13 @@
     display: flex;
     flex-direction: column;
     animation: slide-up 0.25s ease;
+  }
+
+  /* The dialog container itself is not part of the visible focus flow — it's
+     only focusable as a fallback when the sheet has no interactive content
+     (e.g. a static info sheet). Hide the focus ring in that case. */
+  .sheet:focus {
+    outline: none;
   }
 
   @keyframes slide-up {

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -1,10 +1,12 @@
 <script>
-  import { getContext } from "svelte";
+  import { getContext, tick } from "svelte";
   import { cycleTheme, getThemePreference } from "../../theme.svelte.js";
 
   const store = getContext("app");
 
   let menuOpen = $state(false);
+  let menuBtnEl = $state();
+  let dropdownEl = $state();
   const themeLabel = { system: "◐ System", light: "☀ Light", dark: "☽ Dark" };
 
   function toggleMenu() {
@@ -45,11 +47,75 @@
     store.connectAddress = "";
     store.disconnectStorage();
   }
+
+  // Focusable items inside the dropdown — used for the Tab cycle and for
+  // moving initial focus into the menu when it opens.
+  function getFocusableElements() {
+    if (!dropdownEl) return [];
+    return [
+      ...dropdownEl.querySelectorAll(
+        'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    ];
+  }
+
+  function handleMenuKeydown(e) {
+    if (!menuOpen) return;
+
+    if (e.key === "Escape") {
+      e.preventDefault();
+      closeMenu();
+      // Return focus to the trigger so keyboard users land somewhere sensible.
+      menuBtnEl?.focus();
+      return;
+    }
+
+    if (e.key === "Tab") {
+      const focusable = getFocusableElements();
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (!dropdownEl?.contains(active)) {
+        e.preventDefault();
+        first.focus();
+        return;
+      }
+
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+
+  // Wire up keyboard handling and initial focus while the menu is open.
+  $effect(() => {
+    if (!menuOpen) return;
+
+    window.addEventListener("keydown", handleMenuKeydown);
+
+    tick().then(() => {
+      if (!menuOpen) return;
+      const focusable = getFocusableElements();
+      if (focusable.length > 0) focusable[0].focus();
+    });
+
+    return () => {
+      window.removeEventListener("keydown", handleMenuKeydown);
+    };
+  });
 </script>
 
 {#if menuOpen}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="menu-backdrop" onclick={closeMenu} onkeydown={() => {}}></div>
+  <div class="menu-backdrop" onclick={closeMenu}></div>
 {/if}
 
 <header class="top-bar">
@@ -70,12 +136,20 @@
   <div class="right">
 
     <div class="menu-wrapper">
-      <button type="button" class="menu-btn" onclick={toggleMenu} aria-label="Menu">
+      <button
+        type="button"
+        class="menu-btn"
+        bind:this={menuBtnEl}
+        onclick={toggleMenu}
+        aria-label="Menu"
+        aria-haspopup="true"
+        aria-expanded={menuOpen}
+      >
         &middot;&middot;&middot;
       </button>
 
       {#if menuOpen}
-        <div class="dropdown">
+        <div class="dropdown" bind:this={dropdownEl}>
           {#if currentAccount}
             <div class="dropdown-current">
               <span class="active-dot"></span>


### PR DESCRIPTION
## Summary
- **#58** — `BottomNav.svelte`: tab-icon glyphs (die / star / eighth-note / cog / `?`) now have `aria-hidden="true"` so VoiceOver no longer announces them alongside the visible label.
- **#57** — `BottomSheet.svelte` and the `TopBar.svelte` account/theme dropdown now:
  - close on `Escape` (window keydown listener attached only while open)
  - trap `Tab` / `Shift+Tab` so focus cycles within the sheet/dropdown
  - move focus into the surface on open
  - restore focus on close (BottomSheet → previously focused element; TopBar → menu trigger)
- Replaced the no-op `onkeydown={() => {}}` a11y placeholders with real keyboard handling, and added `role="dialog"`/`aria-modal` on BottomSheet plus `aria-haspopup`/`aria-expanded` on the TopBar trigger.

Closes #57, closes #58.

## Test plan

### #58 — BottomNav VoiceOver

- [ ] iPad with VoiceOver on: swipe through the five bottom-nav tabs. Each announces only its label (`Roll`, `Saved`, `Songs`, `Band`, `Help`) — no "die symbol", "star", "eighth note", "gear", or "question mark".
- [ ] macOS with VoiceOver on: same — `VO+Right` through the tabs and confirm glyphs are not read.
- [ ] Sighted check: all five glyph icons are still visually rendered above their labels.
- [ ] Inspect DOM: every `.tab-icon` span has `aria-hidden="true"`; every `.tab-label` does not.

### #57 — TopBar dropdown (account/theme menu)

Keyboard:
- [ ] Tab to the `…` menu button, press `Enter`/`Space` → menu opens, focus moves into the first dropdown item.
- [ ] Press `Tab` from the first item → focus moves to the next interactive item.
- [ ] Press `Tab` on the last item ("Theme: …") → focus wraps to the first item.
- [ ] Press `Shift+Tab` on the first item → focus wraps to the last item.
- [ ] Press `Shift+Tab` from the middle of the list → focus moves to the previous item (no wrap).
- [ ] Press `Escape` while menu is open → menu closes and focus returns to the `…` trigger button.
- [ ] Open menu, click the backdrop (outside the dropdown) → menu closes (existing behavior preserved).

ARIA:
- [ ] When closed: trigger button has `aria-haspopup="true"` and `aria-expanded="false"`.
- [ ] When open: trigger button has `aria-expanded="true"`.

State variants (tab cycle covers all items in each):
- [ ] Connected with no other known accounts → cycle is: `Add Account` → `Theme: …` → wraps.
- [ ] Connected with one or more other known accounts → cycle is: each "Switch to" account button → `Add Account` → `Theme: …` → wraps.
- [ ] Disconnected (no current account) → cycle is: `Add Account` → `Theme: …` → wraps; `Escape` still returns focus to trigger.

Listener hygiene:
- [ ] Open and close the menu several times → in DevTools `getEventListeners(window)`, the keydown count does not grow.
- [ ] Open menu, navigate to a different view (e.g. hit a nav tab via mouse) → menu closes, no console errors, no leaked window listeners.

### #57 — BottomSheet (component-level checks; not yet wired into a screen)

Mount a BottomSheet in a scratch view (or via Svelte devtools) with a few buttons inside, then:

Keyboard:
- [ ] Open the sheet from a trigger button → focus moves to the first focusable element inside the sheet.
- [ ] Press `Escape` → sheet closes; `onclose` fires; focus returns to the trigger button that opened it.
- [ ] Press `Tab` repeatedly → focus cycles only within the sheet (overlay/page background never receives focus).
- [ ] Press `Shift+Tab` from the first focusable item → focus wraps to the last focusable item.
- [ ] Press `Tab` from the last focusable item → focus wraps to the first.
- [ ] Open a sheet that contains **no** focusable children → `Tab` is suppressed and focus stays on the dialog container; `Escape` still closes.
- [ ] If focus is forced outside the sheet (e.g. via DevTools), pressing `Tab` pulls it back into the first focusable element.

Mouse / pointer (regression):
- [ ] Click the overlay outside the sheet → sheet closes (existing behavior).
- [ ] Click the drag handle area → sheet closes (existing behavior).
- [ ] Click inside the sheet body → does **not** close (`stopPropagation` still works).

ARIA & focus restoration:
- [ ] Inspect DOM: sheet element has `role="dialog"`, `aria-modal="true"`, `tabindex="-1"`, and `aria-label` equal to `title` (or `"Bottom sheet"` when no title).
- [ ] Trigger comes from a focused button → after close, that button is focused again.
- [ ] Trigger element is removed from the DOM while the sheet is open → close does not throw; focus simply does not restore.

Listener hygiene:
- [ ] Open/close the sheet 5+ times → window keydown listener count stays constant in DevTools.

### Cross-cutting verification

- [ ] `npm run lint` → clean (`Checked 41 files in …ms. No fixes applied.`).
- [ ] `npm test` → all 262 tests across 7 files pass.
- [ ] `npm run build` → succeeds; no new Svelte a11y warnings introduced (pre-existing `theme.svelte.js` warnings unrelated to this PR).
- [ ] Manual smoke test of unrelated screens (Roll / Saved / Songs / Band / Help) → no regressions from the BottomNav change.
- [ ] Reduced motion (`prefers-reduced-motion: reduce`) → BottomSheet still opens/closes correctly; existing animations are unaffected.