### PR TITLE
fix(remotestorage): partial offline-first loads, atomic member rename, cold-start coverage

### DIFF
--- a/src/lib/remotestorage.js
+++ b/src/lib/remotestorage.js
@@ -383,64 +383,100 @@ export function createRemoteStorageRepository() {
         },
 
         async loadAll({ onStep } = {}) {
+            // Each slice loads independently so a single failed read (network
+            // hiccup, 5xx on a folder, malformed body) doesn't blank the UI.
+            // We use Promise.allSettled instead of Promise.all and surface
+            // failures through the returned `errors` map; the caller decides
+            // what to keep, what to warn about, and what to retry.
+            const slices = [
+                [
+                    "songs",
+                    () =>
+                        this.listSongs().then((result) => {
+                            onStep?.(
+                                `Loaded ${result.songs.length} songs${result.pending ? ` (${result.pending} pending)` : ""}`,
+                            );
+                            return result;
+                        }),
+                ],
+                [
+                    "config",
+                    () =>
+                        this.getConfig().then((config) => {
+                            onStep?.(config ? "Loaded settings" : "No settings found yet");
+                            return config;
+                        }),
+                ],
+                [
+                    "bootstrap",
+                    () =>
+                        this.getBootstrapMeta().then((bootstrap) => {
+                            onStep?.(bootstrap ? "Loaded bootstrap info" : "No bootstrap info found");
+                            return bootstrap;
+                        }),
+                ],
+                [
+                    "setlists",
+                    () =>
+                        this.listSetlists().then((result) => {
+                            onStep?.(
+                                `Loaded ${result.setlists.length} saved setlists${result.pending ? ` (${result.pending} pending)` : ""}`,
+                            );
+                            return result;
+                        }),
+                ],
+                [
+                    "members",
+                    () =>
+                        this.listMembers().then((result) => {
+                            onStep?.(
+                                `Loaded ${Object.keys(result.members || {}).length} band members${result.pending ? ` (${result.pending} pending)` : ""}`,
+                            );
+                            return result;
+                        }),
+                ],
+            ];
+
             onStep?.("Loading songs");
-            const songsPromise = this.listSongs().then((result) => {
-                onStep?.(`Loaded ${result.songs.length} songs${result.pending ? ` (${result.pending} pending)` : ""}`);
-                return result;
-            });
-
             onStep?.("Loading settings");
-            const configPromise = this.getConfig().then((config) => {
-                onStep?.(config ? "Loaded settings" : "No settings found yet");
-                return config;
-            });
-
             onStep?.("Loading bootstrap info");
-            const bootstrapPromise = this.getBootstrapMeta().then((bootstrap) => {
-                onStep?.(bootstrap ? "Loaded bootstrap info" : "No bootstrap info found");
-                return bootstrap;
-            });
-
             onStep?.("Loading saved setlists");
-            const setlistsPromise = this.listSetlists().then((result) => {
-                onStep?.(
-                    `Loaded ${result.setlists.length} saved setlists${result.pending ? ` (${result.pending} pending)` : ""}`,
-                );
-                return result;
-            });
-
             onStep?.("Loading band members");
-            const membersPromise = this.listMembers().then((result) => {
-                onStep?.(
-                    `Loaded ${Object.keys(result.members || {}).length} band members${result.pending ? ` (${result.pending} pending)` : ""}`,
-                );
-                return result;
-            });
 
-            const [songsResult, config, bootstrap, setlistsResult, membersResult] = await Promise.all([
-                songsPromise,
-                configPromise,
-                bootstrapPromise,
-                setlistsPromise,
-                membersPromise,
-            ]);
+            const settled = await Promise.allSettled(slices.map(([, run]) => run()));
+
+            const values = {};
+            const errors = {};
+            settled.forEach((outcome, i) => {
+                const [name] = slices[i];
+                if (outcome.status === "fulfilled") {
+                    values[name] = outcome.value;
+                } else {
+                    const reason = outcome.reason instanceof Error ? outcome.reason : new Error(String(outcome.reason));
+                    errors[name] = reason;
+                    onStep?.(`Could not load ${name}: ${reason.message}`);
+                }
+            });
 
             // pendingBodies: total documents whose bodies haven't yet arrived
             // from the remote. rs.js's getAll(path, false) returns stub
             // entries (`true` / `{}` / object without id) for items it knows
             // exist (folder ETag) but whose bodies are not yet in the local
             // cache. As long as this is > 0, more onChange events will fire
-            // and the UI is not yet in a settled state.
+            // and the UI is not yet in a settled state. Slices that rejected
+            // contribute 0 — we'll find out about their bodies on the next
+            // successful load.
             const pendingBodies =
-                (songsResult.pending || 0) + (setlistsResult.pending || 0) + (membersResult.pending || 0);
+                (values.songs?.pending || 0) + (values.setlists?.pending || 0) + (values.members?.pending || 0);
 
             return {
-                songs: songsResult.songs,
-                config,
-                bootstrap,
-                setlists: setlistsResult.setlists,
-                members: membersResult.members,
+                songs: values.songs?.songs,
+                config: values.config,
+                bootstrap: values.bootstrap,
+                setlists: values.setlists?.setlists,
+                members: values.members?.members,
                 pendingBodies,
+                errors,
             };
         },
 

