### PR TITLE
ci: smoke tests on PRs, full e2e only on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,20 +60,22 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
+          key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}-chromium
 
       - name: Install Playwright browsers
         if: steps.pw-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium webkit
+        run: npx playwright install --with-deps chromium
 
       - name: Install Playwright system deps
         # Cached browsers don't include OS-level deps (libnss3, etc.), so we
         # still need the deps step on a cache hit.
         if: steps.pw-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium webkit
+        run: npx playwright install-deps chromium
 
-      - name: Run E2E tests (chromium + mobile webkit)
-        run: npm run test:e2e:all
+      - name: Run smoke tests (chromium only)
+        # PRs run the @smoke subset (~20 tests) on Chromium only.
+        # The full suite (both browsers) runs as a release pre-flight in release.yml.
+        run: npm run test:e2e:smoke
 
       - name: Upload Playwright report on failure
         if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,30 +16,40 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  validate:
+    name: Lint & unit tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ github.token }}
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test
 
+  e2e:
+    name: E2E shard ${{ matrix.shard }}
+    needs: validate
+    runs-on: ubuntu-latest
+    strategy:
+      # Don't cancel remaining shards when one fails — collect all
+      # failures before blocking the deploy.
+      fail-fast: false
+      matrix:
+        shard: ["1/3", "2/3", "3/3"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
       - run: npm ci
 
-      # Pre-release validation gate — block the deploy if anything is broken.
-      - name: Lint
-        run: npm run lint
-
-      - name: Unit tests
-        run: npm test
-
       - name: Start armadietto
-        # E2E runs against a real remoteStorage server.
+        # Each shard runner gets its own fresh armadietto container, so
+        # there's no shared state between shards.
         run: docker compose up -d
 
       - name: Resolve Playwright version
@@ -62,23 +72,68 @@ jobs:
         if: steps.pw-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps chromium webkit
 
-      - name: E2E tests (chromium + mobile webkit)
-        run: npm run test:e2e:all
+      - name: E2E tests (chromium + mobile webkit, shard ${{ matrix.shard }})
+        run: npx playwright test --shard=${{ matrix.shard }}
 
       - name: Upload Playwright report on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          # strategy.job-index is 0/1/2; avoids slashes from matrix.shard
+          name: playwright-report-shard-${{ strategy.job-index }}
           path: playwright-report/
           retention-days: 14
 
+      - name: Upload test-results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-shard-${{ strategy.job-index }}
+          path: test-results/
+          retention-days: 14
+
+      - name: Capture armadietto logs on failure
+        if: failure()
+        run: docker compose logs armadietto > armadietto.log 2>&1 || true
+
+      - name: Upload armadietto logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: armadietto-logs-shard-${{ strategy.job-index }}
+          path: armadietto.log
+          retention-days: 14
+
+      - name: Stop armadietto
+        if: always()
+        run: docker compose down
+
+  deploy:
+    name: Version, build & deploy
+    # Only runs when both validate and all e2e shards pass.
+    needs: [validate, e2e]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
       - name: Bump version
         id: version
+        env:
+          BUMP: ${{ inputs.bump }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          npm version ${{ inputs.bump }} --no-git-tag-version
+          npm version "$BUMP" --no-git-tag-version
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
@@ -103,19 +158,25 @@ jobs:
           echo -e "Host 5apps.com\n  IdentityFile ~/.ssh/5apps_key" >> ~/.ssh/config
 
       - name: Deploy to 5apps
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           git remote add 5apps git@5apps.com:silverbucket_setlist-roller.git 2>/dev/null || git remote set-url 5apps git@5apps.com:silverbucket_setlist-roller.git
-          git switch -c deploy-${{ steps.version.outputs.version }}
+          git switch -c "deploy-${VERSION}"
           git add package.json dist -f
-          git commit -m "deploy v${{ steps.version.outputs.version }}"
+          git commit -m "deploy v${VERSION}"
           git push 5apps HEAD:refs/heads/master --force
 
       - name: Tag and push version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
         run: |
-          git tag "v${{ steps.version.outputs.version }}" "${{ steps.source.outputs.sha }}"
-          git push origin "${{ steps.source.outputs.sha }}":master --tags
+          git tag "v${VERSION}" "${SOURCE_SHA}"
+          git push origin "${SOURCE_SHA}":master --tags
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "v${{ steps.version.outputs.version }}" --generate-notes
+          VERSION: ${{ steps.version.outputs.version }}
+        run: gh release create "v${VERSION}" --generate-notes

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "test": "vitest run",
         "test:watch": "vitest",
         "test:e2e": "playwright test --project=chromium",
+        "test:e2e:smoke": "playwright test --project=chromium --grep @smoke",
         "test:e2e:mobile": "playwright test --project=mobile",
         "test:e2e:all": "playwright test",
         "test:e2e:ui": "playwright test --ui",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,8 +26,9 @@ export default defineConfig({
     workers: process.env.CI ? 1 : undefined,
     reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : [["list"], ["html", { open: "never" }]],
     // Real-backend tests do real I/O — give them more headroom than the
-    // 30s the fake-repo suite ran with.
-    timeout: 60_000,
+    // 30s the fake-repo suite ran with. 45s is still generous for any
+    // single test but fails faster than 60s when something hangs.
+    timeout: 45_000,
     expect: {
         timeout: 10_000,
     },

--- a/tests/e2e/band.spec.ts
+++ b/tests/e2e/band.spec.ts
@@ -6,7 +6,7 @@ import { BandPage } from "../pages/BandPage";
  * Band screen — band name, members, advanced config, data import/export,
  * and account management.
  */
-test.describe("Band screen — band name", () => {
+test.describe("Band screen — band name", { tag: ["@smoke"] }, () => {
     test("editing the band name updates the top bar title", async ({ page, app }) => {
         await app.seed(buildSeed());
         await app.goto();
@@ -43,7 +43,7 @@ test.describe("Band screen — members", () => {
         await expect(band.screen.locator(".empty-state")).toContainText("No members yet");
     });
 
-    test("can add a member; appears in the list", async ({ page, app }) => {
+    test("can add a member; appears in the list", { tag: ["@smoke"] }, async ({ page, app }) => {
         await app.seed(buildSeed());
         await app.goto();
         await new AppShell(page).gotoBand();

--- a/tests/e2e/connection.spec.ts
+++ b/tests/e2e/connection.spec.ts
@@ -16,7 +16,7 @@ test.describe("Connection screen", () => {
         await expect(connect.connectButton).toBeVisible();
     });
 
-    test("connects with an address and shows app shell", async ({ page, app }) => {
+    test("connects with an address and shows app shell", { tag: ["@smoke"] }, async ({ page, app }) => {
         const user = await app.provisionUser("alice");
         await app.goto();
         const connect = new ConnectPage(page);
@@ -90,7 +90,7 @@ test.describe("Connection screen", () => {
     });
 });
 
-test.describe("Auto-connect with seed", () => {
+test.describe("Auto-connect with seed", { tag: ["@smoke"] }, () => {
     test("seeded user boots straight into app shell", async ({ page, app }) => {
         await app.seed(buildSeed());
         await app.goto();

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -5,7 +5,7 @@ import { AppShell } from "../pages/AppShell";
  * App-level navigation — bottom tab bar, hash routing, persistence across
  * reloads. Five tabs: roll, saved, songs, band, help.
  */
-test.describe("Tab navigation", () => {
+test.describe("Tab navigation", { tag: ["@smoke"] }, () => {
     test("each bottom-nav tab navigates to its view", async ({ page, app }) => {
         await app.seed(buildSeed());
         await app.goto();

--- a/tests/e2e/roll.spec.ts
+++ b/tests/e2e/roll.spec.ts
@@ -33,7 +33,7 @@ function seedWithCatalog(extraSongs: SeedSong[] = []) {
 }
 
 test.describe("Roll screen — onboarding & sync state", () => {
-    test("empty catalog shows onboarding card with link to Songs tab", async ({ page, app }) => {
+    test("empty catalog shows onboarding card with link to Songs tab", { tag: ["@smoke"] }, async ({ page, app }) => {
         await app.seed(buildSeed());
         await app.goto();
         const shell = new AppShell(page);
@@ -44,7 +44,7 @@ test.describe("Roll screen — onboarding & sync state", () => {
         await expect(roll.onboardingCard).toContainText("Almost showtime");
     });
 
-    test("catalog with songs shows the idle nudge before rolling", async ({ page, app }) => {
+    test("catalog with songs shows the idle nudge before rolling", { tag: ["@smoke"] }, async ({ page, app }) => {
         await app.seed(seedWithCatalog());
         await app.goto();
         const shell = new AppShell(page);
@@ -67,7 +67,7 @@ test.describe("Roll screen — onboarding & sync state", () => {
 });
 
 test.describe("Roll screen — generation flow", () => {
-    test("clicking Roll generates a setlist", async ({ page, app }) => {
+    test("clicking Roll generates a setlist", { tag: ["@smoke"] }, async ({ page, app }) => {
         await app.seed(seedWithCatalog());
         await app.goto();
         await app.waitForReady();
@@ -164,7 +164,7 @@ test.describe("Roll screen — settings drawer", () => {
 });
 
 test.describe("Roll screen — lock / save / re-roll", () => {
-    test("can lock a generated setlist; locked badge appears", async ({ page, app }) => {
+    test("can lock a generated setlist; locked badge appears", { tag: ["@smoke"] }, async ({ page, app }) => {
         await app.seed(seedWithCatalog());
         await app.goto();
         await app.waitForReady();
@@ -195,7 +195,7 @@ test.describe("Roll screen — lock / save / re-roll", () => {
         await expect(roll.lockedBadge).toBeVisible();
     });
 
-    test("saving a locked setlist adds it to Greatest Hits", async ({ page, app }) => {
+    test("saving a locked setlist adds it to Greatest Hits", { tag: ["@smoke"] }, async ({ page, app }) => {
         await app.seed(seedWithCatalog());
         await app.goto();
         await app.waitForReady();

--- a/tests/e2e/saved.spec.ts
+++ b/tests/e2e/saved.spec.ts
@@ -31,7 +31,7 @@ function fixtureCatalogSongs(): Record<string, unknown> {
     };
 }
 
-test.describe("Saved screen — empty state", () => {
+test.describe("Saved screen — empty state", { tag: ["@smoke"] }, () => {
     test("empty state appears when no saved setlists exist", async ({ page, app }) => {
         await app.seed(buildSeed());
         await app.goto();
@@ -43,7 +43,7 @@ test.describe("Saved screen — empty state", () => {
 });
 
 test.describe("Saved screen — list", () => {
-    test("seeded setlists render as cards with name and song count", async ({ page, app }) => {
+    test("seeded setlists render as cards with name and song count", { tag: ["@smoke"] }, async ({ page, app }) => {
         await app.seed(
             buildSeed({
                 songs: fixtureCatalogSongs(),
@@ -116,7 +116,7 @@ test.describe("Saved screen — view modal", () => {
         await saved.closeCard();
     });
 
-    test("Load to Roll button loads the setlist into the Roll screen", async ({ page, app }) => {
+    test("Load to Roll button loads the setlist into the Roll screen", { tag: ["@smoke"] }, async ({ page, app }) => {
         await app.seed(
             buildSeed({
                 songs: fixtureCatalogSongs(),
@@ -192,7 +192,7 @@ test.describe("Saved screen — load", () => {
 });
 
 test.describe("Saved screen — delete with confirm", () => {
-    test("Remove → Delete? confirms and deletes", async ({ page, app }) => {
+    test("Remove → Delete? confirms and deletes", { tag: ["@smoke"] }, async ({ page, app }) => {
         await app.seed(
             buildSeed({
                 setlists: { s: setlistFixture({ id: "s", name: "Doomed Set" }) },

--- a/tests/e2e/song-editor.spec.ts
+++ b/tests/e2e/song-editor.spec.ts
@@ -10,7 +10,7 @@ import { SongsPage } from "../pages/SongsPage";
  * techniques, duplicate, delete with confirmation.
  */
 test.describe("Song editor — basics", () => {
-    test("create a song with name, key, and notes", async ({ page, app }) => {
+    test("create a song with name, key, and notes", { tag: ["@smoke"] }, async ({ page, app }) => {
         await app.seed(buildSeed());
         await app.goto();
         await new AppShell(page).gotoSongs();

--- a/tests/e2e/songs.spec.ts
+++ b/tests/e2e/songs.spec.ts
@@ -7,7 +7,7 @@ import { SongsPage } from "../pages/SongsPage";
  * Songs catalog screen — list, search, filter (type/status/key), empty
  * states. The detailed editor flows live in `song-editor.spec.ts`.
  */
-test.describe("Songs catalog — empty states", () => {
+test.describe("Songs catalog — empty states", { tag: ["@smoke"] }, () => {
     test("empty catalog shows 'Crickets...' empty state", async ({ page, app }) => {
         await app.seed(buildSeed());
         await app.goto();
@@ -35,7 +35,7 @@ test.describe("Songs catalog — empty states", () => {
     });
 });
 
-test.describe("Songs catalog — list & count", () => {
+test.describe("Songs catalog — list & count", { tag: ["@smoke"] }, () => {
     test("renders all seeded songs sorted by name", async ({ page, app }) => {
         await app.seed(
             buildSeed({


### PR DESCRIPTION
## Summary

Splits the e2e test strategy so PRs get fast feedback and the full suite stays as a hardened release gate.

### Changes

**Option A — Smoke test subset (PR workflow)**
- Tagged 23 critical tests with `@smoke` across 7 spec files:
  - `connection.spec.ts` — OAuth connect + auto-connect (3)
  - `navigation.spec.ts` — tab nav (2)
  - `roll.spec.ts` — onboarding, idle nudge, generate, lock, save (5)
  - `songs.spec.ts` — empty state, list & count (5)
  - `saved.spec.ts` — empty state, list, load-to-roll, delete (4)
  - `band.spec.ts` — band name, add member (3)
  - `song-editor.spec.ts` — create song (1)
- Added `test:e2e:smoke` npm script (`playwright test --project=chromium --grep @smoke`)

**Option B — Chromium only on PRs**
- `ci.yml` installs only Chromium (no webkit), uses a `-chromium`-suffixed cache key

**Option C — Sharding on release**
- `release.yml` split into 3 jobs: `validate` → `e2e` (3-shard matrix) → `deploy`
- Each shard runs on its own VM with its own armadietto container (no shared state)
- `fail-fast: false` so all shards report failures before blocking deploy
- Failure artifacts (report, test-results, armadietto logs) uploaded per-shard
- All step outputs touching shell commands now go through env vars (security hygiene)

**Option D — Faster timeout**
- `playwright.config.ts`: per-test timeout 60 s → 45 s

### Expected impact

| | Before | After |
|--|--|--|
| PR e2e | 11+ min (154 tests, 2 browsers) | ~2 min (23 tests, 1 browser) |
| Release e2e | 11+ min (1 serial runner) | ~4 min (3 parallel runners) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * CI now runs a faster Chromium-only smoke subset instead of the full browser suite.
  * Many E2E cases were marked as smoke to enable quick validation; a dedicated smoke test command was added.

* **Chores**
  * Global E2E timeout reduced for faster feedback.
  * Release pipeline updated to run validated, sharded E2E jobs before deploy and to handle version bumping and artifacts per shard.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/setlist-roller/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->