### PR TITLE
fix: address audit findings in docs and test helpers

### DIFF
--- a/src/lib/stores/account-switching.test.js
+++ b/src/lib/stores/account-switching.test.js
@@ -45,7 +45,12 @@ class MemStorage {
     }
 }
 
+let _origLocalStorage;
+let _origWindow;
+
 beforeEach(() => {
+    _origLocalStorage = globalThis.localStorage;
+    _origWindow = globalThis.window;
     // Fresh per-test storage so saved tokens / snapshots don't leak.
     globalThis.localStorage = new MemStorage();
     // Minimum window surface the store touches: location.hash for routing
@@ -59,6 +64,10 @@ beforeEach(() => {
 
 afterEach(() => {
     vi.useRealTimers();
+    if (typeof _origLocalStorage === "undefined") delete globalThis.localStorage;
+    else globalThis.localStorage = _origLocalStorage;
+    if (typeof _origWindow === "undefined") delete globalThis.window;
+    else globalThis.window = _origWindow;
 });
 
 /**

--- a/tests/e2e/account-switching.spec.ts
+++ b/tests/e2e/account-switching.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from "../fixtures/test-fixtures";
 
 /**
  * Real-backend account-switching coverage. Same scenarios as
- * tests/e2e/account-switching.spec.ts but against a live armadietto +
+ * the fake-repo account-switching tests but against a live armadietto +
  * rs.js stack, so the OAuth redirect, webfinger discovery, and IndexedDB
  * cache are all exercised. The fake-repo equivalents pass — these catch
  * the regressions that only surface against real machinery.

--- a/tests/pages/BandPage.ts
+++ b/tests/pages/BandPage.ts
@@ -124,16 +124,6 @@ export class BandPage {
         await expect(this.advancedTitle).toBeVisible();
     }
 
-    async setDieColor(color: string) {
-        await this.screen
-            .locator(".pip-swatch")
-            .filter({ has: this.page.locator(`[aria-label="Set die color to ${color}"]`) })
-            .first()
-            .click();
-        // The accessible-name route doesn't always pick up button aria-labels
-        // through filter — fallback selector that's resilient:
-    }
-
     async pickDieColor(color: string) {
         await this.screen.getByRole("button", { name: `Set die color to ${color}` }).click();
     }


### PR DESCRIPTION
## Summary

Three small cleanup items from the code audit.

### 1. Fix self-referential comment in tests/e2e/account-switching.spec.ts

The JSDoc block at the top of the real-backend e2e spec referenced itself ("Same scenarios as tests/e2e/account-switching.spec.ts"). Updated to say "the fake-repo account-switching tests", which correctly identifies the counterpart suite.

### 2. Restore mutated globals in teardown in src/lib/stores/account-switching.test.js

`beforeEach` replaced `globalThis.localStorage` and `globalThis.window` but `afterEach` never restored them. Added `_origLocalStorage` and `_origWindow` module-level variables that capture the originals before each test and restore them after. If the original was `undefined` the global is deleted rather than set to `undefined`, which correctly handles the Node environment where those globals don't exist by default.

### 3. Remove incomplete setDieColor method from tests/pages/BandPage.ts

`setDieColor` was a half-finished implementation with a dangling comment promising a "fallback selector" that was never written. `pickDieColor` (which correctly uses `getByRole`) already covers all call sites — no test file calls `setDieColor`. The dead method is removed.

---

**Skipped finding:** The audit flagged `BandScreen` passing the full `field` object to `updateConfigField` instead of `field.path`. This is intentional — `updateConfigField` uses `field.rule` internally for order-rule array construction, so passing only `field.path` would break that functionality. The current code is correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test stability through improved global state management in account-switching tests.
  * Refined test interactions for die-color selection in the page object layer.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/setlist-roller/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->