### PR TITLE
fix(ios): make bottom nav in-flow to eliminate whitespace below bar in installed PWA

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -62,8 +62,9 @@
     //
     // 2. Micro-scroll (+1 / back to 0).  WebKit's compositor builds its
     //    hit-test tree against the *old* DOM (sync-shell).  Any positional
-    //    delta, however tiny, forces a rebuild so the new fixed-position
-    //    elements (TopBar, BottomNav) become tappable immediately.
+    //    delta, however tiny, forces a rebuild so the new TopBar (still fixed)
+    //    and layout changes become correct immediately. BottomNav is now
+    //    in-flow so it is less sensitive to this.
     //
     // Account swaps re-flip initialSyncComplete (true → false → true);
     // the nudge only matters on the first true after boot, so latch it.
@@ -377,10 +378,8 @@
            blank space when short-content screens are visited after a
            long-content screen. --real-vh is set from window.innerHeight in
            main.js, which is authoritative on iOS PWA cold-start unlike 100dvh.
-           No overflow:hidden — .main-content handles its own overflow via
-           overflow-y:auto, and overflow:hidden on a fixed-position ancestor
-           can cause Chrome to misreport getBoundingClientRect() for elements
-           inside position:fixed children (compositing layer clipping). */
+           BottomNav is now an in-flow flex child (no longer position:fixed),
+           so the flex column naturally places it at the visual bottom. */
         height: var(--real-vh, 100dvh);
         display: flex;
         flex-direction: column;
@@ -394,7 +393,10 @@
         overscroll-behavior: contain;
         padding: var(--space-3);
         padding-top: calc(var(--top-bar-height) + var(--space-3));
-        padding-bottom: calc(var(--bottom-nav-height) + var(--space-3));
+        /* Bottom padding reduced now that BottomNav is an in-flow flex child.
+           The previous calc(var(--bottom-nav-height) + ...) reservation was
+           required only when the nav was position:fixed. */
+        padding-bottom: var(--space-3);
         max-width: 640px;
         width: 100%;
         margin: 0 auto;

--- a/src/lib/components/band/BandScreen.svelte
+++ b/src/lib/components/band/BandScreen.svelte
@@ -1072,10 +1072,12 @@
         color: var(--ink, #182230);
     }
 
-    /* Sticky footer */
+    /* Sticky footer — positioned above the (now in-flow) BottomNav.
+       --bottom-nav-height already includes env(safe-area-inset-bottom),
+       so do not add it again here. */
     .sticky-footer {
         position: sticky;
-        bottom: calc(var(--bottom-nav-height, 56px) + env(safe-area-inset-bottom, 0px) + 0.5rem);
+        bottom: calc(var(--bottom-nav-height, 56px) + 0.5rem);
         padding: 0.75rem 0;
         z-index: 10;
     }

--- a/src/lib/components/layout/BottomNav.svelte
+++ b/src/lib/components/layout/BottomNav.svelte
@@ -27,15 +27,14 @@
 
 <style>
   .bottom-nav {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    /* height must match --bottom-nav-height so the element covers the same
-       vertical space that main-content reserves in its padding-bottom.
-       Using only 56px leaves the safe-area zone (env(safe-area-inset-bottom))
-       uncovered, producing a persistent gap above the nav. */
+    /* In-flow at the bottom of the .app-shell flex column (no longer fixed).
+       The shell's height is locked to --real-vh (from window.innerHeight).
+       This removes the fixed positioning vs. viewport measurement mismatches
+       that were causing whitespace below the nav on installed iOS PWAs.
+       Height still includes the safe area so the background extends under
+       the home indicator. */
     height: var(--bottom-nav-height);
+    flex-shrink: 0;
     display: flex;
     align-items: stretch;
     background: var(--paper);


### PR DESCRIPTION
The BottomNav was `position:fixed; bottom:0` with its height coming from `--bottom-nav-height` (calc including `env(safe-area-inset-bottom)`) and `.main-content` reserving matching padding.

On installed iOS PWAs this produced a persistent strip of page background below the entire nav bar (visible down to the home indicator). The gap was always present (not just cold start), was made more visible by the recent safe-area height extension (0e16caa), and rotation reduced but did not eliminate it.

**Root cause:** Mismatch between fixed positioning (layout viewport) and the app's locked `--real-vh` + env() measurements that the rest of the shell already uses to work around iOS WebKit PWA viewport quirks.

**Fix (Option A):** Make BottomNav a normal last flex child of `.app-shell` (which is already `height: var(--real-vh)` + `flex column`). Remove the manual padding-bottom reservation. Safe-area background extension is preserved via the nav's own height + padding.

Also cleaned up a double `env(safe-area-inset-bottom)` count on the BandScreen sticky footer that was masked before.

TopBar remains fixed (it was already behaving correctly).

**Testing:** This bug is not reproducible in Safari or `npm run preview` — it only appears in the installed standalone PWA on device. The only reliable verification is building + installing the PWA (or deploying).

Related previous work: #105, #106, #111 and the iOS scroll-nudge / --real-vh mitigations already in main.js + App.svelte.

Changes:
- BottomNav.svelte: removed fixed positioning, now in-flow
- App.svelte: removed reservation, updated comments
- BandScreen.svelte: fixed double safe-area calc on sticky footer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved bottom navigation component layout positioning for better iOS PWA compatibility and viewport behavior.
  * Optimized padding calculations and safe-area inset handling to align with the updated navigation layout structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/setlist-roller/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->