### PR TITLE
fix(ios): lock app-shell to viewport height, scroll within main-content

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -371,13 +371,23 @@
 
     /* ---- App shell ---- */
     .app-shell {
-        min-height: var(--real-vh, 100dvh);
+        /* height (not min-height) locks the shell to the viewport so the body
+           never scrolls. Each screen scrolls within .main-content instead.
+           Prevents scroll state from bleeding between tabs and eliminates
+           blank space when short-content screens are visited after a
+           long-content screen. --real-vh is set from window.innerHeight in
+           main.js, which is authoritative on iOS PWA cold-start unlike 100dvh. */
+        height: var(--real-vh, 100dvh);
+        overflow: hidden;
         display: flex;
         flex-direction: column;
     }
 
     .main-content {
         flex: 1;
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+        overscroll-behavior: contain;
         padding: var(--space-3);
         padding-top: calc(var(--top-bar-height) + var(--space-3));
         padding-bottom: calc(var(--bottom-nav-height) + var(--space-3));

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -385,6 +385,7 @@
 
     .main-content {
         flex: 1;
+        min-height: 0; /* flex items default to min-height:auto which prevents shrinking and blocks overflow-y scroll on Safari */
         overflow-y: auto;
         -webkit-overflow-scrolling: touch;
         overscroll-behavior: contain;


### PR DESCRIPTION
## Problem

`min-height` on `.app-shell` allowed the document to grow taller than the viewport whenever a long-content screen (e.g. Songs with 42 items) was visited. The body became scrollable. Navigating back to a short-content screen (Roll) swapped the content but left the window scroll position wherever Songs had left it — with the document now only `window.innerHeight` tall, any non-zero scroll offset puts the bottom of the viewport past the end of the document, producing blank space.

Songs "fixing" the layout was coincidence: its content happened to fill the page top-to-bottom, making blank space unreachable.

## Fix

Use `height` (not `min-height`) on `.app-shell` so the shell is locked to the viewport and the body **never scrolls**. Add `overflow-y: auto` and `overscroll-behavior: contain` to `.main-content` so each screen scrolls internally instead.

`--real-vh` (set from `window.innerHeight` in `main.js`) is kept as the height value because iOS PWA computes `100dvh` lazily on cold-start and the JS value is synchronously correct from the first render.

## Changes

- `.app-shell`: `min-height` → `height`, add `overflow: hidden`
- `.main-content`: add `overflow-y: auto`, `-webkit-overflow-scrolling: touch`, `overscroll-behavior: contain`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Locked the app layout to the viewport height to prevent body/window scrolling.
  * Reworked main content to allow internal scrolling while preventing layout overflow.
  * Enabled smoother touch scrolling on iOS and improved overscroll containment for more consistent scroll behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/setlist-roller/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->