### PR TITLE
fix(connect): connect-screen UX polish and stall recovery (#61, #62, #63, #65)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -100,7 +100,7 @@
                 />
             </label>
 
-            <button type="button" class="btn primary" onclick={() => store.connectStorage()} disabled={store.connectionStatus === "connecting"}>
+            <button type="button" class="btn primary" onclick={() => store.connectStorage()} disabled={store.connectionStatus === "connecting" || !store.connectAddress.trim()}>
                 {store.connectionStatus === "connecting" ? "Connecting..." : "Connect"}
             </button>
 
@@ -146,6 +146,15 @@
                             <span>{entry.message}</span>
                         </div>
                     {/each}
+                </div>
+            {/if}
+            {#if store.syncStalled}
+                <div class="sync-recovery" role="alert">
+                    <p class="sync-recovery-text">This is taking longer than usual. The remote storage may be slow or unreachable.</p>
+                    <div class="sync-recovery-actions">
+                        <button type="button" class="btn primary" onclick={() => store.retrySync()}>Retry</button>
+                        <button type="button" class="btn" onclick={() => store.disconnectStorage()}>Disconnect</button>
+                    </div>
                 </div>
             {/if}
         </div>
@@ -323,6 +332,30 @@
         white-space: nowrap;
     }
 
+    .sync-recovery {
+        width: 100%;
+        display: grid;
+        gap: var(--space-3);
+        padding: var(--space-3);
+        border-radius: var(--radius-lg);
+        background: var(--paper-strong);
+        border: 1px solid var(--line);
+        text-align: center;
+    }
+
+    .sync-recovery-text {
+        margin: 0;
+        font-size: 0.85rem;
+        color: var(--muted);
+    }
+
+    .sync-recovery-actions {
+        display: flex;
+        gap: var(--space-2);
+        justify-content: center;
+        flex-wrap: wrap;
+    }
+
     @keyframes pulse-fade {
         0%, 100% { transform: scale(1); }
         50% { transform: scale(1.06); }
@@ -445,6 +478,11 @@
 
     .recent-account-btn {
         flex: 1;
+        /* min-width: 0 lets the flex item shrink below its content's intrinsic
+           width so a long .recent-address can be ellipsised instead of pushing
+           the row past the card. */
+        min-width: 0;
+        overflow: hidden;
         display: grid;
         gap: 0.15rem;
         padding: 0.6rem 0.75rem;
@@ -469,7 +507,9 @@
     .recent-address {
         font-size: 0.75rem;
         color: var(--muted);
-        word-break: break-all;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 
     .recent-forget {

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -185,6 +185,10 @@ export function createAppStore(repo) {
     // Count of in-flight reloadAll calls. We can't mark "synced" while any
     // reload is mid-flight.
     let reloadInFlight = 0;
+    // Bumped when manual recovery abandons a stalled reload. Late completions
+    // from older epochs are still stale via reloadGen, and should not touch
+    // in-flight accounting for the fresh retry.
+    let reloadEpoch = 0;
     // Monotonic counter incremented on every reloadAll START. After a reload
     // completes, it only applies its results if its captured generation is
     // still the latest — older concurrent reloads (which captured an emptier
@@ -935,6 +939,7 @@ export function createAppStore(repo) {
     // ---- data loading ----
     async function reloadAll({ quiet = false, session = activeSession } = {}) {
         const callId = Math.random().toString(36).slice(2, 6);
+        const myEpoch = reloadEpoch;
         // Capture this reload's generation. By the time we return, a newer
         // reload may have started; if so, that newer one captured a more
         // recent cache snapshot and ours is stale. We discard our results
@@ -1017,31 +1022,38 @@ export function createAppStore(repo) {
             // the live session will resolve its own state.
             if (session === activeSession) setSyncState("error");
         } finally {
-            reloadInFlight = Math.max(0, reloadInFlight - 1);
-            busyMessage = "";
-            initialSyncComplete = true;
-            // Only the last in-flight reload should clear the watchdog —
-            // a fast one finishing while a slow one is still pulling
-            // shouldn't drop the stall guard.
-            if (reloadInFlight === 0) {
-                if (syncStalledTimer) clearTimeout(syncStalledTimer);
-                syncStalledTimer = null;
-                syncStalled = false;
+            if (myEpoch === reloadEpoch) {
+                reloadInFlight = Math.max(0, reloadInFlight - 1);
+                busyMessage = "";
+                initialSyncComplete = true;
+                // Only the last in-flight reload should clear the watchdog —
+                // a fast one finishing while a slow one is still pulling
+                // shouldn't drop the stall guard.
+                if (reloadInFlight === 0) {
+                    if (syncStalledTimer) clearTimeout(syncStalledTimer);
+                    syncStalledTimer = null;
+                    syncStalled = false;
+                }
+            } else {
+                dbg(`reloadAll[${callId}] ignored stale epoch ${myEpoch} (current=${reloadEpoch})`);
             }
             dbg(`reloadAll[${callId}] END gen=${myGen} songs=${songs.length} pending=${pendingBodies} reloadInFlight=${reloadInFlight}`);
             // Try to resolve the pill. Falls through silently if any of the
             // gates (pending bodies, in-flight reloads, sync round) aren't
             // satisfied yet — a later reload (triggered by an onChange when
             // the next body arrives) will check again.
-            if (session === activeSession) maybeMarkSynced();
+            if (session === activeSession && myEpoch === reloadEpoch) maybeMarkSynced();
         }
     }
 
     // Manual recovery for the stall watchdog. Invoked from the sync-shell's
-    // Retry button. We don't try to abort a stuck rs.js operation — just
-    // start a fresh reloadAll on top of it. If the underlying load finally
-    // resolves, our generation guards (reloadGen) discard its stale results.
+    // Retry button. We don't try to abort a stuck rs.js operation; instead
+    // we retire it from our accounting and start a fresh reload. If the
+    // underlying load finally resolves, its generation/epoch guards keep it
+    // from applying stale data or blocking the retry.
     async function retrySync() {
+        reloadEpoch += 1;
+        reloadInFlight = 0;
         syncStalled = false;
         if (syncStalledTimer) {
             clearTimeout(syncStalledTimer);

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -28,6 +28,19 @@ export function normalizeAuthToken(token) {
     return typeof token === "string" && token.length > 0 ? token : undefined;
 }
 
+// Sanity-check a remoteStorage address before handing it to webfinger
+// discovery. Accepts either `user@host.tld` or a bare `host.tld`. We
+// can't validate that the host actually serves remoteStorage without a
+// network round-trip — this just rejects obvious typos so the user
+// gets immediate feedback instead of a 1–3 s spinner ending in a
+// confusing rs.js error.
+const CONNECT_ADDRESS_RE = /^([^\s@]+@)?[^\s@.]+\.[^\s@]+$/;
+
+export function isValidConnectAddress(address) {
+    if (typeof address !== "string") return false;
+    return CONNECT_ADDRESS_RE.test(address.trim());
+}
+
 export function syncSavedSongIntoSetlist(setlist, savedSong, appConfig, keyFlow = false) {
     if (!setlist?.songs?.length || !savedSong?.id) return setlist;
 
@@ -213,6 +226,15 @@ export function createAppStore(repo) {
     // Tracks whether we've ever flipped to "synced" since the last
     // (re)connect. Used to drive the one-time syncInterval relaxation.
     let initialSyncSettled = false;
+    // Watchdog for stalled reloads. If reloadAll runs longer than
+    // SYNC_STALL_TIMEOUT_MS (15 s) — flaky network, rs.js stuck mid-pull —
+    // surface a Retry / Disconnect CTA in the sync-shell so the user
+    // isn't trapped on a spinner. The init flow already has its own 10 s
+    // pending → disconnected fallback (init() below); this covers the
+    // gap once the connection has succeeded but the data load hangs.
+    const SYNC_STALL_TIMEOUT_MS = 15000;
+    let syncStalled = $state(false);
+    let syncStalledTimer = null;
 
     // ---- generation options (loaded properly on connect via loadUserLocalData) ----
     let generationOptions = $state(defaultGenerationOptions(DEFAULT_APP_CONFIG));
@@ -703,8 +725,15 @@ export function createAppStore(repo) {
 
     // ---- connection ----
     function connectStorage(token) {
-        if (!connectAddress.trim()) {
+        const trimmed = connectAddress.trim();
+        if (!trimmed) {
             toastError("Put in a remoteStorage address first.");
+            return;
+        }
+        if (!isValidConnectAddress(trimmed)) {
+            // Inline error — webfinger would otherwise spin 1–3 s before
+            // reporting a confusing DiscoveryError.
+            loadError = "That doesn't look like a remoteStorage address. Try user@host or host.tld.";
             return;
         }
         const normalizedToken = normalizeAuthToken(token);
@@ -712,8 +741,8 @@ export function createAppStore(repo) {
         connectionStatus = "connecting";
         loadError = "";
         syncStatusLabel = "Connecting to remoteStorage";
-        pushSyncLog(`Connecting to ${connectAddress.trim()}`);
-        repo.connect(connectAddress.trim(), normalizedToken);
+        pushSyncLog(`Connecting to ${trimmed}`);
+        repo.connect(trimmed, normalizedToken);
     }
 
     function disconnectStorage() {
@@ -919,6 +948,16 @@ export function createAppStore(repo) {
         bumpSyncActivity("reloadAll start");
         setSyncState("syncing");
         reloadInFlight += 1;
+        // Re-arm the stall watchdog. Cleared in `finally`, so each reload
+        // gets its own fresh window — long-running rs.js streams that
+        // emit progress through onChange (which kicks a new reload) keep
+        // resetting the timer instead of falsely tripping it.
+        if (syncStalledTimer) clearTimeout(syncStalledTimer);
+        syncStalled = false;
+        syncStalledTimer = setTimeout(() => {
+            syncStalledTimer = null;
+            if (reloadInFlight > 0) syncStalled = true;
+        }, SYNC_STALL_TIMEOUT_MS);
         try {
             busyMessage = quiet ? "" : "Loading your songs...";
             loadError = "";
@@ -981,6 +1020,14 @@ export function createAppStore(repo) {
             reloadInFlight = Math.max(0, reloadInFlight - 1);
             busyMessage = "";
             initialSyncComplete = true;
+            // Only the last in-flight reload should clear the watchdog —
+            // a fast one finishing while a slow one is still pulling
+            // shouldn't drop the stall guard.
+            if (reloadInFlight === 0) {
+                if (syncStalledTimer) clearTimeout(syncStalledTimer);
+                syncStalledTimer = null;
+                syncStalled = false;
+            }
             dbg(`reloadAll[${callId}] END gen=${myGen} songs=${songs.length} pending=${pendingBodies} reloadInFlight=${reloadInFlight}`);
             // Try to resolve the pill. Falls through silently if any of the
             // gates (pending bodies, in-flight reloads, sync round) aren't
@@ -988,6 +1035,20 @@ export function createAppStore(repo) {
             // the next body arrives) will check again.
             if (session === activeSession) maybeMarkSynced();
         }
+    }
+
+    // Manual recovery for the stall watchdog. Invoked from the sync-shell's
+    // Retry button. We don't try to abort a stuck rs.js operation — just
+    // start a fresh reloadAll on top of it. If the underlying load finally
+    // resolves, our generation guards (reloadGen) discard its stale results.
+    async function retrySync() {
+        syncStalled = false;
+        if (syncStalledTimer) {
+            clearTimeout(syncStalledTimer);
+            syncStalledTimer = null;
+        }
+        pushSyncLog("User triggered retry");
+        await reloadAll({ quiet: true });
     }
 
     async function finishFirstRun() {
@@ -2268,6 +2329,9 @@ export function createAppStore(repo) {
             pendingBodies = 0;
             syncRoundCompleted = false;
             initialSyncSettled = false;
+            if (syncStalledTimer) clearTimeout(syncStalledTimer);
+            syncStalledTimer = null;
+            syncStalled = false;
             bumpSyncActivity("disconnected");
             // Reset the pill's high-level state too. Without this, a
             // disconnect mid-bootstrap (or mid-swap that fell through the
@@ -2349,6 +2413,7 @@ export function createAppStore(repo) {
             if (syncIndicatorTimer) clearTimeout(syncIndicatorTimer);
             if (syncStateTimer) clearTimeout(syncStateTimer);
             if (syncFlipTimer) clearTimeout(syncFlipTimer);
+            if (syncStalledTimer) clearTimeout(syncStalledTimer);
             if (switchingWatchdog) clearTimeout(switchingWatchdog);
             if (pendingSwapDisconnectTimer) clearTimeout(pendingSwapDisconnectTimer);
             detachConnecting();
@@ -2395,6 +2460,8 @@ export function createAppStore(repo) {
         get syncActivelyRunning() { return syncActiveCount > 0; },
         get syncState() { return syncState; },
         get syncLogEntries() { return syncLogEntries; },
+        get syncStalled() { return syncStalled; },
+        retrySync,
         get generationOptions() { return generationOptions; },
         get editorSong() { return editorSong; },
         get selectedSongId() { return selectedSongId; },

--- a/src/lib/stores/app.test.js
+++ b/src/lib/stores/app.test.js
@@ -1,7 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { DEFAULT_APP_CONFIG } from "../defaults.js";
-import { isValidConnectAddress, normalizeAuthToken, syncSavedSongIntoSetlist } from "./app.svelte.js";
+import { createAppStore, isValidConnectAddress, normalizeAuthToken, syncSavedSongIntoSetlist } from "./app.svelte.js";
+
+afterEach(() => {
+    vi.useRealTimers();
+});
 
 describe("normalizeAuthToken", () => {
     it("keeps non-empty string tokens", () => {
@@ -44,6 +48,39 @@ describe("isValidConnectAddress", () => {
         expect(isValidConnectAddress(null)).toBe(false);
         expect(isValidConnectAddress(undefined)).toBe(false);
         expect(isValidConnectAddress(42)).toBe(false);
+    });
+});
+
+describe("retrySync", () => {
+    it("recovers from a stalled reload even if the original load never resolves", async () => {
+        vi.useFakeTimers();
+        let calls = 0;
+        const repo = {
+            loadAll: vi.fn(() => {
+                calls += 1;
+                if (calls === 1) return new Promise(() => {});
+                return Promise.resolve({
+                    songs: [],
+                    pendingBodies: 0,
+                    bootstrap: null,
+                    config: DEFAULT_APP_CONFIG,
+                    setlists: [],
+                    members: {},
+                });
+            }),
+        };
+        const store = createAppStore(repo);
+
+        store.retrySync();
+        await vi.advanceTimersByTimeAsync(15000);
+        expect(store.syncStalled).toBe(true);
+
+        await store.retrySync();
+        expect(store.syncStalled).toBe(false);
+        expect(store.initialSyncComplete).toBe(true);
+
+        await vi.advanceTimersByTimeAsync(15000);
+        expect(store.syncStalled).toBe(false);
     });
 });
 

--- a/src/lib/stores/app.test.js
+++ b/src/lib/stores/app.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { DEFAULT_APP_CONFIG } from "../defaults.js";
-import { normalizeAuthToken, syncSavedSongIntoSetlist } from "./app.svelte.js";
+import { isValidConnectAddress, normalizeAuthToken, syncSavedSongIntoSetlist } from "./app.svelte.js";
 
 describe("normalizeAuthToken", () => {
     it("keeps non-empty string tokens", () => {
@@ -12,6 +12,38 @@ describe("normalizeAuthToken", () => {
         expect(normalizeAuthToken({ type: "click" })).toBeUndefined();
         expect(normalizeAuthToken("")).toBeUndefined();
         expect(normalizeAuthToken(null)).toBeUndefined();
+    });
+});
+
+describe("isValidConnectAddress", () => {
+    it("accepts user@host addresses", () => {
+        expect(isValidConnectAddress("nick@silverbucket.net")).toBe(true);
+        expect(isValidConnectAddress("user@5apps.com")).toBe(true);
+    });
+
+    it("accepts bare host names", () => {
+        expect(isValidConnectAddress("storage.example.com")).toBe(true);
+        expect(isValidConnectAddress("example.org")).toBe(true);
+    });
+
+    it("trims whitespace before validating", () => {
+        expect(isValidConnectAddress("  nick@silverbucket.net  ")).toBe(true);
+    });
+
+    it("rejects obvious garbage", () => {
+        expect(isValidConnectAddress("not an address")).toBe(false);
+        expect(isValidConnectAddress("nick@")).toBe(false);
+        expect(isValidConnectAddress("@example.com")).toBe(false);
+        expect(isValidConnectAddress("nohost")).toBe(false);
+        expect(isValidConnectAddress(".com")).toBe(false);
+        expect(isValidConnectAddress("")).toBe(false);
+        expect(isValidConnectAddress("   ")).toBe(false);
+    });
+
+    it("rejects non-string input", () => {
+        expect(isValidConnectAddress(null)).toBe(false);
+        expect(isValidConnectAddress(undefined)).toBe(false);
+        expect(isValidConnectAddress(42)).toBe(false);
     });
 });
 

--- a/tests/e2e/connection.spec.ts
+++ b/tests/e2e/connection.spec.ts
@@ -38,11 +38,11 @@ test.describe("Connection screen", () => {
         await expect(shell.rollTab).toBeVisible({ timeout: 10_000 });
     });
 
-    test("rejects empty address (button stays disabled-ish, no app shell appears)", async ({ page, app }) => {
+    test("Connect button is disabled when address is empty", async ({ page, app }) => {
         await app.goto();
         const connect = new ConnectPage(page);
         await connect.waitForVisible();
-        await connect.connectButton.click();
+        await expect(connect.connectButton).toBeDisabled();
         // App shell never appears
         await expect(page.locator("nav.bottom-nav")).toHaveCount(0);
     });


### PR DESCRIPTION
## Summary
- **#65** Disable Connect when the address input is empty.
- **#63** Validate the remoteStorage address client-side; show an inline error instead of letting webfinger spin for 1–3 s.
- **#61** Truncate long addresses on recent-account rows so they can't push past the card width.
- **#62** When an active `reloadAll` runs past 15 s, surface a **Retry / Disconnect** CTA in the sync-shell so the user isn't trapped on a spinner.

## Test plan
- [ ] Open the connect screen with an empty input — Connect button is disabled.
- [ ] Type a string with a space (e.g. `not an address`) and press Enter — inline error appears immediately, no network round-trip.
- [ ] Type a valid address (`user@host.tld` or `host.tld`) — connection proceeds normally.
- [ ] Add a recent account with a very long address — row stays inside the card; address ellipsises.
- [ ] Block the network (or stall rs.js) during initial sync; after ~15 s the Retry / Disconnect buttons appear. Retry kicks a fresh `reloadAll`; Disconnect returns to the connect screen.
- [ ] `npm test` (267 tests pass, including 5 new for `isValidConnectAddress`).
- [ ] `npm run lint` and `npm run build` clean.