### PR TITLE
refactor: address review findings #51-54, #59

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -34,7 +34,6 @@
 
     let dieColor = $derived(store.appConfig?.ui?.dieColor || DEFAULT_DIE_COLOR);
     let dieColorRgb = $derived(hexToRgb(dieColor));
-    let customDieColor = $derived(store.appConfig?.ui?.dieColor || null);
 
     let faviconHref = $derived(
         `data:image/svg+xml,${encodeURIComponent(generateDieSvgString(dieColor))}`
@@ -46,25 +45,23 @@
 
     $effect(() => {
         const root = document.documentElement;
-        if (customDieColor) {
-            root.style.setProperty("--accent", customDieColor);
-            root.style.setProperty("--accent-strong", darkenHex(customDieColor, 0.85));
-            root.style.setProperty("--accent-soft", hexToRgba(customDieColor, 0.12));
-            root.style.setProperty("--accent-line", hexToRgba(customDieColor, 0.24));
-        } else {
-            root.style.removeProperty("--accent");
-            root.style.removeProperty("--accent-strong");
-            root.style.removeProperty("--accent-soft");
-            root.style.removeProperty("--accent-line");
-        }
+        root.style.setProperty("--accent", dieColor);
+        root.style.setProperty("--accent-strong", darkenHex(dieColor, 0.85));
+        root.style.setProperty("--accent-soft", hexToRgba(dieColor, 0.12));
+        root.style.setProperty("--accent-line", hexToRgba(dieColor, 0.24));
     });
 
     // iOS standalone PWA: after the sync-shell → app-shell DOM swap,
     // WebKit's compositor has stale hit-test regions for the new
     // fixed-position elements (TopBar, BottomNav). A micro-scroll
     // forces the compositor to rebuild its layer hit-test tree.
+    // Account swaps re-flip initialSyncComplete (true → false → true);
+    // the nudge only matters on the first true after boot, so latch it.
+    let iosScrollNudged = false;
     $effect(() => {
+        if (iosScrollNudged) return;
         if (store.initialSyncComplete && isIosStandaloneAuthContext()) {
+            iosScrollNudged = true;
             requestAnimationFrame(() => {
                 const x = window.scrollX;
                 const y = window.scrollY;

--- a/src/lib/accounts.js
+++ b/src/lib/accounts.js
@@ -5,9 +5,10 @@ export const KNOWN_ACCOUNTS_KEY = `${STORAGE_PREFIX}-known-accounts`;
 
 /**
  * Hash a per-account suffix so app-owned localStorage keys (snapshots, UI
- * options, etc.) don't leak between accounts.
+ * options, etc.) don't leak between accounts. Internal helper — callers
+ * should use accountSlot(address).key(base).
  */
-export function scopedKey(base, userAddress) {
+function scopedKey(base, userAddress) {
     if (!userAddress) return `${STORAGE_PREFIX}-${base}`;
     let h = 0;
     for (let i = 0; i < userAddress.length; i++) {

--- a/src/lib/accounts.test.js
+++ b/src/lib/accounts.test.js
@@ -8,7 +8,6 @@ import {
     KNOWN_ACCOUNTS_KEY,
     removeKnownAccountEntry,
     saveKnownAccount,
-    scopedKey,
 } from "./accounts.js";
 
 // ===================================================================
@@ -36,43 +35,37 @@ afterEach(() => {
 });
 
 // ===================================================================
-// scopedKey / accountSlot
+// accountSlot
 // ===================================================================
-describe("scopedKey", () => {
+describe("accountSlot", () => {
     it("returns unscoped key when no user address", () => {
-        expect(scopedKey("snapshot", "")).toBe("setlist-roller-snapshot");
-        expect(scopedKey("snapshot", undefined)).toBe("setlist-roller-snapshot");
+        expect(accountSlot("").key("snapshot")).toBe("setlist-roller-snapshot");
+        expect(accountSlot(undefined).key("snapshot")).toBe("setlist-roller-snapshot");
     });
 
     it("returns hashed key for a user address", () => {
-        const key = scopedKey("snapshot", "alice@example.com");
-        expect(key).toMatch(/^setlist-roller-snapshot-[a-z0-9]+$/);
+        expect(accountSlot("alice@example.com").key("snapshot")).toMatch(/^setlist-roller-snapshot-[a-z0-9]+$/);
     });
 
     it("produces different keys for different addresses", () => {
-        const a = scopedKey("snapshot", "alice@example.com");
-        const b = scopedKey("snapshot", "bob@example.com");
+        const a = accountSlot("alice@example.com").key("snapshot");
+        const b = accountSlot("bob@example.com").key("snapshot");
         expect(a).not.toBe(b);
     });
 
     it("produces the same key for the same address", () => {
-        const a = scopedKey("snapshot", "alice@example.com");
-        const b = scopedKey("snapshot", "alice@example.com");
+        const a = accountSlot("alice@example.com").key("snapshot");
+        const b = accountSlot("alice@example.com").key("snapshot");
         expect(a).toBe(b);
     });
 
     it("produces different keys for different bases", () => {
-        const a = scopedKey("snapshot", "alice@example.com");
-        const b = scopedKey("opts", "alice@example.com");
-        expect(a).not.toBe(b);
-    });
-});
-
-describe("accountSlot", () => {
-    it("derives the same key as scopedKey for the same address", () => {
         const slot = accountSlot("alice@example.com");
-        expect(slot.address).toBe("alice@example.com");
-        expect(slot.key("snapshot")).toBe(scopedKey("snapshot", "alice@example.com"));
+        expect(slot.key("snapshot")).not.toBe(slot.key("opts"));
+    });
+
+    it("exposes the address", () => {
+        expect(accountSlot("alice@example.com").address).toBe("alice@example.com");
     });
 
     it("isolates keys between accounts", () => {

--- a/src/lib/components/roll/RollScreen.svelte
+++ b/src/lib/components/roll/RollScreen.svelte
@@ -426,44 +426,42 @@
 
   <!-- Setlist result -->
   {#if store.generatedSetlist}
-    {#key store.setlistViewVersion}
-      <section class="result-section">
-        <div class="song-list" bind:this={songListEl}>
-          {#each store.generatedSetlist.songs as song, i (song.id)}
-            <div class="song-list-item" class:drag-over={dragIndex !== null && dragOverIndex === i && dragIndex !== i}>
-              <SetlistSongCard
-                {song}
-                index={i}
-                prevSong={i > 0 ? store.generatedSetlist.songs[i - 1] : null}
-                onDragStart={handleDragStart}
-                onEdit={handleEditSong}
-                onRemove={(idx) => store.removeSetlistSong(idx)}
-              />
-            </div>
-          {/each}
-        </div>
+    <section class="result-section">
+      <div class="song-list" bind:this={songListEl}>
+        {#each store.generatedSetlist.songs as song, i (song.id)}
+          <div class="song-list-item" class:drag-over={dragIndex !== null && dragOverIndex === i && dragIndex !== i}>
+            <SetlistSongCard
+              {song}
+              index={i}
+              prevSong={i > 0 ? store.generatedSetlist.songs[i - 1] : null}
+              onDragStart={handleDragStart}
+              onEdit={handleEditSong}
+              onRemove={(idx) => store.removeSetlistSong(idx)}
+            />
+          </div>
+        {/each}
+      </div>
 
-        <div class="roadie-score">
-          <span class="roadie-label">Bass Player Anxiety</span>
-          <span class="roadie-val">{anxietyLevel.scaled}/10</span>
-          <p class="roadie-hint">{anxietyLevel.label}</p>
-        </div>
+      <div class="roadie-score">
+        <span class="roadie-label">Bass Player Anxiety</span>
+        <span class="roadie-val">{anxietyLevel.scaled}/10</span>
+        <p class="roadie-hint">{anxietyLevel.label}</p>
+      </div>
 
-        <div class="setlist-actions">
-          <button type="button" class="save-set-btn add-song-btn" onclick={() => { showAddSongPicker = true; }}>+ Add song</button>
-          {#if store.setlistLocked}
-            <div class="locked-badge">🔒 Locked in</div>
-            {#if store.setlistSaved}
-              <div class="saved-badge">✓ Saved</div>
-            {:else}
-              <button type="button" class="save-set-btn secondary" onclick={handleSaveSetlist}>Save to Greatest Hits</button>
-            {/if}
+      <div class="setlist-actions">
+        <button type="button" class="save-set-btn add-song-btn" onclick={() => { showAddSongPicker = true; }}>+ Add song</button>
+        {#if store.setlistLocked}
+          <div class="locked-badge">🔒 Locked in</div>
+          {#if store.setlistSaved}
+            <div class="saved-badge">✓ Saved</div>
           {:else}
-            <button type="button" class="save-set-btn" onclick={handleLock}>Lock it in 🔒</button>
+            <button type="button" class="save-set-btn secondary" onclick={handleSaveSetlist}>Save to Greatest Hits</button>
           {/if}
-        </div>
-      </section>
-    {/key}
+        {:else}
+          <button type="button" class="save-set-btn" onclick={handleLock}>Lock it in 🔒</button>
+        {/if}
+      </div>
+    </section>
   {/if}
 
   {#if store.pendingRollConfirm}

--- a/src/lib/stores/account-switching.test.js
+++ b/src/lib/stores/account-switching.test.js
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { saveKnownAccount, scopedKey } from "../accounts.js";
+import { accountSlot, saveKnownAccount } from "../accounts.js";
 import { createAppStore } from "./app.svelte.js";
 
 /**
@@ -260,7 +260,7 @@ describe("connectToAccount — snapshot path", () => {
     it("paints the new account's data instantly when a snapshot exists", async () => {
         saveKnownAccount("user-b@example.com", { bandName: "B" }, "token-b");
         localStorage.setItem(
-            scopedKey("snapshot", "user-b@example.com"),
+            accountSlot("user-b@example.com").key("snapshot"),
             JSON.stringify({
                 songs: [{ id: "s1", name: "Snapshot Song" }],
                 config: { bandName: "Band B (snapshot)", schemaVersion: 2 },
@@ -298,7 +298,7 @@ describe("connectToAccount — snapshot path", () => {
         // overwritten by an empty cache read on the same account.
         saveKnownAccount("user-b@example.com", { bandName: "B" }, "token-b");
         localStorage.setItem(
-            scopedKey("snapshot", "user-b@example.com"),
+            accountSlot("user-b@example.com").key("snapshot"),
             JSON.stringify({
                 songs: [],
                 config: { bandName: "Band B (snapshot)", schemaVersion: 2 },

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -151,7 +151,6 @@ export function createAppStore(repo) {
     let appConfig = $state(null);
     let bootstrapMeta = $state(null);
     let generatedSetlist = $state(null);
-    let setlistViewVersion = $state(0);
     let isGenerating = $state(false);
     let activeWorker = null;
     let generationId = 0;
@@ -454,7 +453,6 @@ export function createAppStore(repo) {
 
     function replaceGeneratedSetlist(nextSetlist) {
         generatedSetlist = nextSetlist;
-        if (nextSetlist) setlistViewVersion += 1;
     }
 
     function updateCurrentSetlist(nextSetlist) {
@@ -2565,7 +2563,6 @@ export function createAppStore(repo) {
         get appConfig() { return appConfig; },
         get bandMembers() { return bandMembers; },
         get generatedSetlist() { return generatedSetlist; },
-        get setlistViewVersion() { return setlistViewVersion; },
         get isGenerating() { return isGenerating; },
         get setlistLocked() { return setlistLocked; },
         get setlistSaved() { return setlistSaved; },

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -133,37 +133,32 @@ export function tryParseJson(text, fallback) {
 
 export const DEFAULT_DIE_COLOR = "#e15b37";
 
-function parseHexChannel(hex, offset) {
-    const v = parseInt(hex.slice(offset, offset + 2), 16);
-    return Number.isFinite(v) ? v : 0;
+// Parse a #rrggbb string into [r, g, b]. Falls back to DEFAULT_DIE_COLOR
+// for any invalid input so callers don't have to guard.
+function parseHex(hex) {
+    const source = typeof hex === "string" && /^#[0-9a-fA-F]{6}$/.test(hex) ? hex : DEFAULT_DIE_COLOR;
+    return [parseInt(source.slice(1, 3), 16), parseInt(source.slice(3, 5), 16), parseInt(source.slice(5, 7), 16)];
 }
 
-function clampByte(v) {
-    return Math.min(255, Math.max(0, Math.round(v)));
+function toHexByte(v) {
+    return Math.min(255, Math.max(0, Math.round(v)))
+        .toString(16)
+        .padStart(2, "0");
 }
 
 export function hexToRgb(hex) {
-    if (typeof hex !== "string" || !/^#[0-9a-fA-F]{6}$/.test(hex)) {
-        return hexToRgb(DEFAULT_DIE_COLOR);
-    }
-    return `${parseHexChannel(hex, 1)}, ${parseHexChannel(hex, 3)}, ${parseHexChannel(hex, 5)}`;
+    const [r, g, b] = parseHex(hex);
+    return `${r}, ${g}, ${b}`;
 }
 
 export function hexToRgba(hex, alpha) {
-    if (typeof hex !== "string" || !/^#[0-9a-fA-F]{6}$/.test(hex)) {
-        return hexToRgba(DEFAULT_DIE_COLOR, alpha);
-    }
+    const [r, g, b] = parseHex(hex);
     const a = Number.isFinite(alpha) ? Math.min(1, Math.max(0, alpha)) : 1;
-    return `rgba(${parseHexChannel(hex, 1)}, ${parseHexChannel(hex, 3)}, ${parseHexChannel(hex, 5)}, ${a})`;
+    return `rgba(${r}, ${g}, ${b}, ${a})`;
 }
 
 export function darkenHex(hex, factor) {
-    if (typeof hex !== "string" || !/^#[0-9a-fA-F]{6}$/.test(hex)) {
-        return darkenHex(DEFAULT_DIE_COLOR, factor);
-    }
     const f = Number.isFinite(factor) ? Math.min(1, Math.max(0, factor)) : 1;
-    const r = clampByte(parseHexChannel(hex, 1) * f);
-    const g = clampByte(parseHexChannel(hex, 3) * f);
-    const b = clampByte(parseHexChannel(hex, 5) * f);
-    return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
+    const [r, g, b] = parseHex(hex);
+    return `#${toHexByte(r * f)}${toHexByte(g * f)}${toHexByte(b * f)}`;
 }


### PR DESCRIPTION
## Summary

Five small, independent cleanups from the comprehensive review.

- **#54** — `App.svelte`: collapse `dieColor` / `customDieColor` derives into one. The `else` branch on the CSS-variable effect was dead code (the `--accent*` properties are never set when `customDieColor` is null in the first place).
- **#59** — `App.svelte`: latch the iOS-PWA scroll-nudge so it only fires the first time `initialSyncComplete` flips to true. Account swaps re-flip it true → false → true, so each swap was triggering another (harmless but wasted) nudge.
- **#51** — `RollScreen.svelte` + `stores/app.svelte.js`: drop the `{#key store.setlistViewVersion}` wrapper and the matching `setlistViewVersion` state. Svelte 5's reactivity already updates the keyed `{#each}` cleanly when `generatedSetlist` changes — no need to tear down and rebuild the whole result subtree on every roll. Audit notes:
  - `SetlistSongCard`'s `expanded` state now persists across rolls when the same song happens to repeat (keyed by `song.id`). Reasonable UX.
  - `.result-section`'s `pop-in` animation now only runs the first time the section mounts (i.e., the first roll after an empty state). The dice button's `landed` bounce + confetti still gives feedback on every subsequent roll.
- **#53** — `accounts.js`: make `scopedKey` module-private. `accountSlot(address).key(base)` is the public API. Tests rewritten to exercise the same behavior through `accountSlot`.
- **#52** — `utils.js`: extract a `parseHex(hex) → [r, g, b]` helper that internalizes the validate-and-fallback pattern, drop the recursive fallback in each formatter, and add a `toHexByte` helper for `darkenHex`.

Closes #51, #52, #53, #54, #59 once merged.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 276/276 pass
- [x] `npm run build` — succeeds
- [x] `npm run test:e2e` — 136/136 pass