### PR TITLE
Prevent iOS focus-zoom on song editor and form inputs

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -117,6 +117,10 @@ body,
 #app {
     margin: 0;
     min-height: 100%;
+    /* Prevent iOS Safari from auto-inflating text (which can interact with the
+       16px input-zoom threshold below). Keep text sizing deterministic. */
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
 }
 
 body {

--- a/src/lib/components/band/BandScreen.svelte
+++ b/src/lib/components/band/BandScreen.svelte
@@ -642,7 +642,8 @@
         border-radius: var(--radius-md, 16px);
         border: 1px solid var(--line, rgba(27, 49, 80, 0.12));
         background: var(--surface);
-        font-size: 1rem;
+        /* iOS zooms inputs <16px on focus — keep at 16px (not rem) to prevent zoom. See app.css. */
+        font-size: 16px;
         box-sizing: border-box;
     }
 

--- a/src/lib/components/shared/NumberStepper.svelte
+++ b/src/lib/components/shared/NumberStepper.svelte
@@ -57,7 +57,8 @@
         border-right: 1px solid var(--line);
         border-radius: 0;
         padding: 0.5rem 0.2rem;
-        font-size: 1rem;
+        /* iOS zooms inputs <16px on focus — keep at 16px (not rem) to prevent zoom. See app.css. */
+        font-size: 16px;
         font-weight: 800;
         background: transparent;
         min-height: 2.8rem;

--- a/src/lib/components/songs/SongEditor.svelte
+++ b/src/lib/components/songs/SongEditor.svelte
@@ -593,7 +593,8 @@
         border: 1px solid var(--line);
         background: var(--surface);
         font: inherit;
-        font-size: 1rem;
+        /* iOS zooms inputs <16px on focus — keep at 16px (not rem) to prevent zoom. See app.css. */
+        font-size: 16px;
         box-sizing: border-box;
         width: 100%;
     }
@@ -737,7 +738,8 @@
     .field-input.small {
         min-height: 2.4rem;
         padding: 0.4rem 0.7rem;
-        font-size: 1rem;
+        /* iOS zooms inputs <16px on focus — keep at 16px (not rem) to prevent zoom. See app.css. */
+        font-size: 16px;
     }
 
     .add-sm-btn {

--- a/src/lib/components/songs/SongsScreen.svelte
+++ b/src/lib/components/songs/SongsScreen.svelte
@@ -191,7 +191,8 @@
         border-radius: var(--radius-md, 12px);
         border: 1px solid var(--line);
         background: var(--surface);
-        font-size: 1rem;
+        /* iOS zooms inputs <16px on focus — keep at 16px (not rem) to prevent zoom. See app.css. */
+        font-size: 16px;
         box-sizing: border-box;
     }
 


### PR DESCRIPTION
## Summary
- iOS Safari auto-zooms when a focused input's computed font-size is below 16px and never cleanly zooms back. The app already has a global `input/select/textarea { font-size: 16px }` rule plus a documented policy (app.css) to use the **literal** `16px` on every control — but several controls still used `font-size: 1rem`. At a default root that equals 16px, yet rem can round/drift under the threshold, producing intermittent zoom when editing songs.
- Migrated the holdouts to `16px`: `.field-input` + `.field-input.small` (SongEditor), `.step-input` (NumberStepper/Capo), `.search-input` (SongsScreen), `.text-input` (BandScreen).
- Added `-webkit-text-size-adjust: 100%` globally so iOS can't auto-inflate text and interact with the threshold.
- Left untouched on purpose: `.band-name-input` (~18px, already safe) and `.file-input` (`type="file"` doesn't focus-zoom). Viewport unchanged so deliberate pinch-zoom stays available (accessibility).

## Test plan
- [ ] On iOS, open the song editor and focus name / key select / notes / member / instrument / tuning / technique fields — no zoom
- [ ] Focus the Capo stepper — no zoom
- [ ] Focus the song-list search — no zoom
- [ ] Focus band name / member text fields — no zoom
- [ ] Confirm deliberate pinch-zoom still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated input field font sizing to ensure consistent visual rendering across search inputs, text fields, and numeric steppers.
  * Applied text sizing adjustments to the application root for improved rendering consistency across devices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/setlist-roller/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->