### PR TITLE
refactor: extract duplicated technique helpers to shared utility

### DIFF
--- a/src/lib/components/roll/SetlistSongCard.svelte
+++ b/src/lib/components/roll/SetlistSongCard.svelte
@@ -1,18 +1,9 @@
 <script>
+  import { normalizeTechniqueValue, techniqueDisplay } from "../../technique-utils.js";
+
   const { song, index, prevSong, onDragStart, onEdit, onRemove, arming = false, dragging = false } = $props();
 
   let expanded = $state(false);
-
-  function normalizeTechniqueValue(value) {
-    if (!Array.isArray(value)) return String(value || "");
-    return value.filter((technique) => technique && technique !== "none").slice().sort().join(",");
-  }
-
-  function techniqueDisplay(value) {
-    if (!Array.isArray(value)) return value || null;
-    const normalized = value.filter((technique) => technique && technique !== "none").slice().sort();
-    return normalized.length ? normalized.join(", ") : null;
-  }
 
   function toggleExpand() {
     expanded = !expanded;

--- a/src/lib/components/saved/SavedScreen.svelte
+++ b/src/lib/components/saved/SavedScreen.svelte
@@ -1,6 +1,7 @@
 <script>
   import { getContext } from "svelte";
   import { anxietyLabel } from "../../anxiety.js";
+  import { normalizeTechniqueValue, techniqueDisplay } from "../../technique-utils.js";
 
   const store = getContext("app");
 
@@ -121,17 +122,6 @@
     if (!iso) return "";
     const d = new Date(iso);
     return d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
-  }
-
-  function normalizeTechniqueValue(value) {
-    if (!Array.isArray(value)) return String(value || "");
-    return value.filter((technique) => technique && technique !== "none").slice().sort().join(",");
-  }
-
-  function techniqueDisplay(value) {
-    if (!Array.isArray(value)) return value || null;
-    const normalized = value.filter((technique) => technique && technique !== "none").slice().sort();
-    return normalized.length ? normalized.join(", ") : null;
   }
 
   // Transition notes — same logic as SetlistSongCard

--- a/src/lib/technique-utils.js
+++ b/src/lib/technique-utils.js
@@ -6,8 +6,11 @@
  * @returns {string}
  */
 export function normalizeTechniqueValue(value) {
-    if (!Array.isArray(value)) return String(value || "");
-    return value.filter((technique) => technique && technique !== "none").slice().sort().join(",");
+    return (Array.isArray(value) ? value : [value])
+        .filter((technique) => technique && technique !== "none")
+        .slice()
+        .sort()
+        .join(",");
 }
 
 /**
@@ -18,7 +21,9 @@ export function normalizeTechniqueValue(value) {
  * @returns {string|null}
  */
 export function techniqueDisplay(value) {
-    if (!Array.isArray(value)) return value || null;
-    const normalized = value.filter((technique) => technique && technique !== "none").slice().sort();
+    const normalized = (Array.isArray(value) ? value : [value])
+        .filter((technique) => technique && technique !== "none")
+        .slice()
+        .sort();
     return normalized.length ? normalized.join(", ") : null;
 }

--- a/src/lib/technique-utils.js
+++ b/src/lib/technique-utils.js
@@ -1,0 +1,24 @@
+/**
+ * Normalise a technique value for comparison.
+ * Filters out falsy values and "none", sorts, and joins with commas.
+ *
+ * @param {string|string[]} value
+ * @returns {string}
+ */
+export function normalizeTechniqueValue(value) {
+    if (!Array.isArray(value)) return String(value || "");
+    return value.filter((technique) => technique && technique !== "none").slice().sort().join(",");
+}
+
+/**
+ * Format a technique value for display.
+ * Returns null when there is nothing meaningful to show.
+ *
+ * @param {string|string[]} value
+ * @returns {string|null}
+ */
+export function techniqueDisplay(value) {
+    if (!Array.isArray(value)) return value || null;
+    const normalized = value.filter((technique) => technique && technique !== "none").slice().sort();
+    return normalized.length ? normalized.join(", ") : null;
+}


### PR DESCRIPTION
## Summary

`normalizeTechniqueValue` and `techniqueDisplay` were defined verbatim in two components:

- `src/lib/components/roll/SetlistSongCard.svelte`
- `src/lib/components/saved/SavedScreen.svelte`

Both functions have been extracted to a new shared module at `src/lib/technique-utils.js`, and each component now imports from there.

This eliminates the duplication and ensures any future changes to the normalisation or display logic only need to be made in one place, following DRY principles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved technique/picking normalization and display logic into a shared utility and updated components to use it.
  * Result: more consistent normalization and display of technique/picking values across saved and setlist views, with no visible API changes to exported entities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/setlist-roller/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->