### PR TITLE
refactor(stores): lean setlist shape with reactive catalog overlay and sync-safe pruning

### DIFF
--- a/src/lib/components/roll/RollScreen.svelte
+++ b/src/lib/components/roll/RollScreen.svelte
@@ -15,7 +15,7 @@
   let showAddSongPicker = $state(false);
   let addSongSearch = $state("");
   let setlistSongIds = $derived(
-    new Set((store.generatedSetlist?.songs || []).map((s) => s.id))
+    new Set((store.displayedSetlist?.songs || []).map((s) => s.id))
   );
   let filteredPickerSongs = $derived.by(() => {
     const eligible = store.songs?.filter((s) => !s.unpracticed) || [];
@@ -30,7 +30,7 @@
     const generating = store.isGenerating;
     if (prevGenerating && !generating) {
       diceValue = Math.floor(Math.random() * 6) + 1;
-      if (store.generatedSetlist) {
+      if (store.displayedSetlist) {
         landed = true;
         showConfetti = true;
         setTimeout(() => { showConfetti = false; landed = false; }, 1200);
@@ -115,7 +115,7 @@
   let hasConstraints = $derived(membersWithChoices().length > 0);
   // anxietyLevel: pre-computed by the generator, label from anxiety lib
   let anxietyLevel = $derived.by(() => {
-    const anxiety = store.generatedSetlist?.summary?.anxiety;
+    const anxiety = store.displayedSetlist?.summary?.anxiety;
     if (!anxiety) return { scaled: 0, label: "" };
     return { scaled: anxiety.scaled, label: anxietyLabel(anxiety) };
   });
@@ -545,7 +545,7 @@
   {/if}
 
   <!-- Ready to roll but nothing rolled yet -->
-  {#if readyToRoll && !store.generatedSetlist}
+  {#if readyToRoll && !store.displayedSetlist}
     <div class="idle-nudge">
       <div class="idle-die-face" style="--pip-rgb: {pipColorRgb};">
         {#each PIP_LAYOUTS[5] as [px, py]}
@@ -557,10 +557,10 @@
   {/if}
 
   <!-- Setlist result -->
-  {#if store.generatedSetlist}
+  {#if store.displayedSetlist}
     <section class="result-section">
       <div class="song-list" bind:this={songListEl} class:drag-active={dragIndex !== null}>
-        {#each store.generatedSetlist.songs as song, i (song.id)}
+        {#each store.displayedSetlist.songs as song, i (song.id)}
           <div
             class="song-list-item"
             class:dragging={dragIndex === i}
@@ -575,7 +575,7 @@
             <SetlistSongCard
               {song}
               index={i}
-              prevSong={i > 0 ? store.generatedSetlist.songs[i - 1] : null}
+              prevSong={i > 0 ? store.displayedSetlist.songs[i - 1] : null}
               onDragStart={handleDragStart}
               onEdit={handleEditSong}
               onRemove={(idx) => store.removeSetlistSong(idx)}

--- a/src/lib/components/saved/SavedScreen.svelte
+++ b/src/lib/components/saved/SavedScreen.svelte
@@ -178,14 +178,14 @@
 <div class="saved-screen">
   <h2 class="screen-title">Greatest Hits</h2>
 
-  {#if !store.savedSetlists?.length}
+  {#if !store.displayedSavedSetlists?.length}
     <div class="empty-state">
       <p class="empty-title">Nothing saved yet</p>
       <p class="empty-sub">Roll a setlist you love, lock it in, then save it here for safekeeping.</p>
     </div>
   {:else}
     <div class="saved-list">
-      {#each store.savedSetlists as saved}
+      {#each store.displayedSavedSetlists as saved}
         <!-- svelte-ignore a11y_no_static_element_interactions -->
         <div class="saved-card" onclick={() => handleView(saved)} role="button" tabindex="0" onkeydown={(e) => { if (e.key === 'Enter') handleView(saved); }}>
           {#if editingId === saved.id}
@@ -200,11 +200,11 @@
             </div>
           {:else}
             <div class="saved-top">
-              <span class="saved-name">{saved.name || `Set #${saved.songCount || "?"}`}</span>
+              <span class="saved-name">{saved.name || `Set #${saved.songs?.length || "?"}`}</span>
               <span class="saved-date">{formatDate(saved.savedAt)}</span>
             </div>
             <div class="saved-meta">
-              <span>{saved.songCount || saved.songs?.length || 0} songs</span>
+              <span>{saved.songs?.length || 0} songs</span>
             </div>
             <div class="saved-card-actions">
               <button type="button" class="card-btn edit" onclick={(e) => startEdit(e, saved)}>Edit</button>

--- a/src/lib/components/saved/SavedScreen.svelte
+++ b/src/lib/components/saved/SavedScreen.svelte
@@ -4,14 +4,17 @@
 
   const store = getContext("app");
 
-  let viewingSet = $state(null);
+  let viewingId = $state(null);
+  let viewingSet = $derived(
+    viewingId ? (store.displayedSavedSetlists?.find(s => s.id === viewingId) ?? null) : null
+  );
   let editingId = $state(null);
   let editName = $state("");
   let editDate = $state("");
 
   function handleView(saved) {
     if (editingId) return;
-    viewingSet = saved;
+    viewingId = saved.id;
   }
 
   function startEdit(e, saved) {
@@ -38,7 +41,7 @@
   }
 
   function handleClose() {
-    viewingSet = null;
+    viewingId = null;
   }
 
   function handleLoad(e, id) {
@@ -278,7 +281,7 @@
 
       <div class="modal-actions">
         <button type="button" class="modal-btn" onclick={handlePrint}>Print / Export PDF</button>
-        <button type="button" class="modal-btn primary" onclick={(e) => { handleLoad(e, viewingSet.id); viewingSet = null; }}>Load to Roll</button>
+        <button type="button" class="modal-btn primary" onclick={(e) => { handleLoad(e, viewingSet.id); viewingId = null; }}>Load to Roll</button>
       </div>
     </div>
   </div>

--- a/src/lib/migrations.js
+++ b/src/lib/migrations.js
@@ -27,3 +27,28 @@ migrator.register({
         return doc;
     },
 });
+
+migrator.register({
+    version: 2,
+    collection: "setlists",
+    description: "Lean shape — songs reference catalog by songId; drop embedded catalog fields and derived summary",
+    transform(doc) {
+        if (Array.isArray(doc.songs)) {
+            doc.songs = doc.songs.map((s) => ({
+                songId: s.songId || s.id,
+                performance: s.performance || {},
+            }));
+        }
+        if (doc.summary) {
+            for (const flag of ["minimumsRelaxed", "openerFilterRelaxed", "closerFilterRelaxed"]) {
+                if (doc.summary[flag] !== undefined && doc[flag] === undefined) {
+                    doc[flag] = doc.summary[flag];
+                }
+            }
+            delete doc.summary;
+        }
+        delete doc.songNames;
+        delete doc.songCount;
+        return doc;
+    },
+});

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -1379,7 +1379,7 @@ export function createAppStore(repo) {
                     minimumsRelaxed: !!generatedSetlist.minimumsRelaxed,
                     openerFilterRelaxed: !!generatedSetlist.openerFilterRelaxed,
                     closerFilterRelaxed: !!generatedSetlist.closerFilterRelaxed,
-                    songs: clone(generatedSetlist.songs),
+                    songs: clone(generatedSetlist.songs.filter((e) => songsById.has(e.songId))),
                 });
                 setlistSaved = true;
                 return;
@@ -1411,7 +1411,7 @@ export function createAppStore(repo) {
             minimumsRelaxed: !!generatedSetlist.minimumsRelaxed,
             openerFilterRelaxed: !!generatedSetlist.openerFilterRelaxed,
             closerFilterRelaxed: !!generatedSetlist.closerFilterRelaxed,
-            songs: clone(generatedSetlist.songs),
+            songs: clone(generatedSetlist.songs.filter((e) => songsById.has(e.songId))),
         };
         try {
             await withSync("Saving setlist", () => repo.putSetlist(entry));

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -472,6 +472,15 @@ export function createAppStore(repo) {
     let displayedSetlist = $derived(hydrateSetlist(generatedSetlist));
     let displayedSavedSetlists = $derived((savedSetlists || []).map(hydrateSetlist));
 
+    // True only when the catalog is fully settled and safe to treat as
+    // authoritative. Excludes "syncing" (reload in flight) AND "error"
+    // (reload failed — catalog may be incomplete). Only "idle" (post-sync
+    // steady state) and "synced" (just completed) are considered settled.
+    // pendingBodies === 0 ensures all song bodies have arrived.
+    let catalogSettled = $derived(
+        (syncState === "idle" || syncState === "synced") && pendingBodies === 0,
+    );
+
     /**
      * Strip a generator/scoring result down to the lean persisted shape.
      *
@@ -1396,7 +1405,6 @@ export function createAppStore(repo) {
         // remotely but haven't loaded yet. When unsettled, we save the songs
         // verbatim — any truly-deleted entries will be pruned on the next save
         // once the catalog is stable.
-        const catalogSettled = syncState !== "syncing" && pendingBodies === 0;
         const persistedSongs = catalogSettled
             ? clone(generatedSetlist.songs.filter((e) => songsById.has(e.songId)))
             : clone(generatedSetlist.songs);
@@ -1481,14 +1489,18 @@ export function createAppStore(repo) {
     function loadSavedSetlist(id) {
         const saved = savedSetlists.find((s) => s.id === id);
         if (!saved) return;
-        const valid = (saved.songs || []).filter((e) => songsById.has(e.songId));
-        const dropped = (saved.songs || []).length - valid.length;
+        const all = (saved.songs || []).map((e) => ({ songId: e.songId, performance: e.performance || {} }));
+        // Guard: only prune against songsById when the catalog is settled.
+        // If the catalog is still loading, treat every entry as valid so
+        // not-yet-pulled songs don't trigger a false "no longer in catalog" warn.
+        const songs = catalogSettled ? all.filter((e) => songsById.has(e.songId)) : all;
+        const dropped = catalogSettled ? all.length - songs.length : 0;
         generatedSetlist = {
             seed: saved.seed,
             minimumsRelaxed: !!saved.minimumsRelaxed,
             openerFilterRelaxed: !!saved.openerFilterRelaxed,
             closerFilterRelaxed: !!saved.closerFilterRelaxed,
-            songs: valid.map((e) => ({ songId: e.songId, performance: e.performance || {} })),
+            songs,
         };
         setlistLocked = true;
         setlistSaved = true;
@@ -1497,26 +1509,41 @@ export function createAppStore(repo) {
         if (dropped > 0) {
             toastWarn(`Skipped ${dropped} song${dropped === 1 ? "" : "s"} no longer in your catalog.`);
         }
-        toastInfo(`Loaded ${valid.length}-song set.`);
+        toastInfo(`Loaded ${songs.length}-song set.`);
     }
 
     // Mutation helpers operate on the lean entries — no rescoring needed,
     // since `displayedSetlist` runs scoreFixedOrder() in its derivation
     // chain whenever the underlying data changes.
+    //
+    // Indices come from the UI, which iterates displayedSetlist.songs.
+    // hydrateSetlist() filters out stale (deleted/not-yet-loaded) entries,
+    // so the displayed index may not match the raw generatedSetlist index.
+    // Resolve by songId to guarantee the right entry is mutated.
     function reorderSetlistSong(fromIndex, toIndex) {
-        if (!generatedSetlist) return;
+        if (!generatedSetlist || !displayedSetlist) return;
+        const fromSongId = displayedSetlist.songs[fromIndex]?.id;
+        const toSongId   = displayedSetlist.songs[toIndex]?.id;
+        if (!fromSongId || !toSongId) return;
+        const rawFrom = generatedSetlist.songs.findIndex((e) => e.songId === fromSongId);
+        const rawTo   = generatedSetlist.songs.findIndex((e) => e.songId === toSongId);
+        if (rawFrom === -1 || rawTo === -1) return;
         const list = [...generatedSetlist.songs];
-        const [moved] = list.splice(fromIndex, 1);
-        list.splice(toIndex, 0, moved);
+        const [moved] = list.splice(rawFrom, 1);
+        list.splice(rawTo, 0, moved);
         generatedSetlist = { ...generatedSetlist, songs: list };
         setlistSaved = false;
         persistCurrentSetlist();
     }
 
     function removeSetlistSong(index) {
-        if (!generatedSetlist) return;
+        if (!generatedSetlist || !displayedSetlist) return;
+        const songId = displayedSetlist.songs[index]?.id;
+        if (!songId) return;
+        const rawIndex = generatedSetlist.songs.findIndex((e) => e.songId === songId);
+        if (rawIndex === -1) return;
         const list = [...generatedSetlist.songs];
-        list.splice(index, 1);
+        list.splice(rawIndex, 1);
         if (!list.length) {
             clearGeneratedSetlist();
             setlistLocked = false;

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -288,6 +288,27 @@ export function createAppStore(repo) {
         if (currentUserAddress) scheduleSnapshot();
     });
 
+    // Once the catalog is fully settled, reconcile any stale song refs that
+    // were deferred during the initial sync (or pruned any time a song is
+    // deleted mid-session while a setlist is active). Runs whenever
+    // catalogSettled, generatedSetlist, or songsById changes — safe because
+    // a second run after the mutation finds dropped===0 and exits.
+    $effect(() => {
+        if (!catalogSettled || !generatedSetlist) return;
+        const valid = generatedSetlist.songs.filter((e) => songsById.has(e.songId));
+        const dropped = generatedSetlist.songs.length - valid.length;
+        if (dropped === 0) return;
+        if (valid.length === 0) {
+            clearGeneratedSetlist();
+            setlistLocked = false;
+        } else {
+            generatedSetlist = { ...generatedSetlist, songs: valid };
+        }
+        setlistSaved = false;
+        persistCurrentSetlist();
+        toastWarn(`Removed ${dropped} song${dropped === 1 ? "" : "s"} no longer in your catalog.`);
+    });
+
     // ---- helpers ----
 
     function defaultGenerationOptions(config = appConfig) {

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -537,7 +537,7 @@ export function createAppStore(repo) {
      * @returns {object|null} Setlist with lean `{songId, performance}` song entries.
      */
     function normalizeLeanSetlist(setlist) {
-        if (!setlist || !Array.isArray(setlist.songs)) return setlist;
+        if (!setlist || !Array.isArray(setlist.songs)) return null;
         const songs = setlist.songs.map((s) => ({
             songId: s.songId || s.id,
             performance: s.performance || {},
@@ -1516,21 +1516,33 @@ export function createAppStore(repo) {
         // not-yet-pulled songs don't trigger a false "no longer in catalog" warn.
         const songs = catalogSettled ? all.filter((e) => songsById.has(e.songId)) : all;
         const dropped = catalogSettled ? all.length - songs.length : 0;
-        generatedSetlist = {
-            seed: saved.seed,
-            minimumsRelaxed: !!saved.minimumsRelaxed,
-            openerFilterRelaxed: !!saved.openerFilterRelaxed,
-            closerFilterRelaxed: !!saved.closerFilterRelaxed,
-            songs,
-        };
-        setlistLocked = true;
-        setlistSaved = true;
-        loadedSavedId = id;
-        persistCurrentSetlist();
+        if (catalogSettled && songs.length === 0) {
+            // All songs were pruned — don't mark a saved set as loaded with an
+            // empty lean list; that would let the next save clobber the document
+            // with songs:[]. Clear instead, mirroring the pruning-effect path.
+            clearGeneratedSetlist();
+            setlistLocked = false;
+            setlistSaved = false;
+            persistCurrentSetlist();
+        } else {
+            generatedSetlist = {
+                seed: saved.seed,
+                minimumsRelaxed: !!saved.minimumsRelaxed,
+                openerFilterRelaxed: !!saved.openerFilterRelaxed,
+                closerFilterRelaxed: !!saved.closerFilterRelaxed,
+                songs,
+            };
+            setlistLocked = true;
+            setlistSaved = true;
+            loadedSavedId = id;
+            persistCurrentSetlist();
+        }
         if (dropped > 0) {
             toastWarn(`Skipped ${dropped} song${dropped === 1 ? "" : "s"} no longer in your catalog.`);
         }
-        toastInfo(`Loaded ${songs.length}-song set.`);
+        if (songs.length > 0) {
+            toastInfo(`Loaded ${songs.length}-song set.`);
+        }
     }
 
     // Mutation helpers operate on the lean entries — no rescoring needed,

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -1236,9 +1236,9 @@ export function createAppStore(repo) {
     }
 
     function confirmOptimizeOrder() {
-        if (!generatedSetlist) return;
+        if (!displayedSetlist) return;
         pendingRollConfirm = false;
-        const currentSongs = generatedSetlist.songs;
+        const currentSongs = displayedSetlist.songs;
         const currentCovers = currentSongs.filter(s => s.cover).length;
         const currentInstrumentals = currentSongs.filter(s => s.instrumental).length;
         generate({

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -49,41 +49,6 @@ export function normalizeAuthToken(token) {
     return typeof token === "string" && token.length > 0 ? token : undefined;
 }
 
-export function syncSavedSongIntoSetlist(setlist, savedSong, appConfig, keyFlow = false) {
-    if (!setlist?.songs?.length || !savedSong?.id) return setlist;
-
-    let changed = false;
-    const syncedSongs = setlist.songs.map((song) => {
-        if (song.id !== savedSong.id) return song;
-
-        const nextSong = {
-            ...song,
-            name: savedSong.name,
-            cover: savedSong.cover || false,
-            instrumental: savedSong.instrumental || false,
-            key: savedSong.key || "",
-            notes: savedSong.notes || "",
-        };
-
-        if (
-            nextSong.name !== song.name ||
-            nextSong.cover !== song.cover ||
-            nextSong.instrumental !== song.instrumental ||
-            nextSong.key !== song.key ||
-            nextSong.notes !== song.notes
-        ) {
-            changed = true;
-        }
-
-        return nextSong;
-    });
-
-    if (!changed) return setlist;
-
-    const rescored = scoreFixedOrder(syncedSongs, appConfig || DEFAULT_APP_CONFIG, { keyFlow });
-    return { ...setlist, songs: rescored.songs, summary: rescored.summary };
-}
-
 export function createAppStore(repo) {
     // ---- per-user localStorage scoping ----
     let currentUserAddress = "";
@@ -456,38 +421,91 @@ export function createAppStore(repo) {
         localStorage.setItem(storageKey("ui-options"), JSON.stringify(generationOptions));
     }
 
-    function replaceGeneratedSetlist(nextSetlist) {
-        generatedSetlist = nextSetlist;
-    }
-
-    function updateCurrentSetlist(nextSetlist) {
-        generatedSetlist = nextSetlist;
-    }
-
     function clearGeneratedSetlist() {
         generatedSetlist = null;
         loadedSavedId = "";
     }
 
-    // Strip deprecated "energy" field and energy-related notes from saved setlist songs
-    function stripEnergy(sets) {
-        if (!Array.isArray(sets)) return sets;
-        return sets.map((s) => ({
-            ...s,
-            songs: (s.songs || []).map((song) => {
-                const { energy, ...rest } = song;
-                return {
-                    ...rest,
-                    transitionNotes: (rest.transitionNotes || []).filter((n) => !/energy/i.test(n)),
-                    contextNotes: (rest.contextNotes || []).filter((n) => !/energy/i.test(n)),
-                };
-            }),
+    // Catalog lookup table. Recomputes whenever `songs` changes, which is
+    // what makes the displayed setlists below auto-refresh on RS pulls and
+    // local edits — no manual sync paths required.
+    let songsById = $derived(new Map((songs || []).map((s) => [s.id, s])));
+
+    // Take a lean setlist + the live catalog and produce the fully-fat
+    // form that views render: catalog fields overlaid, scores and summary
+    // recomputed by scoreFixedOrder. Songs whose ids no longer exist in
+    // the catalog are filtered out — saved setlists shrink gracefully when
+    // their referenced songs have been deleted.
+    function hydrateSetlist(setlist) {
+        if (!setlist || !Array.isArray(setlist.songs)) return setlist || null;
+        const fat = [];
+        for (const entry of setlist.songs) {
+            const song = songsById.get(entry.songId);
+            if (song) fat.push({ ...song, performance: entry.performance || {} });
+        }
+        const scored = scoreFixedOrder(fat, appConfig || DEFAULT_APP_CONFIG, {
+            keyFlow: generationOptions?.keyFlow,
+        });
+        return {
+            ...setlist,
+            songs: scored.songs,
+            summary: {
+                ...scored.summary,
+                minimumsRelaxed: !!setlist.minimumsRelaxed,
+                openerFilterRelaxed: !!setlist.openerFilterRelaxed,
+                closerFilterRelaxed: !!setlist.closerFilterRelaxed,
+            },
+        };
+    }
+
+    let displayedSetlist = $derived(hydrateSetlist(generatedSetlist));
+    let displayedSavedSetlists = $derived((savedSetlists || []).map(hydrateSetlist));
+
+    // Strip a generator/scoring result down to the lean persisted shape:
+    // each setlist entry keeps only what isn't derivable from the catalog
+    // (the song reference and the rolled performance choice). Generation
+    // metadata moves to top-level fields; the scored summary is recomputed
+    // at display time inside hydrateSetlist().
+    function leanFromGeneratorResult(result) {
+        if (!result) return null;
+        const summary = result.summary || {};
+        return {
+            seed: result.seed,
+            minimumsRelaxed: !!summary.minimumsRelaxed,
+            openerFilterRelaxed: !!summary.openerFilterRelaxed,
+            closerFilterRelaxed: !!summary.closerFilterRelaxed,
+            songs: (result.songs || []).map((s) => ({
+                songId: s.id,
+                performance: s.performance || {},
+            })),
+        };
+    }
+
+    // Detect a pre-refactor (fat) saved/persisted setlist where each song
+    // entry carries embedded catalog fields, and convert it to the lean
+    // shape. Idempotent — already-lean entries pass through unchanged.
+    function normalizeLeanSetlist(setlist) {
+        if (!setlist || !Array.isArray(setlist.songs)) return setlist;
+        const songs = setlist.songs.map((s) => ({
+            songId: s.songId || s.id,
+            performance: s.performance || {},
         }));
+        const out = { ...setlist, songs };
+        if (out.summary) {
+            for (const flag of ["minimumsRelaxed", "openerFilterRelaxed", "closerFilterRelaxed"]) {
+                if (out.summary[flag] !== undefined && out[flag] === undefined) out[flag] = out.summary[flag];
+            }
+            delete out.summary;
+        }
+        delete out.songNames;
+        delete out.songCount;
+        return out;
     }
 
     function loadCurrentSetlist() {
         if (typeof localStorage === "undefined") return null;
-        return tryParseJson(localStorage.getItem(storageKey("current-set")), null);
+        const raw = tryParseJson(localStorage.getItem(storageKey("current-set")), null);
+        return normalizeLeanSetlist(raw);
     }
 
     function persistCurrentSetlist() {
@@ -523,7 +541,7 @@ export function createAppStore(repo) {
     function loadUserLocalData() {
         const current = loadCurrentSetlist();
         const locked = current?._locked || false;
-        if (locked) replaceGeneratedSetlist(current);
+        if (locked) generatedSetlist = current;
         else clearGeneratedSetlist();
         setlistLocked = locked;
         setlistSaved = false;
@@ -955,7 +973,7 @@ export function createAppStore(repo) {
             if (!data.config) return false;
             songs = (data.songs || []).map(normalizeSongRecord);
             appConfig = normalizeAppConfig(data.config);
-            savedSetlists = stripEnergy(data.setlists || []);
+            savedSetlists = (data.setlists || []).map((s) => migrator.migrateDocument("setlists", s));
             bandMembers = Object.fromEntries(
                 Object.entries(data.members || {}).map(([name, d]) => [name, normalizeMemberRecord(d)])
             );
@@ -1065,7 +1083,7 @@ export function createAppStore(repo) {
                 appConfig = normalizeAppConfig(data.config);
             }
             if (data.setlists !== undefined) {
-                savedSetlists = stripEnergy(data.setlists);
+                savedSetlists = data.setlists.map((s) => migrator.migrateDocument("setlists", s));
             }
             if (data.members !== undefined) {
                 bandMembers = Object.fromEntries(
@@ -1296,7 +1314,7 @@ export function createAppStore(repo) {
                 ]));
                 return;
             }
-            replaceGeneratedSetlist(result);
+            generatedSetlist = leanFromGeneratorResult(result);
             if (opts._keepLock) {
                 setlistSaved = false;
             } else {
@@ -1349,7 +1367,6 @@ export function createAppStore(repo) {
     async function saveCurrentSetlist() {
         if (!generatedSetlist) return;
         const currentSaved = savedSetlists || [];
-        const songNames = generatedSetlist.songs.map(s => s.name || s.title || "?");
 
         // If this setlist was loaded from a saved entry, update that entry in
         // place instead of creating a duplicate with a new id and name.
@@ -1358,11 +1375,11 @@ export function createAppStore(repo) {
             if (existing) {
                 await updateSavedSetlist(loadedSavedId, {
                     savedAt: nowIso(),
-                    summary: clone(generatedSetlist.summary),
-                    songs: clone(generatedSetlist.songs),
-                    songNames,
                     seed: generatedSetlist.seed,
-                    songCount: generatedSetlist.songs.length,
+                    minimumsRelaxed: !!generatedSetlist.minimumsRelaxed,
+                    openerFilterRelaxed: !!generatedSetlist.openerFilterRelaxed,
+                    closerFilterRelaxed: !!generatedSetlist.closerFilterRelaxed,
+                    songs: clone(generatedSetlist.songs),
                 });
                 setlistSaved = true;
                 return;
@@ -1389,11 +1406,12 @@ export function createAppStore(repo) {
             id: uid("set"),
             name: randomName,
             savedAt: nowIso(),
-            summary: clone(generatedSetlist.summary),
-            songs: clone(generatedSetlist.songs),
-            songNames,
+            schemaVersion: 2,
             seed: generatedSetlist.seed,
-            songCount: generatedSetlist.songs.length
+            minimumsRelaxed: !!generatedSetlist.minimumsRelaxed,
+            openerFilterRelaxed: !!generatedSetlist.openerFilterRelaxed,
+            closerFilterRelaxed: !!generatedSetlist.closerFilterRelaxed,
+            songs: clone(generatedSetlist.songs),
         };
         try {
             await withSync("Saving setlist", () => repo.putSetlist(entry));
@@ -1430,78 +1448,71 @@ export function createAppStore(repo) {
     function loadSavedSetlist(id) {
         const saved = savedSetlists.find((s) => s.id === id);
         if (!saved) return;
-        replaceGeneratedSetlist({
-            songs: clone(saved.songs),
-            summary: clone(saved.summary),
+        const valid = (saved.songs || []).filter((e) => songsById.has(e.songId));
+        const dropped = (saved.songs || []).length - valid.length;
+        generatedSetlist = {
             seed: saved.seed,
-        });
+            minimumsRelaxed: !!saved.minimumsRelaxed,
+            openerFilterRelaxed: !!saved.openerFilterRelaxed,
+            closerFilterRelaxed: !!saved.closerFilterRelaxed,
+            songs: valid.map((e) => ({ songId: e.songId, performance: e.performance || {} })),
+        };
         setlistLocked = true;
         setlistSaved = true;
         loadedSavedId = id;
         persistCurrentSetlist();
-        toastInfo(`Loaded ${saved.songs?.length || 0}-song set.`);
+        if (dropped > 0) {
+            toastWarn(`Skipped ${dropped} song${dropped === 1 ? "" : "s"} no longer in your catalog.`);
+        }
+        toastInfo(`Loaded ${valid.length}-song set.`);
     }
 
+    // Mutation helpers operate on the lean entries — no rescoring needed,
+    // since `displayedSetlist` runs scoreFixedOrder() in its derivation
+    // chain whenever the underlying data changes.
     function reorderSetlistSong(fromIndex, toIndex) {
         if (!generatedSetlist) return;
-        const songList = clone(generatedSetlist.songs);
-        const [moved] = songList.splice(fromIndex, 1);
-        songList.splice(toIndex, 0, moved);
-        const rescored = scoreFixedOrder(songList, appConfig, { keyFlow: generationOptions.keyFlow });
-        updateCurrentSetlist({ ...generatedSetlist, songs: rescored.songs, summary: rescored.summary });
+        const list = [...generatedSetlist.songs];
+        const [moved] = list.splice(fromIndex, 1);
+        list.splice(toIndex, 0, moved);
+        generatedSetlist = { ...generatedSetlist, songs: list };
         setlistSaved = false;
         persistCurrentSetlist();
     }
 
     function removeSetlistSong(index) {
         if (!generatedSetlist) return;
-        const songList = clone(generatedSetlist.songs);
-        songList.splice(index, 1);
-        if (!songList.length) {
+        const list = [...generatedSetlist.songs];
+        list.splice(index, 1);
+        if (!list.length) {
             clearGeneratedSetlist();
             setlistLocked = false;
             setlistSaved = false;
             persistCurrentSetlist();
             return;
         }
-        const rescored = scoreFixedOrder(songList, appConfig, { keyFlow: generationOptions.keyFlow });
-        updateCurrentSetlist({ ...generatedSetlist, songs: rescored.songs, summary: rescored.summary });
+        generatedSetlist = { ...generatedSetlist, songs: list };
         setlistSaved = false;
         persistCurrentSetlist();
     }
 
     function addSetlistSong(songId) {
         if (!generatedSetlist) return;
-        if (generatedSetlist.songs.some((s) => s.id === songId)) return;
-        const song = songs.find((s) => s.id === songId);
+        if (generatedSetlist.songs.some((s) => s.songId === songId)) return;
+        const song = songsById.get(songId);
         if (!song) return;
         const performance = buildDefaultPerformance(song, generationOptions?.show || {});
-        const songList = clone(generatedSetlist.songs);
-        songList.push({
-            id: song.id,
-            name: song.name,
-            cover: song.cover || false,
-            instrumental: song.instrumental || false,
-            key: song.key || "",
-            notes: song.notes || "",
-            performance,
-            // position is intentionally omitted; scoreFixedOrder re-stamps it
-            // after rescoring. Setting it here was off-by-one.
-            incrementalScore: 0,
-            cumulativeScore: 0,
-            transitionNotes: [],
-            positionNotes: [],
-            contextNotes: [],
-        });
-        const rescored = scoreFixedOrder(songList, appConfig, { keyFlow: generationOptions.keyFlow });
-        updateCurrentSetlist({ ...generatedSetlist, songs: rescored.songs, summary: rescored.summary });
+        generatedSetlist = {
+            ...generatedSetlist,
+            songs: [...generatedSetlist.songs, { songId, performance }],
+        };
         setlistSaved = false;
         persistCurrentSetlist();
     }
 
     let songsNotInSetlist = $derived.by(() => {
         if (!generatedSetlist?.songs) return songs.filter((s) => !s.unpracticed);
-        const usedIds = new Set(generatedSetlist.songs.map((s) => s.id));
+        const usedIds = new Set(generatedSetlist.songs.map((s) => s.songId));
         return songs.filter((s) => !s.unpracticed && !usedIds.has(s.id));
     });
 
@@ -1654,16 +1665,8 @@ export function createAppStore(repo) {
                 ...editorSong, updatedAt: nowIso()
             }));
             songs = songs.filter((s) => s.id !== saved.id).concat(saved).sort((a, b) => a.name.localeCompare(b.name));
-            const syncedSetlist = syncSavedSongIntoSetlist(
-                generatedSetlist,
-                saved,
-                appConfig,
-                generationOptions.keyFlow,
-            );
-            if (syncedSetlist !== generatedSetlist) {
-                updateCurrentSetlist(syncedSetlist);
-                persistCurrentSetlist();
-            }
+            // No manual setlist sync needed: displayedSetlist re-derives from
+            // the catalog automatically when `songs` changes.
 
             // Sync member names and instruments from the song into band members
             const dirtyMembers = new Map();
@@ -2114,7 +2117,7 @@ export function createAppStore(repo) {
             songs: songs.map(normalizeSongRecord),
             config: clone(appConfig),
             bandMembers: clone(bandMembers),
-            savedSetlists: stripEnergy(clone(currentSaved)),
+            savedSetlists: clone(currentSaved),
             meta: {
                 bandName: appConfig?.bandName || "",
                 songCount: songs.length,
@@ -2158,7 +2161,9 @@ export function createAppStore(repo) {
                 songs: payload.songs.map(normalizeSongRecord),
                 config: migratedConfig,
                 bandMembers: importedMembers,
-                savedSetlists: Array.isArray(payload.savedSetlists) ? stripEnergy(payload.savedSetlists) : null,
+                savedSetlists: Array.isArray(payload.savedSetlists)
+                    ? payload.savedSetlists.map((s) => migrator.migrateDocument("setlists", s))
+                    : null,
             };
         }
         if (payload && payload.general && payload.show && payload.props) {
@@ -2263,7 +2268,7 @@ export function createAppStore(repo) {
             const raw = localStorage.getItem(localKey);
             if (raw) {
                 pushSyncLog("Migrating saved setlists from local storage");
-                const localSets = stripEnergy(tryParseJson(raw, []) || []);
+                const localSets = tryParseJson(raw, []) || [];
                 if (localSets.length > 0) {
                     // Normalize via rs-migrate before uploading
                     const remoteIds = new Set(savedSetlists.map((s) => s.id));
@@ -2568,6 +2573,8 @@ export function createAppStore(repo) {
         get appConfig() { return appConfig; },
         get bandMembers() { return bandMembers; },
         get generatedSetlist() { return generatedSetlist; },
+        get displayedSetlist() { return displayedSetlist; },
+        get displayedSavedSetlists() { return displayedSavedSetlists; },
         get isGenerating() { return isGenerating; },
         get setlistLocked() { return setlistLocked; },
         get setlistSaved() { return setlistSaved; },

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -421,21 +421,32 @@ export function createAppStore(repo) {
         localStorage.setItem(storageKey("ui-options"), JSON.stringify(generationOptions));
     }
 
+    /** Reset the active generated setlist and clear any loaded-saved reference. */
     function clearGeneratedSetlist() {
         generatedSetlist = null;
         loadedSavedId = "";
     }
 
-    // Catalog lookup table. Recomputes whenever `songs` changes, which is
-    // what makes the displayed setlists below auto-refresh on RS pulls and
-    // local edits — no manual sync paths required.
+    /**
+     * Catalog lookup table keyed by song id.
+     * Recomputes whenever `songs` changes, which is what makes the displayed
+     * setlists below auto-refresh on RS pulls and local edits — no manual
+     * sync paths required.
+     */
     let songsById = $derived(new Map((songs || []).map((s) => [s.id, s])));
 
-    // Take a lean setlist + the live catalog and produce the fully-fat
-    // form that views render: catalog fields overlaid, scores and summary
-    // recomputed by scoreFixedOrder. Songs whose ids no longer exist in
-    // the catalog are filtered out — saved setlists shrink gracefully when
-    // their referenced songs have been deleted.
+    /**
+     * Take a lean setlist + the live catalog and produce the fully-fat form
+     * that views render: catalog fields overlaid, scores and summary
+     * recomputed by scoreFixedOrder.
+     *
+     * Songs whose ids no longer exist in the catalog are filtered out —
+     * saved setlists shrink gracefully when their referenced songs have
+     * been deleted.
+     *
+     * @param {object|null} setlist - Lean setlist object with `songs` array of `{songId, performance}`.
+     * @returns {object|null} Hydrated setlist with full song data and recomputed summary, or null.
+     */
     function hydrateSetlist(setlist) {
         if (!setlist || !Array.isArray(setlist.songs)) return setlist || null;
         const fat = [];
@@ -461,11 +472,17 @@ export function createAppStore(repo) {
     let displayedSetlist = $derived(hydrateSetlist(generatedSetlist));
     let displayedSavedSetlists = $derived((savedSetlists || []).map(hydrateSetlist));
 
-    // Strip a generator/scoring result down to the lean persisted shape:
-    // each setlist entry keeps only what isn't derivable from the catalog
-    // (the song reference and the rolled performance choice). Generation
-    // metadata moves to top-level fields; the scored summary is recomputed
-    // at display time inside hydrateSetlist().
+    /**
+     * Strip a generator/scoring result down to the lean persisted shape.
+     *
+     * Each setlist entry keeps only what isn't derivable from the catalog
+     * (the song reference and the rolled performance choice). Generation
+     * metadata moves to top-level fields; the scored summary is recomputed
+     * at display time inside hydrateSetlist().
+     *
+     * @param {object|null} result - Raw generator result with `songs`, `seed`, and `summary`.
+     * @returns {object|null} Lean setlist `{seed, minimumsRelaxed, …, songs: [{songId, performance}]}`.
+     */
     function leanFromGeneratorResult(result) {
         if (!result) return null;
         const summary = result.summary || {};
@@ -481,9 +498,14 @@ export function createAppStore(repo) {
         };
     }
 
-    // Detect a pre-refactor (fat) saved/persisted setlist where each song
-    // entry carries embedded catalog fields, and convert it to the lean
-    // shape. Idempotent — already-lean entries pass through unchanged.
+    /**
+     * Detect a pre-refactor (fat) saved/persisted setlist where each song
+     * entry carries embedded catalog fields, and convert it to the lean shape.
+     * Idempotent — already-lean entries pass through unchanged.
+     *
+     * @param {object|null} setlist - Raw setlist, possibly in the old fat format.
+     * @returns {object|null} Setlist with lean `{songId, performance}` song entries.
+     */
     function normalizeLeanSetlist(setlist) {
         if (!setlist || !Array.isArray(setlist.songs)) return setlist;
         const songs = setlist.songs.map((s) => ({
@@ -1368,6 +1390,17 @@ export function createAppStore(repo) {
         if (!generatedSetlist) return;
         const currentSaved = savedSetlists || [];
 
+        // Only prune stale song references when the catalog is fully settled.
+        // During initial sync or while bodies are still arriving, songsById is
+        // incomplete; filtering against it would silently drop songs that exist
+        // remotely but haven't loaded yet. When unsettled, we save the songs
+        // verbatim — any truly-deleted entries will be pruned on the next save
+        // once the catalog is stable.
+        const catalogSettled = syncState !== "syncing" && pendingBodies === 0;
+        const persistedSongs = catalogSettled
+            ? clone(generatedSetlist.songs.filter((e) => songsById.has(e.songId)))
+            : clone(generatedSetlist.songs);
+
         // If this setlist was loaded from a saved entry, update that entry in
         // place instead of creating a duplicate with a new id and name.
         if (loadedSavedId) {
@@ -1379,7 +1412,7 @@ export function createAppStore(repo) {
                     minimumsRelaxed: !!generatedSetlist.minimumsRelaxed,
                     openerFilterRelaxed: !!generatedSetlist.openerFilterRelaxed,
                     closerFilterRelaxed: !!generatedSetlist.closerFilterRelaxed,
-                    songs: clone(generatedSetlist.songs.filter((e) => songsById.has(e.songId))),
+                    songs: persistedSongs,
                 });
                 setlistSaved = true;
                 return;
@@ -1411,7 +1444,7 @@ export function createAppStore(repo) {
             minimumsRelaxed: !!generatedSetlist.minimumsRelaxed,
             openerFilterRelaxed: !!generatedSetlist.openerFilterRelaxed,
             closerFilterRelaxed: !!generatedSetlist.closerFilterRelaxed,
-            songs: clone(generatedSetlist.songs.filter((e) => songsById.has(e.songId))),
+            songs: persistedSongs,
         };
         try {
             await withSync("Saving setlist", () => repo.putSetlist(entry));

--- a/src/lib/stores/app.test.js
+++ b/src/lib/stores/app.test.js
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { DEFAULT_APP_CONFIG } from "../defaults.js";
-import { createAppStore, normalizeAuthToken, syncSavedSongIntoSetlist } from "./app.svelte.js";
+import { migrator } from "../migrations.js";
+import { createAppStore, normalizeAuthToken } from "./app.svelte.js";
 
 afterEach(() => {
     vi.useRealTimers();
@@ -52,90 +53,85 @@ describe("retrySync", () => {
     });
 });
 
-describe("syncSavedSongIntoSetlist", () => {
-    it("updates matching song metadata in the current setlist immediately", () => {
-        const setlist = {
+describe("setlist v2 migration", () => {
+    it("collapses a fat saved setlist to lean references and hoists the relaxed flags", () => {
+        const fat = {
+            id: "set-1",
+            name: "Old School",
+            savedAt: "2026-01-01T00:00:00.000Z",
             seed: 42,
-            summary: { score: 999 },
+            songNames: ["A", "B"],
+            songCount: 2,
+            summary: {
+                score: 17,
+                anxiety: { scaled: 4 },
+                minimumsRelaxed: true,
+                openerFilterRelaxed: false,
+                closerFilterRelaxed: true,
+            },
             songs: [
                 {
                     id: "song-1",
-                    name: "Old Name",
+                    name: "A",
                     cover: false,
                     instrumental: false,
                     key: "C",
-                    notes: "old notes",
-                    performance: {
-                        nick: { instrument: "guitar", tuning: "Standard", capo: 0, picking: [] },
-                    },
+                    notes: "n1",
+                    performance: { nick: { instrument: "guitar" } },
+                    position: 1,
+                    incrementalScore: 0,
+                    cumulativeScore: 0,
+                    transitionNotes: ["whatever"],
                 },
                 {
                     id: "song-2",
-                    name: "Keep Me",
-                    cover: false,
+                    name: "B",
+                    cover: true,
                     instrumental: false,
                     key: "G",
                     notes: "",
-                    performance: {
-                        nick: { instrument: "guitar", tuning: "DADGAD", capo: 0, picking: [] },
-                    },
+                    performance: { nick: { instrument: "bass" } },
+                    position: 2,
                 },
             ],
         };
 
-        const savedSong = {
-            id: "song-1",
-            name: "New Name",
-            cover: true,
-            instrumental: true,
-            key: "D",
-            notes: "new notes",
-        };
+        const migrated = migrator.migrateDocument("setlists", fat);
 
-        const result = syncSavedSongIntoSetlist(setlist, savedSong, DEFAULT_APP_CONFIG, false);
-
-        expect(result).not.toBe(setlist);
-        expect(result.songs[0]).toMatchObject({
-            id: "song-1",
-            name: "New Name",
-            cover: true,
-            instrumental: true,
-            key: "D",
-            notes: "new notes",
-        });
-        expect(result.songs[1]).toMatchObject({
-            id: "song-2",
-            name: "Keep Me",
-            key: "G",
-        });
-        expect(result.summary).toBeDefined();
+        expect(migrated.songs).toEqual([
+            { songId: "song-1", performance: { nick: { instrument: "guitar" } } },
+            { songId: "song-2", performance: { nick: { instrument: "bass" } } },
+        ]);
+        expect(migrated.minimumsRelaxed).toBe(true);
+        expect(migrated.openerFilterRelaxed).toBe(false);
+        expect(migrated.closerFilterRelaxed).toBe(true);
+        expect(migrated.summary).toBeUndefined();
+        expect(migrated.songNames).toBeUndefined();
+        expect(migrated.songCount).toBeUndefined();
+        // Identity fields are preserved.
+        expect(migrated.id).toBe("set-1");
+        expect(migrated.name).toBe("Old School");
+        expect(migrated.seed).toBe(42);
     });
 
-    it("returns the original setlist when the saved song is not present", () => {
-        const setlist = {
-            summary: { score: 1 },
-            songs: [
-                {
-                    id: "song-1",
-                    name: "Only Song",
-                    cover: false,
-                    instrumental: false,
-                    key: "C",
-                    notes: "",
-                    performance: {
-                        nick: { instrument: "guitar", tuning: "Standard", capo: 0, picking: [] },
-                    },
-                },
-            ],
+    it("is idempotent on already-lean entries", () => {
+        const lean = {
+            id: "set-2",
+            name: "Already Lean",
+            savedAt: "2026-01-02T00:00:00.000Z",
+            schemaVersion: 2,
+            seed: 7,
+            minimumsRelaxed: false,
+            openerFilterRelaxed: false,
+            closerFilterRelaxed: false,
+            songs: [{ songId: "song-9", performance: {} }],
         };
 
-        const result = syncSavedSongIntoSetlist(
-            setlist,
-            { id: "song-2", name: "Different Song", notes: "no-op" },
-            DEFAULT_APP_CONFIG,
-            false,
-        );
+        const once = migrator.migrateDocument("setlists", { ...lean, songs: [...lean.songs] });
+        const twice = migrator.migrateDocument("setlists", once);
 
-        expect(result).toBe(setlist);
+        expect(twice.songs).toEqual([{ songId: "song-9", performance: {} }]);
+        expect(twice.summary).toBeUndefined();
+        expect(twice.minimumsRelaxed).toBe(false);
     });
 });

--- a/tests/e2e/roll-survives-sync.spec.ts
+++ b/tests/e2e/roll-survives-sync.spec.ts
@@ -40,8 +40,8 @@ const B_SONGS = [
 function names(state: { songs: { name: string }[] } | null): string[] {
     return (state?.songs ?? []).map((s) => s.name).sort();
 }
-function setlistIds(state: { generatedSetlist: { songs?: { id: string }[] } | null } | null): string[] {
-    return (state?.generatedSetlist?.songs ?? []).map((s) => s.id);
+function setlistIds(state: { generatedSetlist: { songs?: { songId: string }[] } | null } | null): string[] {
+    return (state?.generatedSetlist?.songs ?? []).map((s) => s.songId);
 }
 
 test.describe("Real backend — roll survives sync, swap retains roll-readiness", () => {

--- a/tests/e2e/saved.spec.ts
+++ b/tests/e2e/saved.spec.ts
@@ -459,7 +459,7 @@ test.describe("Saved screen — tall setlist scrolling", () => {
             songId: `tall-${i}`,
             performance: {},
         }));
-        return setlistFixture({ id: "tall", name: "The Marathon", songs, songCount });
+        return setlistFixture({ id: "tall", name: "The Marathon", songs });
     }
 
     function tallCatalogSongs(count = 40): Record<string, unknown> {

--- a/tests/e2e/saved.spec.ts
+++ b/tests/e2e/saved.spec.ts
@@ -1,5 +1,5 @@
 import type { SeedSetlist } from "../fixtures/test-fixtures";
-import { buildSeed, expect, test } from "../fixtures/test-fixtures";
+import { buildSeed, expect, makeSong, test } from "../fixtures/test-fixtures";
 import { AppShell } from "../pages/AppShell";
 import { RollPage } from "../pages/RollPage";
 import { SavedPage } from "../pages/SavedPage";
@@ -13,16 +13,21 @@ function setlistFixture(overrides: Partial<SeedSetlist> = {}): SeedSetlist {
         id: "set-1",
         name: "Friday Night Set",
         savedAt: "2024-09-15T20:00:00.000Z",
-        songCount: 2,
         songs: [
-            { id: "a", name: "Africa", key: "B" },
-            { id: "b", name: "Bohemian Rhapsody", key: "Bb", cover: true },
+            { songId: "a", performance: {} },
+            { songId: "b", performance: {} },
         ],
-        summary: { anxiety: { scaled: 4, label: "Calm" } },
         schemaVersion: 2,
         createdAt: "2024-09-15T20:00:00.000Z",
         updatedAt: "2024-09-15T20:00:00.000Z",
         ...overrides,
+    };
+}
+
+function fixtureCatalogSongs(): Record<string, unknown> {
+    return {
+        a: makeSong({ id: "a", name: "Africa", key: "B" }),
+        b: makeSong({ id: "b", name: "Bohemian Rhapsody", key: "Bb", cover: true }),
     };
 }
 
@@ -41,6 +46,7 @@ test.describe("Saved screen — list", () => {
     test("seeded setlists render as cards with name and song count", async ({ page, app }) => {
         await app.seed(
             buildSeed({
+                songs: fixtureCatalogSongs(),
                 setlists: {
                     "set-1": setlistFixture({ id: "set-1", name: "Friday" }),
                     "set-2": setlistFixture({ id: "set-2", name: "Saturday", savedAt: "2024-09-16T20:00:00.000Z" }),
@@ -82,6 +88,7 @@ test.describe("Saved screen — view modal", () => {
     test("clicking a card opens the print/view modal", async ({ page, app }) => {
         await app.seed(
             buildSeed({
+                songs: fixtureCatalogSongs(),
                 setlists: { s: setlistFixture({ id: "s", name: "Acoustic" }) },
             }),
         );
@@ -112,6 +119,7 @@ test.describe("Saved screen — view modal", () => {
     test("Load to Roll button loads the setlist into the Roll screen", async ({ page, app }) => {
         await app.seed(
             buildSeed({
+                songs: fixtureCatalogSongs(),
                 setlists: { s: setlistFixture({ id: "s", name: "Loadable" }) },
             }),
         );
@@ -230,6 +238,7 @@ test.describe("Saved screen — dark mode legibility", () => {
         await page.emulateMedia({ colorScheme: "dark" });
         await app.seed(
             buildSeed({
+                songs: fixtureCatalogSongs(),
                 setlists: { s: setlistFixture({ id: "s", name: "After Dark" }) },
             }),
         );
@@ -288,6 +297,7 @@ test.describe("Saved screen — dark mode legibility", () => {
         await page.emulateMedia({ colorScheme: "light" });
         await app.seed(
             buildSeed({
+                songs: fixtureCatalogSongs(),
                 setlists: { s: setlistFixture({ id: "s", name: "Daylight" }) },
             }),
         );
@@ -446,20 +456,23 @@ test.describe("Saved screen — tall setlist scrolling", () => {
      */
     function tallSetlistFixture(songCount = 40): SeedSetlist {
         const songs = Array.from({ length: songCount }, (_, i) => ({
-            id: `tall-${i}`,
-            name: `Marathon Track ${i + 1}`,
-            key: "C",
+            songId: `tall-${i}`,
+            performance: {},
         }));
-        return setlistFixture({
-            id: "tall",
-            name: "The Marathon",
-            songs,
-            songCount,
-        });
+        return setlistFixture({ id: "tall", name: "The Marathon", songs, songCount });
+    }
+
+    function tallCatalogSongs(count = 40): Record<string, unknown> {
+        return Object.fromEntries(
+            Array.from({ length: count }, (_, i) => [
+                `tall-${i}`,
+                makeSong({ id: `tall-${i}`, name: `Marathon Track ${i + 1}`, key: "C" }),
+            ]),
+        );
     }
 
     test("the song list scrolls when the setlist is taller than the viewport", async ({ page, app }) => {
-        await app.seed(buildSeed({ setlists: { tall: tallSetlistFixture(40) } }));
+        await app.seed(buildSeed({ songs: tallCatalogSongs(40), setlists: { tall: tallSetlistFixture(40) } }));
         await page.setViewportSize({ width: 390, height: 600 });
         await app.goto();
         await app.waitForReady();
@@ -487,7 +500,7 @@ test.describe("Saved screen — tall setlist scrolling", () => {
     });
 
     test("action buttons stay visible while the song list is scrolled", async ({ page, app }) => {
-        await app.seed(buildSeed({ setlists: { tall: tallSetlistFixture(40) } }));
+        await app.seed(buildSeed({ songs: tallCatalogSongs(40), setlists: { tall: tallSetlistFixture(40) } }));
         await page.setViewportSize({ width: 390, height: 600 });
         await app.goto();
         await app.waitForReady();
@@ -518,7 +531,7 @@ test.describe("Saved screen — tall setlist scrolling", () => {
     });
 
     test("the last song in a tall setlist can be scrolled into view", async ({ page, app }) => {
-        await app.seed(buildSeed({ setlists: { tall: tallSetlistFixture(40) } }));
+        await app.seed(buildSeed({ songs: tallCatalogSongs(40), setlists: { tall: tallSetlistFixture(40) } }));
         await page.setViewportSize({ width: 390, height: 600 });
         await app.goto();
         await app.waitForReady();
@@ -554,12 +567,9 @@ test.describe("Saved screen — modal contents", () => {
     test("anxiety summary appears in the modal when present", async ({ page, app }) => {
         await app.seed(
             buildSeed({
+                songs: fixtureCatalogSongs(),
                 setlists: {
-                    s: setlistFixture({
-                        id: "s",
-                        name: "With Anxiety",
-                        summary: { anxiety: { scaled: 6, label: "Sweaty" } },
-                    }),
+                    s: setlistFixture({ id: "s", name: "With Anxiety" }),
                 },
             }),
         );
@@ -568,17 +578,18 @@ test.describe("Saved screen — modal contents", () => {
 
         const saved = new SavedPage(page);
         await saved.openCard("With Anxiety");
-        await expect(saved.modal.locator(".print-anxiety")).toContainText("6/10");
+        await expect(saved.modal.locator(".print-anxiety")).toBeVisible();
     });
 
     test("song notes are rendered in the print modal", async ({ page, app }) => {
         await app.seed(
             buildSeed({
+                songs: { a: makeSong({ id: "a", name: "Africa", notes: "Cue intro on synth" }) },
                 setlists: {
                     s: setlistFixture({
                         id: "s",
                         name: "With Notes",
-                        songs: [{ id: "a", name: "Africa", notes: "Cue intro on synth" }],
+                        songs: [{ songId: "a", performance: {} }],
                     }),
                 },
             }),


### PR DESCRIPTION
## Summary

Setlist entries now reference the catalog by id (`{ songId, performance }`) instead of cloning catalog fields. Display goes through `displayedSetlist` / `displayedSavedSetlists` derived values, which run `scoreFixedOrder` once against the live catalog — RS pulls and local edits flow through Svelte reactivity, no manual sync.

Subsequent commits harden the pruning and mutation paths that the new lean shape introduced:

**Lean shape + reactive overlay**
- Removes `syncSavedSongIntoSetlist`, `stripEnergy`, and the `saveSong` mirror block. Mutation helpers collapse to array splices; `scoreFixedOrder` lives in the derived only.
- Saved setlists migrate from the fat shape via rs-migrate v2; localStorage `current-set` normalizes on read.

**Catalog-settled guard on save and load**
- Both `saveCurrentSetlist` and `loadSavedSetlist` now gate deleted-song pruning on a `catalogSettled` derived (`syncState === 'idle' | 'synced'` and `pendingBodies === 0`). While the catalog is still streaming in, songs are persisted verbatim — a partial `songsById` map can't silently drop entries that exist remotely but haven't arrived yet. The old guard (`syncState !== 'syncing'`) also incorrectly passed the error state.

**Settled-catalog reconciliation effect**
- A `` fires whenever `catalogSettled`, `generatedSetlist`, or `songsById` changes while settled. It prunes any stale lean refs that were deferred during initial sync, persists, and toasts. This also handles mid-session catalog deletions from another device.

**Index-based mutation fix**
- `removeSetlistSong` and `reorderSetlistSong` receive indices from `displayedSetlist.songs`, which `hydrateSetlist()` may have shortened by filtering stale entries. Both now resolve the target by `songId` via `findIndex` on `generatedSetlist.songs`, so hidden stale entries can't shift the raw index and misdirect the mutation.

**Zero-songs edge cases**
- `loadSavedSetlist`: when all songs are pruned (`catalogSettled && songs.length === 0`), clears instead of setting an empty locked setlist that would overwrite the RS document with `songs: []` on the next save.
- `normalizeLeanSetlist`: returns `null` when `songs` is not an array instead of passing the raw blob through to `generatedSetlist`, where array methods would throw.

## Why

Original report: RS-driven song changes updated the Songs view but not the Roll screen. Initial fix was an imperative mirror (`syncCatalogIntoSetlists`); on review that was patching the symptom — the live and saved setlists embedded deep clones of catalog fields, so reactivity couldn't propagate. This refactor makes the catalog the single source of truth and lets Svelte's reactive overlay do the work.

The pruning fixes came from review: the lean shape introduced new save/load paths that all read `songsById` — which is only as complete as the current sync state — creating a window where valid songs could be permanently dropped.

## Notable

- Net code change on the refactor commit: +221 / -193.
- No rs-migrate version bump needed for the live setlist (read-side normalizer covers it); v2 covers saved setlists in RS storage.
- Saved setlists are no longer point-in-time snapshots — renaming a catalog song updates its name everywhere, including the saved viewer.

## Test plan
- [x] `npm test` — 291/291 pass (existing) + new migration tests.
- [x] `npm run lint` — no new warnings.
- [ ] Manual: roll a setlist, edit a song's name in Songs view → Roll screen and Saved viewer reflect immediately.
- [ ] Manual: from a second device, edit a song over RS → live and saved screens update without action.
- [ ] Manual: save a setlist, delete one of its songs from catalog → song disappears from saved view; load shows dropped-count toast.
- [ ] Manual: refresh the app with an old (fat) `current-set` localStorage entry → normalizer upgrades it on read; setlist renders.
- [ ] Manual: load a saved setlist during initial sync (before catalog settles) → all songs appear; no false 'no longer in catalog' toast.