### PR TITLE
feat(roll): more intentional drag-to-reorder on mobile

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -53,7 +53,19 @@
         {
             "includes": ["**/*.svelte"],
             "linter": {
-                "enabled": false
+                "enabled": true,
+                "rules": {
+                    "correctness": {
+                        "noUnusedVariables": "off",
+                        "noUnusedImports": "off",
+                        "noUnusedFunctionParameters": "off",
+                        "noUnusedPrivateClassMembers": "off"
+                    },
+                    "style": {
+                        "useConst": "off",
+                        "useImportType": "off"
+                    }
+                }
             },
             "formatter": {
                 "enabled": false
@@ -62,7 +74,17 @@
         {
             "includes": ["**/*.svelte.js"],
             "linter": {
-                "enabled": false
+                "enabled": true,
+                "rules": {
+                    "correctness": {
+                        "noUnusedVariables": "off",
+                        "noUnusedImports": "off",
+                        "noUnusedFunctionParameters": "off"
+                    },
+                    "style": {
+                        "useConst": "off"
+                    }
+                }
             },
             "formatter": {
                 "enabled": false

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -113,11 +113,11 @@
                     <span class="recent-label">Recent</span>
                     {#each store.knownAccounts as account (account.address)}
                         <div class="recent-account">
-                            <button class="recent-account-btn" onclick={() => store.connectToAccount(account.address)}>
+                            <button type="button" class="recent-account-btn" onclick={() => store.connectToAccount(account.address)}>
                                 <span class="recent-band">{account.metadata?.bandName || "Unnamed"}</span>
                                 <span class="recent-address">{account.address}</span>
                             </button>
-                            <button class="recent-forget" onclick={() => store.forgetAccount(account.address)} aria-label="Forget account">&times;</button>
+                            <button type="button" class="recent-forget" onclick={() => store.forgetAccount(account.address)} aria-label="Forget account">&times;</button>
                         </div>
                     {/each}
                 </div>

--- a/src/lib/components/help/HelpScreen.svelte
+++ b/src/lib/components/help/HelpScreen.svelte
@@ -38,7 +38,7 @@
     <section class="help-section">
         <h2>After you roll</h2>
         <ul class="tips">
-            <li><strong>Drag to reorder</strong> — not happy with a song's position? Grab the handle and move it.</li>
+            <li><strong>Drag to reorder</strong> — not happy with a song's position? Press and hold the handle (or click and drag on desktop) to move it. The card lifts up so you can see exactly where it'll land.</li>
             <li><strong>Lock it in</strong> — prevents accidental re-rolls. You can still unlock and roll again.</li>
             <li><strong>Save to Greatest Hits</strong> — stores the setlist so you can view or print it later.</li>
             <li><strong>Print</strong> — from the <button type="button" class="inline-link" onclick={() => store.navigate("saved")}>Saved</button> tab, open a setlist and hit print. Big fonts, clean layout, made for the stage.</li>

--- a/src/lib/components/roll/RollScreen.svelte
+++ b/src/lib/components/roll/RollScreen.svelte
@@ -1,5 +1,6 @@
 <script>
   import { getContext } from "svelte";
+  import { flip } from "svelte/animate";
   import { anxietyLabel } from "../../anxiety.js";
   import { DEFAULT_DIE_COLOR, darkenHex, hexToRgb } from "../../utils.js";
   import ChipToggle from "../shared/ChipToggle.svelte";
@@ -130,44 +131,175 @@
     }
   }
 
+  // ---- drag-to-reorder state ----
+  // dragIndex     : the song currently being dragged (null when idle)
+  // dragOverIndex : the slot the dragged song would land in if released now
+  // dragArmingIndex: the song being long-pressed (touch only) before drag arms
+  // dragYOffset   : translateY on the dragged card so it follows the finger
   let dragIndex = $state(null);
   let dragOverIndex = $state(null);
+  let dragArmingIndex = $state(null);
+  let dragYOffset = $state(0);
   let songListEl = $state(null);
 
+  // Touch needs an intentional gesture to start a drag — otherwise users
+  // accidentally trigger reorders while scrolling. 350ms is short enough to
+  // feel responsive but long enough to distinguish from a scroll-flick.
+  const LONG_PRESS_MS = 350;
+  // If the finger drifts more than this during the press-hold window, treat
+  // it as a scroll attempt and bail out without arming the drag.
+  const PRESS_CANCEL_PX = 8;
+
+  function vibrate(pattern) {
+    // Best-effort haptic. iOS Safari ignores navigator.vibrate but we still
+    // try — Android + most mobile browsers honour it. Wrap in try/catch
+    // because some browsers throw on cross-origin iframes.
+    if (typeof navigator === "undefined" || !("vibrate" in navigator)) return;
+    try { navigator.vibrate(pattern); } catch { /* noop */ }
+  }
+
   function handleDragStart(e, index) {
-    e.preventDefault();
-    dragIndex = index;
-    dragOverIndex = index;
+    const isTouch = e.pointerType === "touch" || e.pointerType === "pen";
+    const startX = e.clientX;
+    const startY = e.clientY;
+    const pointerId = e.pointerId;
+    const captureTarget = e.currentTarget;
+
+    let armed = false;
+    let cancelled = false;
+    let armTimer = null;
+
+    if (!isTouch) {
+      // Mouse: behaviour identical to before — drag begins on pointerdown.
+      // preventDefault stops text selection and the synthetic click.
+      e.preventDefault();
+      armDrag();
+    } else {
+      // Touch / pen: defer drag until the user holds still long enough.
+      // The handle's CSS uses `touch-action: pan-y`, so the page can still
+      // scroll if the user is actually flicking instead of pressing.
+      dragArmingIndex = index;
+      armTimer = setTimeout(() => {
+        if (cancelled) return;
+        armDrag();
+      }, LONG_PRESS_MS);
+    }
+
+    function armDrag() {
+      armed = true;
+      dragArmingIndex = null;
+      dragIndex = index;
+      dragOverIndex = index;
+      dragYOffset = 0;
+
+      // Heads-up haptic so the user knows drag mode just turned on. The card
+      // also pops up visually via .dragging styles.
+      if (isTouch) vibrate(18);
+
+      // Capture the pointer so subsequent pointer events are routed here even
+      // if the finger leaves the original element while dragging.
+      try { captureTarget?.setPointerCapture?.(pointerId); } catch { /* noop */ }
+
+      // Suppress the click event that would otherwise fire after pointerup
+      // and toggle the card's expanded state. Using capture phase + once so
+      // we only swallow the very next click from this gesture.
+      document.addEventListener("click", suppressClickOnce, { capture: true, once: true });
+      // Safety net in case the click never fires (e.g., gesture cancelled by
+      // the OS) — clean up the listener after a short window.
+      setTimeout(() => {
+        document.removeEventListener("click", suppressClickOnce, { capture: true });
+      }, 600);
+    }
+
+    function suppressClickOnce(ev) {
+      ev.preventDefault();
+      ev.stopPropagation();
+      ev.stopImmediatePropagation();
+    }
+
+    function cancelArm() {
+      cancelled = true;
+      if (armTimer) { clearTimeout(armTimer); armTimer = null; }
+      dragArmingIndex = null;
+      cleanup();
+    }
 
     const onMove = (me) => {
-      if (dragIndex === null || !songListEl) return;
+      if (!armed) {
+        // Press-hold phase: any meaningful movement means the user is
+        // scrolling/flicking, not pressing. Bail out and let the browser
+        // handle the gesture natively.
+        const dx = Math.abs(me.clientX - startX);
+        const dy = Math.abs(me.clientY - startY);
+        if (dx + dy > PRESS_CANCEL_PX) cancelArm();
+        return;
+      }
+
+      if (!songListEl) return;
+
+      // Find the card whose midpoint is closest to the finger. We skip the
+      // dragged card itself because its translateY shifts its rect off the
+      // baseline — including it would create a feedback loop where the
+      // closest-match keeps snapping back to the dragged card.
       const cards = Array.from(songListEl.children);
       const y = me.clientY;
       let closest = dragIndex;
       let minDist = Infinity;
       cards.forEach((card, i) => {
+        if (i === dragIndex) return;
         const rect = card.getBoundingClientRect();
         const mid = rect.top + rect.height / 2;
         const dist = Math.abs(y - mid);
         if (dist < minDist) { minDist = dist; closest = i; }
       });
+
+      // Light haptic tick when the drop target changes — gives the user a
+      // tactile sense of "you've crossed into a new slot".
+      if (isTouch && closest !== dragOverIndex) vibrate(8);
+
       dragOverIndex = closest;
+      dragYOffset = me.clientY - startY;
     };
 
     const onUp = () => {
-      if (dragIndex !== null && dragOverIndex !== null && dragIndex !== dragOverIndex) {
+      if (armTimer) { clearTimeout(armTimer); armTimer = null; }
+
+      if (armed && dragIndex !== null && dragOverIndex !== null && dragIndex !== dragOverIndex) {
         store.reorderSetlistSong(dragIndex, dragOverIndex);
+        // Confirmation haptic — slightly different pattern than the arm tap
+        // so the two events feel distinct.
+        if (isTouch) vibrate([10, 30, 14]);
       }
+
+      cancelled = true;
+      dragArmingIndex = null;
       dragIndex = null;
       dragOverIndex = null;
+      dragYOffset = 0;
+      cleanup();
+    };
+
+    function preventScroll(ev) {
+      // Once drag is armed, block the browser from interpreting subsequent
+      // touchmove events as a scroll. Without this the page would scroll out
+      // from under the dragged card on devices that ignore pointer capture
+      // for scroll suppression.
+      if (armed && ev.cancelable) ev.preventDefault();
+    }
+
+    function cleanup() {
       window.removeEventListener("pointermove", onMove);
       window.removeEventListener("pointerup", onUp);
       window.removeEventListener("pointercancel", onUp);
-    };
+      window.removeEventListener("touchmove", preventScroll);
+      try { captureTarget?.releasePointerCapture?.(pointerId); } catch { /* noop */ }
+    }
 
     window.addEventListener("pointermove", onMove);
     window.addEventListener("pointerup", onUp);
     window.addEventListener("pointercancel", onUp);
+    // passive:false is required so preventScroll() can call preventDefault.
+    window.addEventListener("touchmove", preventScroll, { passive: false });
   }
 </script>
 
@@ -427,9 +559,19 @@
   <!-- Setlist result -->
   {#if store.generatedSetlist}
     <section class="result-section">
-      <div class="song-list" bind:this={songListEl}>
+      <div class="song-list" bind:this={songListEl} class:drag-active={dragIndex !== null}>
         {#each store.generatedSetlist.songs as song, i (song.id)}
-          <div class="song-list-item" class:drag-over={dragIndex !== null && dragOverIndex === i && dragIndex !== i}>
+          <div
+            class="song-list-item"
+            class:dragging={dragIndex === i}
+            class:arming={dragArmingIndex === i}
+            class:drop-target={dragIndex !== null && dragOverIndex === i && dragIndex !== i}
+            class:drop-above={dragIndex !== null && dragOverIndex === i && dragIndex > i}
+            class:drop-below={dragIndex !== null && dragOverIndex === i && dragIndex < i}
+            class:dimmed={dragIndex !== null && dragIndex !== i && dragOverIndex !== i}
+            style:transform={dragIndex === i ? `translateY(${dragYOffset}px)` : ""}
+            animate:flip={{ duration: 240 }}
+          >
             <SetlistSongCard
               {song}
               index={i}
@@ -437,6 +579,8 @@
               onDragStart={handleDragStart}
               onEdit={handleEditSong}
               onRemove={(idx) => store.removeSetlistSong(idx)}
+              arming={dragArmingIndex === i}
+              dragging={dragIndex === i}
             />
           </div>
         {/each}
@@ -1078,16 +1222,92 @@
   .song-list {
     display: grid;
     gap: 0.4rem;
+    /* When a drag is armed/active, prevent the list from being scrolled by
+       gestures originating inside the list. Pointer capture handles most
+       cases; this is belt-and-braces for older mobile browsers. */
+  }
+
+  .song-list.drag-active {
+    touch-action: none;
   }
 
   .song-list-item {
-    transition: transform 150ms ease;
+    position: relative;
+    transition:
+      opacity 180ms ease,
+      filter 180ms ease;
   }
 
-  .drag-over {
-    outline: 2px solid var(--accent, #e15b37);
-    outline-offset: -1px;
-    border-radius: var(--radius-md, 12px);
+  /* The dragged card floats above the list and follows the finger. The
+     translateY transform is applied inline (so JS can drive it without
+     fighting CSS), but the lift effects (z-index, rotation, willChange) live
+     here. The inner .song-card handles its own shadow/border via the
+     `dragging` class passed from RollScreen. */
+  .song-list-item.dragging {
+    z-index: 20;
+    will-change: transform;
+    /* Slight rotation on top of the JS-driven translateY adds a "lifted"
+       feel without making the drag feel chaotic. */
+    transition: none;
+  }
+
+  .song-list-item.dragging :global(.song-card) {
+    transform: scale(1.025) rotate(-0.6deg);
+    transform-origin: 12px 50%;
+  }
+
+  /* Cards that aren't the drag source or the drop target fade back so the
+     active interaction stands out clearly. The dimming is subtle — just
+     enough to push them visually behind the action. */
+  .song-list-item.dimmed :global(.song-card) {
+    opacity: 0.55;
+    filter: saturate(0.85);
+    transition: opacity 180ms ease, filter 180ms ease;
+  }
+
+  /* The drop target gets a strong accent treatment so the user is in no
+     doubt about where the song will land. Combined with the lifted dragged
+     card pointing at it, the relationship is clear. */
+  .song-list-item.drop-target :global(.song-card) {
+    border-color: var(--accent, #e15b37);
+    border-width: 2px;
+    padding: calc(0.65rem - 1px) calc(0.75rem - 1px);
+    background: var(--accent-soft);
+    box-shadow: 0 0 0 4px var(--accent-soft);
+  }
+
+  /* Insertion line — a fat accent bar between cards showing exactly where
+     the dragged card will slot in. The direction (above vs. below) tracks
+     whether the user is moving the song up or down the list. */
+  .song-list-item.drop-above::before,
+  .song-list-item.drop-below::after {
+    content: "";
+    position: absolute;
+    left: 4px;
+    right: 4px;
+    height: 4px;
+    background: var(--accent, #e15b37);
+    border-radius: 999px;
+    box-shadow:
+      0 0 0 3px var(--accent-soft),
+      0 2px 6px rgba(225, 91, 55, 0.35);
+    animation: drop-line-pulse 900ms ease-in-out infinite;
+    pointer-events: none;
+    z-index: 5;
+  }
+
+  .song-list-item.drop-above::before { top: -6px; }
+  .song-list-item.drop-below::after { bottom: -6px; }
+
+  @keyframes drop-line-pulse {
+    0%, 100% { opacity: 0.85; transform: scaleX(0.985); }
+    50%      { opacity: 1;    transform: scaleX(1); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .song-list-item.drop-above::before,
+    .song-list-item.drop-below::after { animation: none; }
+    .song-list-item.dragging :global(.song-card) { transform: none; }
   }
 
   .setlist-actions {

--- a/src/lib/components/roll/SetlistSongCard.svelte
+++ b/src/lib/components/roll/SetlistSongCard.svelte
@@ -1,5 +1,5 @@
 <script>
-  const { song, index, prevSong, onDragStart, onEdit, onRemove } = $props();
+  const { song, index, prevSong, onDragStart, onEdit, onRemove, arming = false, dragging = false } = $props();
 
   let expanded = $state(false);
 
@@ -55,14 +55,26 @@
   }
 </script>
 
-<div class="song-card" class:expanded>
+<div class="song-card" class:expanded class:dragging>
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="card-main" onclick={toggleExpand} onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleExpand(); } }} role="button" tabindex="0">
     <span
       class="drag-handle"
-      aria-label="Drag to reorder"
+      class:arming
+      class:dragging
+      aria-label="Press and hold to reorder"
+      title="Press and hold to reorder"
       onpointerdown={(e) => { e.stopPropagation(); if (onDragStart) onDragStart(e, index); }}
-    >&#9776;</span>
+    >
+      <svg class="grip-icon" width="14" height="22" viewBox="0 0 14 22" aria-hidden="true">
+        <circle cx="3.5" cy="4" r="1.6"/>
+        <circle cx="10.5" cy="4" r="1.6"/>
+        <circle cx="3.5" cy="11" r="1.6"/>
+        <circle cx="10.5" cy="11" r="1.6"/>
+        <circle cx="3.5" cy="18" r="1.6"/>
+        <circle cx="10.5" cy="18" r="1.6"/>
+      </svg>
+    </span>
 
     <div class="card-body">
       <div class="title-row">
@@ -126,30 +138,121 @@
     border: 1px solid var(--line);
     border-radius: var(--radius-md, 12px);
     padding: 0.65rem 0.75rem;
-    transition: border-color 150ms ease;
+    transition:
+      border-color 150ms ease,
+      box-shadow 180ms ease,
+      background 180ms ease;
   }
 
   .song-card.expanded {
     border-color: var(--accent-line);
   }
 
+  /* When the parent wrapper marks this card as dragging, lift it visually so
+     the user can clearly see which card they are holding. The wrapper handles
+     the translateY follow-the-finger transform; the card itself only changes
+     elevation, border colour, and a subtle tilt. */
+  .song-card.dragging {
+    border-color: var(--accent, #e15b37);
+    border-width: 2px;
+    padding: calc(0.65rem - 1px) calc(0.75rem - 1px);
+    background: var(--paper-strong);
+    box-shadow:
+      0 18px 40px rgba(27, 39, 58, 0.22),
+      0 4px 12px rgba(225, 91, 55, 0.18);
+  }
+
   .card-main {
     display: flex;
     align-items: flex-start;
-    gap: 0.5rem;
+    gap: 0.4rem;
     cursor: pointer;
     -webkit-tap-highlight-color: transparent;
   }
 
+  /* Drag handle: bigger touch target, clearer visual.
+     - touch-action: pan-y lets the user scroll vertically over the handle by
+       default. Drag mode is opt-in via long-press in RollScreen, so brushing
+       past the handle while scrolling no longer hijacks the gesture.
+     - The .arming and .dragging classes are toggled by the parent to show
+       the press-hold progress and the active drag state. */
   .drag-handle {
     flex-shrink: 0;
-    cursor: grab;
-    font-size: 1rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    /* WCAG 2.5.5 / iOS HIG recommend ≥44px tappable height. We get there
+       via padding + the SVG, so the visual column stays slim while the
+       touch target stays generous. */
+    width: 30px;
+    min-height: 44px;
+    /* Pull the handle slightly into the card's left padding so the visible
+       icon hugs the edge — the touch target still extends inward. */
+    margin-left: -0.4rem;
+    padding: 0.3rem 0.4rem;
     color: var(--muted, #8a95a5);
-    padding: 0.1rem 0;
-    line-height: 1.4;
-    touch-action: none;
+    cursor: grab;
+    touch-action: pan-y;
     user-select: none;
+    -webkit-user-select: none;
+    border-radius: 8px;
+    transition:
+      background 160ms ease,
+      color 160ms ease,
+      transform 160ms ease,
+      box-shadow 160ms ease;
+  }
+
+  .drag-handle:hover {
+    color: var(--ink, #182230);
+    background: var(--hover);
+  }
+
+  .drag-handle:active {
+    cursor: grabbing;
+  }
+
+  /* Arming: shown for the ~350ms long-press window before drag activates.
+     A pulsing accent ring + filled background telegraphs "keep holding".
+     Combined with the haptic tap when the timer fires, the user understands
+     they have entered drag mode. */
+  .drag-handle.arming {
+    color: var(--accent, #e15b37);
+    background: var(--accent-soft);
+    transform: scale(1.08);
+    animation: handle-arm 350ms ease-out;
+  }
+
+  /* Dragging: the handle becomes a solid accent badge so the user can clearly
+     see which card their finger is currently anchored to. */
+  .drag-handle.dragging {
+    color: var(--on-accent);
+    background: var(--accent, #e15b37);
+    transform: scale(1.12);
+    box-shadow: 0 4px 10px rgba(225, 91, 55, 0.35);
+    cursor: grabbing;
+  }
+
+  .grip-icon {
+    fill: currentColor;
+    pointer-events: none;
+  }
+
+  @keyframes handle-arm {
+    0% {
+      transform: scale(1);
+      box-shadow: 0 0 0 0 rgba(225, 91, 55, 0.45);
+    }
+    100% {
+      transform: scale(1.08);
+      box-shadow: 0 0 0 10px rgba(225, 91, 55, 0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .drag-handle.arming {
+      animation: none;
+    }
   }
 
   .card-body {

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -393,7 +393,12 @@ export function createAppStore(repo) {
     function buildAllInstrumentNames() {
         const names = new Set();
         Object.values(memberInstrumentChoicesByMember || {}).forEach((instruments) => {
-            (instruments || []).forEach((name) => names.add(name));
+            // Wrap in a block so the arrow doesn't return Set#add's value —
+            // Biome's useIterableCallbackReturn flags implicit returns from
+            // forEach callbacks as a likely bug.
+            (instruments || []).forEach((name) => {
+                names.add(name);
+            });
         });
         return Array.from(names).sort();
     }


### PR DESCRIPTION
## Summary

- Reordering songs on mobile now requires an intentional **350ms long-press** on the drag handle. Brushing past the handle while scrolling no longer hijacks the gesture into a reorder. Mouse drag is unchanged.
- Drag visuals are far more obvious: the handle is a proper 6-dot grip on a 44px touch target with three explicit states (idle / arming pulse / dragging accent fill). The dragged card lifts (shadow + scale + accent border + slight rotation) and follows the finger; other cards dim back. The drop slot is shown as a thick accent border + soft fill on the target card plus a pulsing accent insertion line above or below it depending on travel direction.
- `animate:flip` smooths the post-drop reorder. Light haptics (where supported) on arm, on each new drop target, and on a successful reorder.
- `prefers-reduced-motion` is honoured.

Second commit is a follow-up: enable the **Biome 2.4 Svelte linter** (`html.experimentalFullSupportEnabled` was already on, but the override block was hard-disabling the linter on `.svelte` / `.svelte.js`). Rule overrides silence the noise from Svelte 5 conventions (`useConst` for `$derived`, template-only usage of script symbols, etc). The formatter for `.svelte` stays disabled — turning it on would reformat every Svelte file and that's a separate decision.

The new linter also caught two genuine issues that this PR fixes:
- `App.svelte` recent-account buttons were missing `type="button"` (silent submit-on-Enter bug if ever placed in a form).
- `buildAllInstrumentNames` in `app.svelte.js` used an implicit-return arrow as a `forEach` callback, returning `Set#add`'s value — wrapped the body in a block.

## Test plan

- [x] On a phone, scroll the setlist by swiping over a song's drag handle — the page should scroll naturally and the song order must not change.
- [x] On a phone, press and hold the drag handle for ~350ms — the handle pulses accent-orange, you feel a haptic tick, and the card lifts.
- [x] Drag the lifted card up and down — the targeted card highlights with a thick accent border + soft fill, and an accent insertion line appears above/below it. Other cards dim to make the active interaction obvious.
- [x] Release on a different slot — the song reorders with a smooth animation and a confirmation haptic fires.
- [x] Release on the same slot (or release after cancelling) — no reorder happens and the card snaps back.
- [x] Long-press, then release without moving — the card's expanded panel does NOT toggle (long-press shouldn't be interpreted as a tap).
- [x] On desktop with a mouse, the drag still begins on `pointerdown` on the handle (no long-press required) and works as before.
- [x] `npm run lint`, `npm run build`, `npm test` all pass locally.