--- a/src/lib/remotestorage.test.js
+++ b/src/lib/remotestorage.test.js
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const remoteStorageMockState = vi.hoisted(() => ({
     instance: null,
+    client: null,
     defaultAuthorize: null,
 }));
 
@@ -22,6 +23,19 @@ let originalWindow;
 
 beforeEach(() => {
     const defaultAuthorize = vi.fn();
+    // The client is exposed as a stable singleton on the mock state so tests
+    // can stub `getAll` / `getObject` / etc. without having to fish the
+    // returned object out of `scope.mock.results`. The repository only calls
+    // `scope()` once per construction, so a singleton matches real usage.
+    const client = {
+        declareType: vi.fn(),
+        on: vi.fn(),
+        removeEventListener: vi.fn(),
+        getAll: vi.fn(),
+        getObject: vi.fn(),
+        storeObject: vi.fn(),
+        remove: vi.fn(),
+    };
     const remoteStorage = {
         access: {
             claim: vi.fn(),
@@ -32,11 +46,7 @@ beforeEach(() => {
             enable: vi.fn(),
             reset: vi.fn(),
         },
-        scope: vi.fn(() => ({
-            declareType: vi.fn(),
-            on: vi.fn(),
-            removeEventListener: vi.fn(),
-        })),
+        scope: vi.fn(() => client),
         remote: {
             storageApi: "webdav",
             configure: vi.fn(),
@@ -54,6 +64,7 @@ beforeEach(() => {
     };
 
     remoteStorageMockState.instance = remoteStorage;
+    remoteStorageMockState.client = client;
     remoteStorageMockState.defaultAuthorize = defaultAuthorize;
     originalWindow = globalThis.window;
 });
@@ -61,6 +72,7 @@ beforeEach(() => {
 afterEach(() => {
     vi.restoreAllMocks();
     remoteStorageMockState.instance = null;
+    remoteStorageMockState.client = null;
     remoteStorageMockState.defaultAuthorize = null;
     if (typeof originalWindow === "undefined") {
         delete globalThis.window;
@@ -571,6 +583,213 @@ describe("createRemoteStorageRepository", () => {
             rs.connected = false;
             await repo.swap("other@example.com", { type: "click" });
             expect(rs.connect).toHaveBeenCalledWith("other@example.com", undefined);
+        });
+    });
+
+    // Regression coverage for the cold-start path.
+    //
+    // rs.js v2.0.0-beta.* documents `client.getAll(path, false)` as a "list
+    // ETags only, skip bodies" optimisation. On a cold IndexedDB the listing
+    // therefore returns stub entries — `true`, `{}`, or partial objects
+    // missing the discriminator field — for items the library knows exist
+    // but hasn't fetched yet. Our list* helpers rely on a discriminator
+    // field per type (`id` for songs, `savedAt` for setlists, `name` for
+    // members) to separate real records from stubs and report the rest as
+    // `pending`. These tests pin that contract so a future schema change
+    // doesn't silently start counting empty placeholders as real records,
+    // which would briefly flash empty UI on first connect to a new device.
+    describe("cold-start stub handling", () => {
+        it("listSongs treats stub entries as pending bodies", async () => {
+            const repo = createRemoteStorageRepository();
+            remoteStorageMockState.client.getAll.mockResolvedValue({
+                "song-1": { id: "song-1", name: "Real", updatedAt: "2025-01-01T00:00:00Z" },
+                "song-2": true,
+                "song-3": {},
+                "song-4": null,
+                "song-5": { name: "Missing id" },
+            });
+
+            const result = await repo.listSongs();
+
+            expect(remoteStorageMockState.client.getAll).toHaveBeenCalledWith("songs/", false);
+            expect(result.songs).toHaveLength(1);
+            expect(result.songs[0].id).toBe("song-1");
+            expect(result.pending).toBe(4);
+        });
+
+        it("listSongs returns empty + zero pending when getAll has no data", async () => {
+            const repo = createRemoteStorageRepository();
+            remoteStorageMockState.client.getAll.mockResolvedValue(undefined);
+            const result = await repo.listSongs();
+            expect(result.songs).toEqual([]);
+            expect(result.pending).toBe(0);
+        });
+
+        it("listSetlists treats entries without savedAt as pending bodies", async () => {
+            const repo = createRemoteStorageRepository();
+            remoteStorageMockState.client.getAll.mockResolvedValue({
+                "set-1": { id: "set-1", savedAt: "2025-02-01T00:00:00Z", songs: [] },
+                "set-2": true,
+                "set-3": { id: "set-3" },
+            });
+
+            const result = await repo.listSetlists();
+
+            expect(result.setlists).toHaveLength(1);
+            expect(result.setlists[0].id).toBe("set-1");
+            expect(result.pending).toBe(2);
+        });
+
+        it("listSetlists sorts loaded setlists by savedAt descending", async () => {
+            const repo = createRemoteStorageRepository();
+            remoteStorageMockState.client.getAll.mockResolvedValue({
+                a: { id: "a", savedAt: "2025-01-01T00:00:00Z" },
+                b: { id: "b", savedAt: "2025-03-01T00:00:00Z" },
+                c: { id: "c", savedAt: "2025-02-01T00:00:00Z" },
+            });
+            const result = await repo.listSetlists();
+            expect(result.setlists.map((s) => s.id)).toEqual(["b", "c", "a"]);
+            expect(result.pending).toBe(0);
+        });
+
+        it("listMembers treats entries without name as pending bodies", async () => {
+            const repo = createRemoteStorageRepository();
+            remoteStorageMockState.client.getAll.mockResolvedValue({
+                Alice: { name: "Alice", instruments: [] },
+                Bob: true,
+                Carol: {},
+                Drew: { instruments: [] },
+            });
+
+            const result = await repo.listMembers();
+
+            expect(Object.keys(result.members)).toEqual(["Alice"]);
+            expect(result.pending).toBe(3);
+        });
+    });
+
+    // The cold-start tests above cover what each list* helper does when its
+    // own getAll call returns stubs. These tests cover what `loadAll` does
+    // when one of the five slices fails outright — the partial-failure path
+    // that motivated switching from Promise.all to Promise.allSettled.
+    describe("loadAll partial-failure handling", () => {
+        function configureClient({ songs, setlists, members, config, bootstrap }) {
+            const { client } = remoteStorageMockState;
+            client.getAll.mockImplementation((path) => {
+                if (path === "songs/") return songs;
+                if (path === "setlists/") return setlists;
+                if (path === "members/") return members;
+                return Promise.resolve({});
+            });
+            client.getObject.mockImplementation((path) => {
+                if (path === "settings/app-config") return config;
+                if (path === "meta/bootstrap") return bootstrap;
+                return Promise.resolve(null);
+            });
+        }
+
+        it("returns successfully-loaded slices and an empty errors map on full success", async () => {
+            const repo = createRemoteStorageRepository();
+            configureClient({
+                songs: Promise.resolve({
+                    "s-1": { id: "s-1", name: "Song", updatedAt: "2025-01-01T00:00:00Z" },
+                }),
+                setlists: Promise.resolve({}),
+                members: Promise.resolve({ Alice: { name: "Alice" } }),
+                config: Promise.resolve({ bandName: "Tunesmith" }),
+                bootstrap: Promise.resolve(null),
+            });
+
+            const result = await repo.loadAll();
+
+            expect(result.songs).toHaveLength(1);
+            // getConfig normalizes the raw record (defaults, schemaVersion);
+            // the test only cares that the user-provided field round-trips.
+            expect(result.config).toMatchObject({ bandName: "Tunesmith" });
+            expect(result.setlists).toEqual([]);
+            expect(result.members).toEqual({ Alice: { name: "Alice" } });
+            expect(result.bootstrap).toBeNull();
+            expect(result.errors).toEqual({});
+        });
+
+        it("does not short-circuit when a single slice rejects", async () => {
+            const repo = createRemoteStorageRepository();
+            configureClient({
+                songs: Promise.resolve({
+                    "s-1": { id: "s-1", name: "Song", updatedAt: "2025-01-01T00:00:00Z" },
+                }),
+                setlists: Promise.resolve({}),
+                members: Promise.reject(new Error("network down")),
+                config: Promise.resolve({ bandName: "Tunesmith" }),
+                bootstrap: Promise.resolve(null),
+            });
+
+            const result = await repo.loadAll();
+
+            expect(result.songs).toHaveLength(1);
+            expect(result.setlists).toEqual([]);
+            // getConfig normalizes the raw record (defaults, schemaVersion);
+            // the test only cares that the user-provided field round-trips.
+            expect(result.config).toMatchObject({ bandName: "Tunesmith" });
+            expect(result.members).toBeUndefined();
+            expect(result.errors.members).toBeInstanceOf(Error);
+            expect(result.errors.members.message).toContain("network down");
+            expect(result.errors.config).toBeUndefined();
+        });
+
+        it("distinguishes a missing config from a failed config read", async () => {
+            const repo = createRemoteStorageRepository();
+            configureClient({
+                songs: Promise.resolve({}),
+                setlists: Promise.resolve({}),
+                members: Promise.resolve({}),
+                config: Promise.reject(new Error("403")),
+                bootstrap: Promise.resolve(null),
+            });
+
+            const result = await repo.loadAll();
+
+            expect(result.config).toBeUndefined();
+            expect(result.errors.config).toBeInstanceOf(Error);
+            expect(result.errors.config.message).toBe("403");
+        });
+
+        it("forwards onStep messages for both successes and failures", async () => {
+            const repo = createRemoteStorageRepository();
+            configureClient({
+                songs: Promise.resolve({}),
+                setlists: Promise.resolve({}),
+                members: Promise.reject(new Error("boom")),
+                config: Promise.resolve(null),
+                bootstrap: Promise.resolve(null),
+            });
+
+            const onStep = vi.fn();
+            await repo.loadAll({ onStep });
+
+            const messages = onStep.mock.calls.map(([m]) => m);
+            expect(messages).toContain("Loading band members");
+            expect(messages.some((m) => m.startsWith("Could not load members"))).toBe(true);
+        });
+
+        it("counts pending bodies only from successful slices", async () => {
+            const repo = createRemoteStorageRepository();
+            configureClient({
+                songs: Promise.resolve({
+                    "s-1": true,
+                    "s-2": { id: "s-2", name: "Song", updatedAt: "2025-01-01T00:00:00Z" },
+                }),
+                setlists: Promise.resolve({ "set-1": true, "set-2": true }),
+                members: Promise.reject(new Error("offline")),
+                config: Promise.resolve(null),
+                bootstrap: Promise.resolve(null),
+            });
+
+            const result = await repo.loadAll();
+
+            // 1 stub from songs + 2 stubs from setlists; members rejected,
+            // so its pending count contributes nothing rather than NaN.
+            expect(result.pendingBodies).toBe(3);
         });
     });
 });

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -1811,27 +1811,42 @@ export function createAppStore(repo) {
         const clean = newName.trim();
         if (!clean || clean === oldName || bandMemberEntries.some(([n]) => n === clean)) return;
         const data = bandMembers[oldName] || { instruments: [] };
+
+        // Put the new key first so a failure leaves the original member
+        // intact — songs that reference `oldName` still resolve, and we
+        // bail out without touching local state.
         try {
-            await withSync("Renaming member", async () => {
-                // Put the new key first so a failure leaves the original
-                // member intact — songs that reference `oldName` still
-                // resolve. If we deleted first and the put failed, the old
-                // key would be gone and any catalog references would be
-                // orphaned. The reverse failure mode (put succeeds, delete
-                // fails) leaves a temporary duplicate that resolves on the
-                // next sync; the in-memory mutation below removes the old
-                // entry locally so the UI shows the rename immediately.
-                await repo.putMember(clean, data);
-                await repo.deleteMember(oldName);
-            });
-            const next = { ...bandMembers };
-            delete next[oldName];
-            next[clean] = data;
-            bandMembers = next;
-            if (expandedBandMember === oldName) expandedBandMember = clean;
-            toastInfo(`Renamed "${oldName}" to "${clean}".`);
+            await withSync("Renaming member", () => repo.putMember(clean, data));
         } catch (error) {
             toastError(error?.message || "Could not rename member.");
+            return;
+        }
+
+        // Apply the local rename now: the new key exists remotely, so the
+        // UI must switch over even if the follow-up delete fails. The
+        // caller (BandScreen) moves `editingMemberName` to `clean` without
+        // awaiting this function; without the local mutation here the
+        // edit-view filter would match nothing and the pane would go blank.
+        const next = { ...bandMembers };
+        delete next[oldName];
+        next[clean] = data;
+        bandMembers = next;
+        if (expandedBandMember === oldName) expandedBandMember = clean;
+
+        // Best-effort delete of the old key. A failure here leaves a
+        // temporary duplicate in remoteStorage; rs.js retries on the next
+        // sync round and the next reloadAll reconciles. This is the
+        // explicit "duplicate member that resolves on next sync" failure
+        // mode #70 accepts — surface it as a warning, not a hard error.
+        try {
+            await withSync("Cleaning up old member name", () => repo.deleteMember(oldName));
+            toastInfo(`Renamed "${oldName}" to "${clean}".`);
+        } catch (error) {
+            toastWarn(
+                `Renamed to "${clean}". Old name will clear on the next sync.${
+                    error?.message ? ` (${error.message})` : ""
+                }`,
+            );
         }
     }
 

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -989,20 +989,49 @@ export function createAppStore(repo) {
             // Update the pending count even if we early-return below — the
             // pill state depends on it being current.
             pendingBodies = data.pendingBodies || 0;
-            dbg(`reloadAll[${callId}] data: ${data.songs.length} songs, pendingBodies=${pendingBodies}, hasConfig=${!!data.config}`);
-            songs = data.songs.map(normalizeSongRecord);
-            bootstrapMeta = data.bootstrap;
-            appConfig = data.config ? normalizeAppConfig(data.config) : null;
-            if (data.setlists) {
+            const errors = data.errors || {};
+            const errorEntries = Object.entries(errors);
+            dbg(
+                `reloadAll[${callId}] data: ${data.songs?.length ?? "—"} songs, pendingBodies=${pendingBodies}, hasConfig=${!!data.config}, errors=${errorEntries.length}`,
+            );
+            // Apply each slice only when its load actually succeeded. A
+            // rejected slice leaves the prior in-memory value intact rather
+            // than blanking the UI — partial offline-first loads are the
+            // whole point of allSettled. `data.<slice>` is undefined when
+            // that slice rejected.
+            if (data.songs !== undefined) {
+                songs = data.songs.map(normalizeSongRecord);
+            }
+            if (!errors.bootstrap) {
+                bootstrapMeta = data.bootstrap;
+            }
+            if (!errors.config) {
+                appConfig = data.config ? normalizeAppConfig(data.config) : null;
+            }
+            if (data.setlists !== undefined) {
                 savedSetlists = stripEnergy(data.setlists);
             }
-            if (data.members) {
+            if (data.members !== undefined) {
                 bandMembers = Object.fromEntries(
-                    Object.entries(data.members).map(([name, data]) => [name, normalizeMemberRecord(data)])
+                    Object.entries(data.members).map(([name, data]) => [name, normalizeMemberRecord(data)]),
                 );
             }
 
-            if (!appConfig) {
+            // Surface partial-failure warnings without short-circuiting. We
+            // skip a toast for `bootstrap` because the metadata is already
+            // optional (callers treat missing bootstrap as "none yet").
+            for (const [slice, error] of errorEntries) {
+                pushSyncLog(`Could not load ${slice}: ${error.message}`);
+                if (slice === "bootstrap") continue;
+                if (!quiet) toastWarn(`Couldn't load ${slice} — keeping last known data.`);
+            }
+
+            // First-run prompt: only when we *know* the config is truly
+            // absent (the slice loaded successfully and returned null), not
+            // when the config slice failed and we kept the previous value.
+            // Without this guard a transient config read failure would push
+            // a returning user into first-run, risking a duplicate config.
+            if (!errors.config && !appConfig) {
                 firstRunBandName = "";
                 navigate("roll");
                 generationOptions = defaultGenerationOptions(DEFAULT_APP_CONFIG);
@@ -1010,9 +1039,11 @@ export function createAppStore(repo) {
                 return;
             }
 
-            generationOptions = deepMerge(defaultGenerationOptions(appConfig), generationOptions || {});
-            persistGenerationOptions();
-            scheduleSnapshot();
+            if (appConfig) {
+                generationOptions = deepMerge(defaultGenerationOptions(appConfig), generationOptions || {});
+                persistGenerationOptions();
+                scheduleSnapshot();
+            }
             pushSyncLog("Initial data load finished");
         } catch (error) {
             loadError = error?.message || "Could not load remote data.";
@@ -1782,8 +1813,16 @@ export function createAppStore(repo) {
         const data = bandMembers[oldName] || { instruments: [] };
         try {
             await withSync("Renaming member", async () => {
-                await repo.deleteMember(oldName);
+                // Put the new key first so a failure leaves the original
+                // member intact — songs that reference `oldName` still
+                // resolve. If we deleted first and the put failed, the old
+                // key would be gone and any catalog references would be
+                // orphaned. The reverse failure mode (put succeeds, delete
+                // fails) leaves a temporary duplicate that resolves on the
+                // next sync; the in-memory mutation below removes the old
+                // entry locally so the UI shows the rename immediately.
                 await repo.putMember(clean, data);
+                await repo.deleteMember(oldName);
             });
             const next = { ...bandMembers };
             delete next[oldName];


### PR DESCRIPTION
## Summary

All in `src/lib/remotestorage.js` and the store's calls into it (`src/lib/stores/app.svelte.js`).

- **#68 — `Promise.allSettled` for partial offline-first loads.** `loadAll` no longer rejects the whole load when any of the five slices (songs / config / bootstrap / setlists / members) fails. It now returns an `errors` map alongside the data; `reloadAll` keeps the previous in-memory value for any rejected slice, surfaces a warning toast per failure (bootstrap stays silent — it's already optional), and crucially does **not** trigger first-run on a config-read error (only a successful load returning genuinely-empty config does that — guards against pushing a returning user into a duplicate-config flow on a transient 5xx).
- **#70 — Member rename atomicity.** `renameBandMember` now does `putMember(new)` *then* `deleteMember(old)`. A failed put leaves the original member intact (no orphan references); a failed delete leaves a temporary duplicate that resolves on next sync. Previously a delete-then-put could leave the catalog pointing at a member key that no longer existed.
- **#69 — Cold-start regression coverage.** rs.js's `client.getAll(path, false)` returns stub entries (`true`, `{}`, partial objects without the discriminator field) on a cold IndexedDB. `listSongs` / `listSetlists` / `listMembers` already filter by a per-type discriminator (`id` / `savedAt` / `name`) and report the rest as `pending`. New tests pin that contract so a future schema change can't silently start counting empty placeholders as real records — plus tests for `loadAll`'s new partial-failure behavior.

Closes #68
Closes #69
Closes #70

## Test plan

- [x] `npm test` — 276 passed (was 273; 31 of those in `remotestorage.test.js` after this change)
- [x] `npm run lint` — clean
- [x] `npm run build` — clean