### PR TITLE
fix(e2e): shrink viewport in scroll-into-view test to eliminate geometry flakiness

### DIFF
--- a/tests/e2e/saved.spec.ts
+++ b/tests/e2e/saved.spec.ts
@@ -532,7 +532,9 @@ test.describe("Saved screen — tall setlist scrolling", () => {
 
     test("the last song in a tall setlist can be scrolled into view", async ({ page, app }) => {
         await app.seed(buildSeed({ songs: tallCatalogSongs(40), setlists: { tall: tallSetlistFixture(40) } }));
-        await page.setViewportSize({ width: 390, height: 600 });
+        // Use a shorter viewport than the sibling scroll test so 40 songs
+        // comfortably exceed the visible area regardless of CI font rendering.
+        await page.setViewportSize({ width: 390, height: 400 });
         await app.goto();
         await app.waitForReady();
         await new AppShell(page).gotoSaved();


### PR DESCRIPTION
## Problem

The `the last song in a tall setlist can be scrolled into view` test failed consistently (0/3 retries) on the release CI runner while passing on PR runs.

Both jobs use identical `ubuntu-latest` + headless Chromium configurations. The issue is that `.print-song` row heights are `rem`-relative (`padding: 0.45rem`, `font-size: 0.9rem`), so their rendered pixel height varies slightly between runner instances. At a 600px viewport the 40-song list sits close to the boundary — the last song can land just inside or just outside the viewport at `scrollTop=0` depending on the exact font metrics of that runner.

The sibling test checks the same scenario via `scrollHeight > clientHeight` — a geometry-independent metric — and was never affected.

## Fix

Reduce the viewport for this one test from 600px to 400px. With 40 songs x ~30px/row = ~1200px of list content, the usable modal height at 400px is roughly 340px, giving a ~3.5x overflow margin. The last song's top edge sits well beyond the visible area at scrollTop=0 regardless of how CI renders the font.

## What this is not

This failure was not caused by the randomness changes in #97. The test seeds a pre-built saved setlist directly; the generator never runs.