### PR TITLE
fix: remove overflow:hidden from .app-shell to restore position:fixed modal behaviour

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -376,9 +376,12 @@
            Prevents scroll state from bleeding between tabs and eliminates
            blank space when short-content screens are visited after a
            long-content screen. --real-vh is set from window.innerHeight in
-           main.js, which is authoritative on iOS PWA cold-start unlike 100dvh. */
+           main.js, which is authoritative on iOS PWA cold-start unlike 100dvh.
+           No overflow:hidden — .main-content handles its own overflow via
+           overflow-y:auto, and overflow:hidden on a fixed-position ancestor
+           can cause Chrome to misreport getBoundingClientRect() for elements
+           inside position:fixed children (compositing layer clipping). */
         height: var(--real-vh, 100dvh);
-        overflow: hidden;
         display: flex;
         flex-direction: column;
     }


### PR DESCRIPTION
## Problem

The e2e tests for tall setlist scrolling were failing after #106 with:

```
Expected: false
Received: true
expect(inViewportBefore).toBe(false);
```

The `position: fixed; inset: 0` modal backdrop (inside `SavedScreen`) was inside an `overflow: hidden` ancestor (`.app-shell`). In Chrome, `overflow: hidden` on an ancestor of a `position: fixed` element can cause the browser to composite the fixed child into the ancestor's painting layer, which makes `getBoundingClientRect()` return coordinates clamped to the clip boundary rather than the element's true off-screen position. This made the last song in a 40-item setlist appear to already be in the viewport before any scrolling.

## Fix

Remove `overflow: hidden` from `.app-shell`. It was redundant:

- `.main-content` already handles all content overflow via `overflow-y: auto`
- Body scroll is prevented by `height` (not `min-height`) on `.app-shell`, which locks the document height to the viewport — no overflow to hide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved app scrolling behavior and layout handling, particularly for iOS and progressive web app experiences. The app shell now allows better content scrolling while maintaining proper viewport dimensions across different devices and browsers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/setlist-roller/pull/107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->