### PR TITLE
fix(ios): extend bottom-nav height to cover safe-area-inset-bottom

### DIFF
--- a/src/lib/components/layout/BottomNav.svelte
+++ b/src/lib/components/layout/BottomNav.svelte
@@ -31,7 +31,11 @@
     bottom: 0;
     left: 0;
     right: 0;
-    height: 56px;
+    /* height must match --bottom-nav-height so the element covers the same
+       vertical space that main-content reserves in its padding-bottom.
+       Using only 56px leaves the safe-area zone (env(safe-area-inset-bottom))
+       uncovered, producing a persistent gap above the nav. */
+    height: var(--bottom-nav-height);
     display: flex;
     align-items: stretch;
     background: var(--paper);

--- a/src/main.js
+++ b/src/main.js
@@ -14,12 +14,20 @@ if ("scrollRestoration" in history) {
 // iOS standalone PWA: 100dvh is computed lazily by WebKit and starts at an
 // incorrect (too large) value on cold-start, creating a gap before the first
 // user touch corrects it. window.innerHeight is authoritative from the first
-// render. Keep it updated on resize so keyboard show/hide is also covered.
+// render. Keep it updated on multiple events so the value stays correct after
+// keyboard show/hide, orientation changes, and page-restore from background.
 function syncAppHeight() {
     document.documentElement.style.setProperty("--real-vh", window.innerHeight + "px");
 }
 syncAppHeight();
 window.addEventListener("resize", syncAppHeight);
+// pageshow fires on back-forward cache restore where resize may not fire
+window.addEventListener("pageshow", syncAppHeight);
+// visualViewport.resize is more reliable than window.resize on iOS for
+// catching height changes caused by the on-screen keyboard
+if (window.visualViewport) {
+    window.visualViewport.addEventListener("resize", syncAppHeight);
+}
 
 registerSW({ immediate: true });
 


### PR DESCRIPTION
## Problem

`--bottom-nav-height` (defined in `app.css`) is `calc(56px + env(safe-area-inset-bottom, 0px))` and is used as the `padding-bottom` for `.main-content`. That reserves the right amount of scroll space at the bottom.

However, `.bottom-nav` was only `height: 56px`. On iPhones with a home indicator the safe-area-inset-bottom is ~34 px, so the nav element was 34 px shorter than the space that `main-content` reserves. The uncovered 34 px above the nav appeared as a persistent blank gap whenever you scrolled to the bottom on any tab.

A second side-effect: `align-items: stretch` was sizing the tab buttons into a content area of only `56 - 34 = 22 px`, which is smaller than the `min-height: 44px` on each tab — meaning the buttons were silently overflowing their container.

## Fix

- **`BottomNav.svelte`** — change `height: 56px` → `height: var(--bottom-nav-height)`. The element now covers exactly the same vertical zone that `main-content` reserves, and the tab buttons get the full 56 px content area above the home-indicator padding.
- **`main.js`** — attach `syncAppHeight()` to `pageshow` and `visualViewport.resize` in addition to `window.resize`. This ensures `--real-vh` stays accurate after BFCache restores and on-screen keyboard transitions on iOS where `resize` sometimes doesn't fire.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bottom navigation layout to properly handle safe-area spacing on mobile devices.
  * Improved viewport height synchronization on iOS and PWA apps for on-screen keyboard interactions and device orientation changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/setlist-roller/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->