### PR TITLE
ci(release): push to master via dedicated SSH deploy key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,12 +112,18 @@ jobs:
     name: Version, build & deploy
     # Only runs when both validate and all e2e shards pass.
     needs: [validate, e2e]
+    # The deploy key can push to the protected master branch, so refuse to run
+    # this privileged job unless it was dispatched from master itself —
+    # otherwise dispatching from any branch would publish that branch to master.
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ github.token }}
+          # Origin pushes use the SSH deploy key, never the default token, so
+          # don't leave the token persisted in the local git config.
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -167,11 +173,22 @@ jobs:
           git commit -m "deploy v${VERSION}"
           git push 5apps HEAD:refs/heads/master --force
 
+      # Push the release commit to the protected master branch using a
+      # dedicated SSH deploy key. That key is the ONLY actor on the master
+      # ruleset's bypass list, so the release job is the only thing that can
+      # write to master — no PAT, no human, not even a repo admin.
       - name: Tag and push version
         env:
           VERSION: ${{ steps.version.outputs.version }}
           SOURCE_SHA: ${{ steps.source.outputs.sha }}
+          RELEASE_DEPLOY_KEY: ${{ secrets.RELEASE_DEPLOY_KEY }}
         run: |
+          mkdir -p ~/.ssh
+          echo "$RELEASE_DEPLOY_KEY" > ~/.ssh/github_release_key
+          chmod 600 ~/.ssh/github_release_key
+          ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+          printf 'Host github.com\n  IdentityFile ~/.ssh/github_release_key\n  IdentitiesOnly yes\n' >> ~/.ssh/config
+          git remote set-url origin git@github.com:silverbucket/setlist-roller.git
           git tag "v${VERSION}" "${SOURCE_SHA}"
           git push origin "${SOURCE_SHA}":master --tags
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "setlist-roller",
-    "version": "2.2.6",
+    "version": "2.2.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "setlist-roller",
-            "version": "2.2.6",
+            "version": "2.2.7",
             "dependencies": {
                 "remotestoragejs": "^2.0.0-beta.9",
                 "rs-migrate": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "setlist-roller",
     "private": true,
-    "version": "2.2.6",
+    "version": "2.2.7",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
## Problem

The `master` ruleset requires changes through a pull request, so the release job's direct push of the version-bump commit is rejected. The default `GITHUB_TOKEN` can't be added to a ruleset bypass list.

## Fix

Authenticate the push to `master` with a **dedicated SSH deploy key** (`secrets.RELEASE_DEPLOY_KEY`), mirroring the existing 5apps deploy-key pattern. The deploy key is the **only** actor on the ruleset's bypass list — so the release job is the sole writer to `master`. No human, no admin PAT, not me locally.

## Required setup (one-time, by repo owner)

1. Generate a keypair:
   ```
   ssh-keygen -t ed25519 -C "setlist-roller-release" -f release_key -N ""
   ```
2. **Public** key (`release_key.pub`): repo → Settings → **Deploy keys → Add** → check **Allow write access**.
3. **Private** key (`release_key`): repo → Settings → Secrets and variables → Actions → add secret **`RELEASE_DEPLOY_KEY`** (full file contents).
4. Add that deploy key as the **only** entry on the `master` ruleset's bypass list (UI: Settings → Rules → master → Bypass list → Add → Deploy keys).

## Test plan
- [ ] Deploy key added (write access) + `RELEASE_DEPLOY_KEY` secret set
- [ ] Deploy key is the sole bypass actor on the master ruleset
- [ ] Run Release workflow (patch) → `release vX.Y.Z` lands on master, tag + GitHub Release created
- [ ] Confirm a manual `git push` to master from a laptop is still rejected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow hardened: deploy job now only runs for the master branch and checkout no longer persists credentials.
  * Tag-and-push step switched to use a dedicated SSH deploy key from repository secrets, configures SSH/known hosts, and uses an SSH remote to push release tags.
  * Package version bumped to 2.2.7.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/setlist-roller/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->