### PR TITLE
fix(ios): scroll-restore whitespace on cold-start + song title overflow in editor

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -51,10 +51,20 @@
         root.style.setProperty("--accent-line", hexToRgba(dieColor, 0.24));
     });
 
-    // iOS standalone PWA: after the sync-shell → app-shell DOM swap,
-    // WebKit's compositor has stale hit-test regions for the new
-    // fixed-position elements (TopBar, BottomNav). A micro-scroll
-    // forces the compositor to rebuild its layer hit-test tree.
+    // iOS standalone PWA: after the sync-shell → app-shell DOM swap two
+    // things need to happen in one rAF chain:
+    //
+    // 1. Reset scroll to the top.  history.scrollRestoration = "manual"
+    //    (set in main.js) stops the runtime from re-applying a stale
+    //    scroll offset, but iOS may still start with a non-zero scrollY
+    //    from the compositor's previous frame.  Explicitly calling
+    //    scrollTo(0, 0) clears it.
+    //
+    // 2. Micro-scroll (+1 / back to 0).  WebKit's compositor builds its
+    //    hit-test tree against the *old* DOM (sync-shell).  Any positional
+    //    delta, however tiny, forces a rebuild so the new fixed-position
+    //    elements (TopBar, BottomNav) become tappable immediately.
+    //
     // Account swaps re-flip initialSyncComplete (true → false → true);
     // the nudge only matters on the first true after boot, so latch it.
     let iosScrollNudged = false;
@@ -63,10 +73,8 @@
         if (store.initialSyncComplete && isIosStandaloneAuthContext()) {
             iosScrollNudged = true;
             requestAnimationFrame(() => {
-                const x = window.scrollX;
-                const y = window.scrollY;
-                window.scrollTo(x, y + 1);
-                requestAnimationFrame(() => window.scrollTo(x, y));
+                window.scrollTo(0, 1); // micro-nudge forces compositor rebuild
+                requestAnimationFrame(() => window.scrollTo(0, 0)); // reset to top
             });
         }
     });

--- a/src/lib/components/songs/SongEditor.svelte
+++ b/src/lib/components/songs/SongEditor.svelte
@@ -495,6 +495,13 @@
         border-bottom: 1px solid var(--line);
         min-height: 48px;
         flex-shrink: 0;
+        /* The overlay uses display:grid with no explicit column template, so
+           grid items default to min-width:auto (= max-content of their flex
+           children).  A very long song title would expand this grid item past
+           the viewport, pushing the Save button off-screen.  Setting
+           min-width:0 lets the grid item shrink to the grid container's width
+           so the flex layout can do its job and the title truncates properly. */
+        min-width: 0;
     }
 
     .back-btn {

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,14 @@ import "./app.css";
 import { registerSW } from "virtual:pwa-register";
 import App from "./App.svelte";
 
+// Prevent the browser / iOS PWA runtime from restoring a stale scroll
+// position on cold-start.  Without this, iOS will replay whatever scrollY
+// the user had last session onto the freshly-mounted (and possibly shorter)
+// idle layout, producing phantom whitespace below the hero card.
+if ("scrollRestoration" in history) {
+    history.scrollRestoration = "manual";
+}
+
 registerSW({ immediate: true });
 
 const app = mount(App, {


### PR DESCRIPTION
## Summary

Two iOS PWA bugs reported via screenshots.

---

### Bug 1: Phantom whitespace below hero card on every cold-start

**Root cause:** iOS standalone PWAs replay the last session's `scrollY` on cold-start. The idle screen (hero card + dice) is shorter than a rolled setlist, so the restored offset dropped the visible content mid-page, creating a large dark gap between the Songs card and the dice icon.

**Fixes:**
- `src/main.js` — set `history.scrollRestoration = "manual"` so the runtime never replays a stale scroll position.
- `src/App.svelte` — update the existing iOS compositor nudge to scroll to `(0, 1)` → `(0, 0)` instead of preserving whatever `scrollY` was already set. This clears any residual first-frame offset *and* still forces the WebKit compositor to rebuild hit-test regions for the new fixed-position elements (TopBar, BottomNav).

---

### Bug 2: Long song title pushes Save button off-screen in editor

**Root cause:** `.editor-overlay` is `display: grid` with no `grid-template-columns`. CSS grid items default to `min-width: auto`, which for a flex container means *max-content* width — wide enough to lay out the title without truncating. The flex inside never had to shrink the title, so `.editor-overlay`'s `overflow: hidden` just silently clipped the Save button at the viewport edge.

**Fix:**
- `src/lib/components/songs/SongEditor.svelte` — add `min-width: 0` to `.editor-header`. This constrains the grid item to the grid container width (= viewport), letting the flex layout run correctly: buttons stay fixed-size, the title fills the remaining space and truncates with `…`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed header layout issue where long song titles could expand beyond the viewport
  * Improved scroll position handling on app startup to prevent stale scroll restoration
  * Enhanced iOS standalone PWA scroll behavior for better user experience

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/setlist-roller/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->