### PR TITLE
chore(deps): upgrade remotestoragejs to 2.0.0-beta.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "setlist-roller",
             "version": "1.8.4",
             "dependencies": {
-                "remotestoragejs": "^2.0.0-beta.8",
+                "remotestoragejs": "^2.0.0-beta.9",
                 "rs-migrate": "^1.0.0",
                 "svelte": "^5.28.2"
             },
@@ -2784,7 +2784,10 @@
             "version": "20.14.0",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.0.tgz",
             "integrity": "sha512-5cHBxFGJx6L4s56Bubp4fglrEpmyJypsqI6RgzMfBHWUJQGWAAi8cWcgetEbZXHYXo9C2Fa4EEds/uSyS4cxmA==",
+            "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -2800,12 +2803,6 @@
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
             "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-            "license": "MIT"
-        },
-        "node_modules/@types/tv4": {
-            "version": "1.2.33",
-            "resolved": "https://registry.npmjs.org/@types/tv4/-/tv4-1.2.33.tgz",
-            "integrity": "sha512-7phCVTXC6Bj50IV1iKOwqGkR4JONJyMbRZnKTSuujv1S/tO9rG5OdCt7BMSjytO+zJmYdn1/I4fd3SH0gtO99g==",
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/types": {
@@ -5247,16 +5244,14 @@
             }
         },
         "node_modules/remotestoragejs": {
-            "version": "2.0.0-beta.8",
-            "resolved": "https://registry.npmjs.org/remotestoragejs/-/remotestoragejs-2.0.0-beta.8.tgz",
-            "integrity": "sha512-rtyHTG2VbtiKTRmbwjponRf5VTPJMcHv/ijNid1zX48C0Z0F8ZCBBfkKD2QCxTQyQvCupkWNy3wuIu4HE+AEng==",
+            "version": "2.0.0-beta.9",
+            "resolved": "https://registry.npmjs.org/remotestoragejs/-/remotestoragejs-2.0.0-beta.9.tgz",
+            "integrity": "sha512-d09ByL7ecbZLMuzl4mQ3SXMFlsCwvvINm6l1CfdR8ylvX9E1nsq44t8gmRxzW6GUS5cwonyYA4FRXYKEhARjTA==",
             "license": "MIT",
             "dependencies": {
-                "@types/node": "20.14.0",
-                "@types/tv4": "^1.2.29",
                 "esm": "^3.2.25",
                 "tv4": "^1.3.0",
-                "webfinger.js": "^2.7.1",
+                "webfinger.js": "^3.0.4",
                 "xhr2": "^0.2.1"
             },
             "optionalDependencies": {
@@ -6117,7 +6112,10 @@
             "version": "5.26.5",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
             "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-            "license": "MIT"
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.1",
@@ -6478,10 +6476,10 @@
             }
         },
         "node_modules/webfinger.js": {
-            "version": "2.8.2",
-            "resolved": "https://registry.npmjs.org/webfinger.js/-/webfinger.js-2.8.2.tgz",
-            "integrity": "sha512-Zqn9KXkGrD1tVEm029bVUIfmzef2KXs3G7OZrdqehDHtgv9YSxX1oy4RoPoMk2PHWIifwWCA0xwKZOAZqXMpfg==",
-            "license": "AGPL"
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/webfinger.js/-/webfinger.js-3.0.4.tgz",
+            "integrity": "sha512-5c15N1n4qCm/jGJjUt32mBdPVlSugLbAztIDNBpuDfukGz2E9NhmXPfLikayn2p3kcgEZsI/UOdOwVpxOr8qJA==",
+            "license": "MIT"
         },
         "node_modules/webidl-conversions": {
             "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "format": "biome format --write ."
     },
     "dependencies": {
-        "remotestoragejs": "^2.0.0-beta.8",
+        "remotestoragejs": "^2.0.0-beta.9",
         "rs-migrate": "^1.0.0",
         "svelte": "^5.28.2"
     },

