### PR TITLE
fix(ios): use window.innerHeight for --real-vh to avoid dvh cold-start gap

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -231,7 +231,7 @@
 <style>
     /* ---- Connect screen ---- */
     .connect-shell {
-        min-height: 100dvh;
+        min-height: var(--real-vh, 100dvh);
         display: grid;
         place-items: center;
         padding: var(--space-4);
@@ -268,7 +268,7 @@
 
     /* ---- Sync screen ---- */
     .sync-shell {
-        min-height: 100dvh;
+        min-height: var(--real-vh, 100dvh);
         display: grid;
         place-items: center;
         padding: var(--space-4);
@@ -371,7 +371,7 @@
 
     /* ---- App shell ---- */
     .app-shell {
-        min-height: 100dvh;
+        min-height: var(--real-vh, 100dvh);
         display: flex;
         flex-direction: column;
     }

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,16 @@ if ("scrollRestoration" in history) {
     history.scrollRestoration = "manual";
 }
 
+// iOS standalone PWA: 100dvh is computed lazily by WebKit and starts at an
+// incorrect (too large) value on cold-start, creating a gap before the first
+// user touch corrects it. window.innerHeight is authoritative from the first
+// render. Keep it updated on resize so keyboard show/hide is also covered.
+function syncAppHeight() {
+    document.documentElement.style.setProperty("--real-vh", window.innerHeight + "px");
+}
+syncAppHeight();
+window.addEventListener("resize", syncAppHeight);
+
 registerSW({ immediate: true });
 
 const app = mount(App, {


### PR DESCRIPTION
## Problem

On iOS standalone PWA, `100dvh` is computed lazily by WebKit on cold-start. It starts at an incorrect (too large) value, creating a blank gap below the bottom nav. The layout only corrects itself after the first user touch gesture.

## Fix

Set a `--real-vh` CSS variable from `window.innerHeight` before mount — this value is authoritative from the first render. A `resize` listener keeps it in sync when the virtual keyboard appears or orientation changes.

Replace `min-height: 100dvh` with `min-height: var(--real-vh, 100dvh)` on the three shell containers (`.connect-shell`, `.sync-shell`, `.app-shell`). The `100dvh` fallback ensures graceful degradation on any browser where the variable is not set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed viewport height calculation to properly adapt to actual device viewport dimensions, improving layout stability and consistency across different devices and display scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/setlist-roller/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->