### PR TITLE
fix: resilience improvements from audit

### DIFF
--- a/src/lib/remotestorage.js
+++ b/src/lib/remotestorage.js
@@ -68,7 +68,9 @@ import { clone, nowIso } from "./utils.js";
         const scheme = PLAIN_HTTP_HOST_RE.test(host) || PLAIN_HTTP_HOST_RE.test(hostNoPort) ? "http" : "https";
         const url = `${scheme}://${host}/.well-known/webfinger?resource=${encodeURIComponent(resource)}`;
 
-        return fetch(url).then(async (resp) => {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 10000);
+        return fetch(url, { signal: controller.signal }).then(async (resp) => {
             if (!resp.ok) throw new Error(`WebFinger failed: ${resp.status}`);
             const data = await resp.json();
             const link = Array.isArray(data?.links)
@@ -90,7 +92,7 @@ import { clone, nowIso } from "./utils.js";
                 }
             }
             return { href: link.href, storageApi, authURL, properties };
-        });
+        }).finally(() => clearTimeout(timeoutId));
     };
 
     // Preserve `RemoteStorage.Discover.DiscoveryError` — rs.js's connect path

--- a/src/lib/remotestorage.js
+++ b/src/lib/remotestorage.js
@@ -70,29 +70,31 @@ import { clone, nowIso } from "./utils.js";
 
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), 10000);
-        return fetch(url, { signal: controller.signal }).then(async (resp) => {
-            if (!resp.ok) throw new Error(`WebFinger failed: ${resp.status}`);
-            const data = await resp.json();
-            const link = Array.isArray(data?.links)
-                ? data.links.find((l) => l?.rel && RS_LINK_RELS.has(l.rel))
-                : undefined;
-            if (!link?.href) throw new Error("No remoteStorage link in WebFinger response");
-            const properties = link.properties ?? {};
-            const storageApi =
-                (typeof link.type === "string" ? link.type : undefined) ??
-                (typeof properties["http://remotestorage.io/spec/version"] === "string"
-                    ? properties["http://remotestorage.io/spec/version"]
-                    : undefined);
-            let authURL;
-            for (const key of AUTH_URL_PROPS) {
-                const v = properties[key];
-                if (typeof v === "string") {
-                    authURL = v;
-                    break;
+        return fetch(url, { signal: controller.signal })
+            .then(async (resp) => {
+                if (!resp.ok) throw new Error(`WebFinger failed: ${resp.status}`);
+                const data = await resp.json();
+                const link = Array.isArray(data?.links)
+                    ? data.links.find((l) => l?.rel && RS_LINK_RELS.has(l.rel))
+                    : undefined;
+                if (!link?.href) throw new Error("No remoteStorage link in WebFinger response");
+                const properties = link.properties ?? {};
+                const storageApi =
+                    (typeof link.type === "string" ? link.type : undefined) ??
+                    (typeof properties["http://remotestorage.io/spec/version"] === "string"
+                        ? properties["http://remotestorage.io/spec/version"]
+                        : undefined);
+                let authURL;
+                for (const key of AUTH_URL_PROPS) {
+                    const v = properties[key];
+                    if (typeof v === "string") {
+                        authURL = v;
+                        break;
+                    }
                 }
-            }
-            return { href: link.href, storageApi, authURL, properties };
-        }).finally(() => clearTimeout(timeoutId));
+                return { href: link.href, storageApi, authURL, properties };
+            })
+            .finally(() => clearTimeout(timeoutId));
     };
 
     // Preserve `RemoteStorage.Discover.DiscoveryError` — rs.js's connect path

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -1956,13 +1956,21 @@ export function createAppStore(repo) {
     // ---- band members ----
     async function persistMemberEdit(memberName, data, errorMessage = "Could not save member.") {
         const normalized = normalizeMemberRecord(data);
-        const previous = bandMembers;
+        const previousMember = bandMembers?.[memberName];
         bandMembers = { ...bandMembers, [memberName]: normalized };
         try {
             await withSync("Saving member", () => repo.putMember(memberName, normalized));
             return true;
         } catch (error) {
-            bandMembers = previous;
+            // Revert only our own key, and only if a newer edit hasn't already
+            // replaced it, so a failed save can't clobber a concurrent successful
+            // edit to this or another member.
+            if (bandMembers?.[memberName] === normalized) {
+                const next = { ...bandMembers };
+                if (previousMember === undefined) delete next[memberName];
+                else next[memberName] = previousMember;
+                bandMembers = next;
+            }
             toastError(error?.message || errorMessage);
             return false;
         }

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -1956,11 +1956,13 @@ export function createAppStore(repo) {
     // ---- band members ----
     async function persistMemberEdit(memberName, data, errorMessage = "Could not save member.") {
         const normalized = normalizeMemberRecord(data);
+        const previous = bandMembers;
         bandMembers = { ...bandMembers, [memberName]: normalized };
         try {
             await withSync("Saving member", () => repo.putMember(memberName, normalized));
             return true;
         } catch (error) {
+            bandMembers = previous;
             toastError(error?.message || errorMessage);
             return false;
         }

--- a/src/lib/theme.svelte.js
+++ b/src/lib/theme.svelte.js
@@ -1,10 +1,14 @@
 // SYNC: key + resolution logic duplicated in index.html inline script to avoid FOITC
 const STORAGE_KEY = "setlist-roller-theme";
 const PREFS = ["system", "light", "dark"];
-const mq = window.matchMedia("(prefers-color-scheme: dark)");
+const mq =
+  typeof window !== "undefined" && typeof window.matchMedia === "function"
+    ? window.matchMedia("(prefers-color-scheme: dark)")
+    : { matches: false };
 
 function readPref() {
   try {
+    if (typeof localStorage === "undefined") return "system";
     const v = localStorage.getItem(STORAGE_KEY);
     return PREFS.includes(v) ? v : "system";
   } catch {
@@ -33,9 +37,19 @@ function onSystemChange() {
   }
 }
 
-mq.addEventListener("change", onSystemChange);
+if (typeof mq.addEventListener === "function") {
+  mq.addEventListener("change", onSystemChange);
+} else if (typeof mq.addListener === "function") {
+  mq.addListener(onSystemChange);
+}
 if (import.meta.hot) {
-  import.meta.hot.dispose(() => mq.removeEventListener("change", onSystemChange));
+  import.meta.hot.dispose(() => {
+    if (typeof mq.removeEventListener === "function") {
+      mq.removeEventListener("change", onSystemChange);
+    } else if (typeof mq.removeListener === "function") {
+      mq.removeListener(onSystemChange);
+    }
+  });
 }
 
 export function getThemePreference() {

--- a/src/lib/theme.svelte.js
+++ b/src/lib/theme.svelte.js
@@ -22,6 +22,7 @@ function resolve(pref) {
 }
 
 function apply(eff) {
+  if (typeof document === "undefined") return;
   document.documentElement.dataset.theme = eff;
 }
 


### PR DESCRIPTION
Three resilience/correctness fixes identified in the code audit.

1. **Rollback optimistic member edits on failure** (): `persistMemberEdit` now captures the previous `bandMembers` state before the optimistic update and restores it in the catch block, preventing local state from diverging from remote data after a failed write.

2. **WebFinger fetch timeout** (`src/lib/remotestorage.js`): The WebFinger `fetch` call now uses an `AbortController` with a 10 s timeout to prevent indefinite hangs on network stalls. The timeout is cleared in a `finally` block to avoid leaking timer handles on success.

3. **Guard browser-only APIs in theme module** (`src/lib/theme.svelte.js`): `window.matchMedia` is now guarded at module level so the file can be imported in non-browser environments (SSR, tests) without throwing. `readPref` guards `localStorage` access the same way. The `addEventListener`/`removeEventListener` calls include `addListener`/`removeListener` fallbacks for Safari 13 compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Network requests now time out after 10 seconds to avoid indefinite hangs.
  * Band member edits use safer rollback logic so failed saves no longer overwrite newer in-memory changes.
  * Theme handling is more robust in constrained environments (no document/localStorage/matchMedia), improving stability and system-theme updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/setlist-roller/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->