--- a/src/lib/remotestorage.js
+++ b/src/lib/remotestorage.js
@@ -260,30 +260,6 @@ export function createRemoteStorageRepository() {
         defaultAuthorize(options);
     };
 
-    /**
-     * After a disconnect, rs.js's `Sync._rs_cleanup` nulls
-     * `remoteStorage.sync` but does NOT clear `caching.activateHandler` —
-     * which still references the dead Sync's lambda. If we then call
-     * `caching.enable(path)`, `set()` finds the (stale) handler set and
-     * calls it directly, so the path is NOT pushed to `pendingActivations`.
-     * When the new Sync is constructed (on the next `ready` event), its
-     * `caching.onActivate(newCb)` overwrites the handler but finds
-     * `pendingActivations` empty — so the new Sync never receives the
-     * path activation, never queues a root task, and `forAllNodes`-based
-     * fallbacks (`collectDiffTasks`, `collectRefreshTasks`) find nothing
-     * because `IndexedDB._rs_cleanup` already deleted the local DB.
-     *
-     * Net effect: after an account swap, rs.js completes sync rounds
-     * without ever fetching the scope folder — songs never appear until
-     * the page is reloaded (which constructs a fresh Sync from a clean
-     * caching state). Clearing the handler restores the documented
-     * `enable → pendingActivations → new Sync's onActivate` flow.
-     */
-    function resetActivateHandler() {
-        remoteStorage.caching.activateHandler = undefined;
-        remoteStorage.caching.pendingActivations = [];
-    }
-
     return {
         remoteStorage,
         client,
@@ -291,8 +267,6 @@ export function createRemoteStorageRepository() {
         connect(userAddress, token) {
             const normalizedToken = normalizeBearerToken(token);
             // Re-enable caching in case it was reset by a previous disconnect.
-            // Clear the stale activate handler first — see resetActivateHandler.
-            resetActivateHandler();
             remoteStorage.caching.enable(`/${APP_SCOPE}/`);
             remoteStorage.connect(userAddress, normalizedToken);
         },
@@ -308,11 +282,6 @@ export function createRemoteStorageRepository() {
          * cache so the previous account's data can't leak, then connect.
          * Resolves once `connect()` has been issued — callers should still
          * wait for the `connected` event for sync.
-         *
-         * Avoids mutating rs.js internals beyond the documented
-         * disconnect → connect lifecycle, with one exception:
-         * `caching.activateHandler` is cleared before re-enabling — see
-         * resetActivateHandler for the rationale.
          */
         async swap(userAddress, token) {
             if (remoteStorage.connected) {
@@ -334,10 +303,6 @@ export function createRemoteStorageRepository() {
                     remoteStorage.disconnect();
                 });
             }
-            // The OLD Sync's activate handler must be cleared before
-            // enable() — otherwise the path activation goes to the dead
-            // handler and the new Sync never queues any tasks.
-            resetActivateHandler();
             remoteStorage.caching.enable(`/${APP_SCOPE}/`);
             remoteStorage.connect(userAddress, normalizeBearerToken(token));
         },

--- a/src/lib/remotestorage.test.js
+++ b/src/lib/remotestorage.test.js
@@ -31,12 +31,6 @@ beforeEach(() => {
         caching: {
             enable: vi.fn(),
             reset: vi.fn(),
-            // Mirror the rs.js Caching public API used by repo's swap/connect
-            // flow. Tests assert these get cleared so that `enable()` routes
-            // its path through `pendingActivations` for the new Sync to pick
-            // up — see resetActivateHandler in remotestorage.js.
-            activateHandler: undefined,
-            pendingActivations: [],
         },
         scope: vi.fn(() => ({
             declareType: vi.fn(),
@@ -577,64 +571,6 @@ describe("createRemoteStorageRepository", () => {
             rs.connected = false;
             await repo.swap("other@example.com", { type: "click" });
             expect(rs.connect).toHaveBeenCalledWith("other@example.com", undefined);
-        });
-
-        it("clears the stale caching.activateHandler before re-enabling", async () => {
-            // Regression: rs.js's Sync._rs_cleanup leaves
-            // caching.activateHandler pointing at the dead Sync's lambda. If
-            // we don't clear it, enable() routes the path to that defunct
-            // handler instead of pendingActivations, and the new Sync never
-            // queues any sync tasks — the next account's data never loads
-            // until the page is reloaded.
-            const repo = createRemoteStorageRepository();
-            const rs = remoteStorageMockState.instance;
-            rs.connected = true;
-
-            const staleHandler = vi.fn();
-            rs.caching.activateHandler = staleHandler;
-            rs.caching.pendingActivations = ["/setlist-roller/"];
-
-            // Capture the state of caching at the moment enable() is called —
-            // it must already be cleared by then.
-            let handlerAtEnable;
-            let pendingAtEnable;
-            rs.caching.enable.mockImplementation(() => {
-                handlerAtEnable = rs.caching.activateHandler;
-                pendingAtEnable = rs.caching.pendingActivations;
-            });
-
-            let disconnectedHandler;
-            rs.on.mockImplementation((event, handler) => {
-                if (event === "disconnected") disconnectedHandler = handler;
-            });
-
-            const swapPromise = repo.swap("other@example.com", "tok-2");
-            disconnectedHandler();
-            await swapPromise;
-
-            expect(handlerAtEnable).toBeUndefined();
-            expect(pendingAtEnable).toEqual([]);
-            expect(staleHandler).not.toHaveBeenCalled();
-        });
-
-        it("clears caching.activateHandler on direct connect too", () => {
-            // Same regression as the swap path: a connect after disconnect
-            // (without an explicit swap) hits the same stale-handler hazard.
-            const repo = createRemoteStorageRepository();
-            const rs = remoteStorageMockState.instance;
-            const staleHandler = vi.fn();
-            rs.caching.activateHandler = staleHandler;
-            rs.caching.pendingActivations = ["/setlist-roller/"];
-
-            let handlerAtEnable;
-            rs.caching.enable.mockImplementation(() => {
-                handlerAtEnable = rs.caching.activateHandler;
-            });
-
-            repo.connect("user@example.com", "tok");
-
-            expect(handlerAtEnable).toBeUndefined();
-            expect(staleHandler).not.toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
## Summary

- Bumps `remotestoragejs` from `^2.0.0-beta.8` to `^2.0.0-beta.9`.
- Removes the `resetActivateHandler()` workaround from `createRemoteStorageRepository`. beta.9's `Sync._rs_cleanup` now clears `caching.activateHandler` and `pendingActivations` itself (remotestorage/remotestorage.js#1377), so manually clearing them before `caching.enable()` in our `connect()` and `swap()` paths is redundant.
- Drops the two regression tests and mock fields that asserted the workaround. The bug they pinned is now upstream's responsibility, and the tests assert our workaround ran rather than testing rs.js behavior — keeping them would just couple our suite to internal library state we no longer touch.

## Other beta.9 fixes (no code change required)

- **#1374 Fix authorize hash cleanup for non-OAuth fragments** — `new RemoteStorage()` no longer wipes `location.hash` on construction. Bookmarks/deep-links to `#/saved`, `#/songs`, etc. now land on the right view instead of falling back to roll.
- **#1378 Fix IndexedDB recovery for missing stores** — defense-in-depth; we don't probe IndexedDB ourselves, so this just makes hangs from corrupt v1 schemas impossible.
- **#1356 Fix sync skipping PUT for ArrayBuffer bodies** — not applicable (we only use `storeObject`).
- **#1353 Detect auth scope changes across app updates** — new `scope-change-required` event + `reauthorize()` alias. Worth wiring in if/when we ever change the claimed scope; deliberately not adopting it here.