### PR TITLE
fix(ios): anchor app shell chrome to viewport

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,7 +8,7 @@
     import SavedScreen from "./lib/components/saved/SavedScreen.svelte";
     import SongsScreen from "./lib/components/songs/SongsScreen.svelte";
     import { generateDieSvgString, updatePwaIcons } from "./lib/pwa-icon.js";
-    import { createRemoteStorageRepository, isIosStandaloneAuthContext } from "./lib/remotestorage.js";
+    import { createRemoteStorageRepository } from "./lib/remotestorage.js";
     import { createAppStore } from "./lib/stores/app.svelte.js";
     import { DEFAULT_DIE_COLOR, darkenHex, hexToRgb, hexToRgba } from "./lib/utils.js";
 
@@ -51,34 +51,6 @@
         root.style.setProperty("--accent-line", hexToRgba(dieColor, 0.24));
     });
 
-    // iOS standalone PWA: after the sync-shell → app-shell DOM swap two
-    // things need to happen in one rAF chain:
-    //
-    // 1. Reset scroll to the top.  history.scrollRestoration = "manual"
-    //    (set in main.js) stops the runtime from re-applying a stale
-    //    scroll offset, but iOS may still start with a non-zero scrollY
-    //    from the compositor's previous frame.  Explicitly calling
-    //    scrollTo(0, 0) clears it.
-    //
-    // 2. Micro-scroll (+1 / back to 0).  WebKit's compositor builds its
-    //    hit-test tree against the *old* DOM (sync-shell).  Any positional
-    //    delta, however tiny, forces a rebuild so the new TopBar (still fixed)
-    //    and layout changes become correct immediately. BottomNav is now
-    //    in-flow so it is less sensitive to this.
-    //
-    // Account swaps re-flip initialSyncComplete (true → false → true);
-    // the nudge only matters on the first true after boot, so latch it.
-    let iosScrollNudged = false;
-    $effect(() => {
-        if (iosScrollNudged) return;
-        if (store.initialSyncComplete && isIosStandaloneAuthContext()) {
-            iosScrollNudged = true;
-            requestAnimationFrame(() => {
-                window.scrollTo(0, 1); // micro-nudge forces compositor rebuild
-                requestAnimationFrame(() => window.scrollTo(0, 0)); // reset to top
-            });
-        }
-    });
 </script>
 
 <svelte:head>
@@ -232,7 +204,7 @@
 <style>
     /* ---- Connect screen ---- */
     .connect-shell {
-        min-height: var(--real-vh, 100svh);
+        min-height: 100svh;
         display: grid;
         place-items: center;
         padding: var(--space-4);
@@ -269,7 +241,7 @@
 
     /* ---- Sync screen ---- */
     .sync-shell {
-        min-height: var(--real-vh, 100svh);
+        min-height: 100svh;
         display: grid;
         place-items: center;
         padding: var(--space-4);
@@ -372,30 +344,19 @@
 
     /* ---- App shell ---- */
     .app-shell {
-        /* height (not min-height) locks the shell so the body never scrolls
-           and each tab keeps its own scroll position inside .main-content.
-           --real-vh is the critical value here. main.js keeps it in sync with
-           visualViewport.height (preferred) + multiple settling measurements
-           because plain innerHeight / 100dvh / 100svh are frequently wrong or
-           stale exactly on installed iOS PWA cold starts — the scenario that
-           produces whitespace below the bottom nav. */
-        height: var(--real-vh, 100svh);
-        display: flex;
-        flex-direction: column;
+        position: fixed;
+        inset: 0;
+        display: grid;
+        grid-template-rows: auto minmax(0, 1fr) auto;
+        overflow: hidden;
     }
 
     .main-content {
-        flex: 1;
-        min-height: 0; /* flex items default to min-height:auto which prevents shrinking and blocks overflow-y scroll on Safari */
+        min-height: 0;
         overflow-y: auto;
         -webkit-overflow-scrolling: touch;
         overscroll-behavior: contain;
         padding: var(--space-3);
-        padding-top: calc(var(--top-bar-height) + var(--space-3));
-        /* Bottom padding reduced now that BottomNav is an in-flow flex child.
-           The previous calc(var(--bottom-nav-height) + ...) reservation was
-           required only when the nav was position:fixed. */
-        padding-bottom: var(--space-3);
         max-width: 640px;
         width: 100%;
         margin: 0 auto;

--- a/src/app.css
+++ b/src/app.css
@@ -62,12 +62,7 @@
     --space-6: 1.5rem;
     --space-8: 2rem;
 
-    /* Layout
-       The JS in main.js keeps --real-vh in sync with the best available
-       visual viewport measurement (preferring visualViewport.height on
-       iOS PWA). The 100svh fallback is deliberately conservative; it is
-       overridden at runtime on iOS standalone where dvh/svh/innerHeight
-       are known to be unreliable on cold start. */
+    /* Layout */
     --top-bar-height: calc(48px + env(safe-area-inset-top, 0px));
     --bottom-nav-height: calc(56px + env(safe-area-inset-bottom, 0px));
     --safe-top: env(safe-area-inset-top, 0px);

--- a/src/lib/components/layout/BottomNav.svelte
+++ b/src/lib/components/layout/BottomNav.svelte
@@ -13,7 +13,7 @@
 </script>
 
 <nav class="bottom-nav">
-  {#each tabs as tab}
+  {#each tabs as tab (tab.id)}
     <button type="button"
       class="tab"
       class:active={store.activeView === tab.id}
@@ -27,14 +27,9 @@
 
 <style>
   .bottom-nav {
-    /* In-flow at the bottom of the .app-shell flex column (no longer fixed).
-       The shell's height is locked to --real-vh (from window.innerHeight).
-       This removes the fixed positioning vs. viewport measurement mismatches
-       that were causing whitespace below the nav on installed iOS PWAs.
-       Height still includes the safe area so the background extends under
-       the home indicator. */
+    /* The app shell owns viewport anchoring; this row stays in normal grid
+       flow and extends through the bottom safe area. */
     height: var(--bottom-nav-height);
-    flex-shrink: 0;
     display: flex;
     align-items: stretch;
     background: var(--paper);

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -184,10 +184,7 @@
 
 <style>
   .top-bar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
+    position: relative;
     height: var(--top-bar-height);
     padding-top: env(safe-area-inset-top, 0px);
     display: grid;

--- a/src/main.js
+++ b/src/main.js
@@ -3,52 +3,6 @@ import "./app.css";
 import { registerSW } from "virtual:pwa-register";
 import App from "./App.svelte";
 
-// Prevent the browser / iOS PWA runtime from restoring a stale scroll
-// position on cold-start.  Without this, iOS will replay whatever scrollY
-// the user had last session onto the freshly-mounted (and possibly shorter)
-// idle layout, producing phantom whitespace below the hero card.
-if ("scrollRestoration" in history) {
-    history.scrollRestoration = "manual";
-}
-
-// iOS standalone PWA: 100dvh / 100svh and window.innerHeight are frequently
-// wrong or stale on cold start, orientation, and some PWA launches. We
-// prefer window.visualViewport.height when available (this is the value
-// WebKit actually uses for the visual content area in many installed PWA
-// scenarios). We also do extra settling measurements on iOS standalone.
-function syncAppHeight() {
-    const vv = window.visualViewport;
-    const h = vv && typeof vv.height === "number" && vv.height > 0 ? vv.height : window.innerHeight;
-    document.documentElement.style.setProperty("--real-vh", `${h}px`);
-}
-
-syncAppHeight();
-window.addEventListener("resize", syncAppHeight);
-// pageshow fires on back-forward cache restore where resize may not fire
-window.addEventListener("pageshow", syncAppHeight);
-
-// visualViewport events are the most reliable signal on iOS for PWA window
-// size changes (keyboard, rotation, some cold-start corrections).
-if (window.visualViewport) {
-    window.visualViewport.addEventListener("resize", syncAppHeight);
-    // scroll can fire during settling on some iOS PWA launches
-    window.visualViewport.addEventListener("scroll", syncAppHeight);
-}
-
-// Extra aggressive settling for installed iOS PWA. visualViewport and
-// innerHeight can take a few frames (or a user gesture) to report the
-// true visual bounds. We re-measure a few times after first paint.
-const isStandalone = window.matchMedia?.("(display-mode: standalone)").matches || window.navigator?.standalone === true;
-
-if (isStandalone) {
-    // Run a few settling syncs. These are cheap and have prevented the
-    // "whitespace below nav / floating UI" symptom on real devices in the past.
-    requestAnimationFrame(() => syncAppHeight());
-    setTimeout(syncAppHeight, 120);
-    setTimeout(syncAppHeight, 350);
-    setTimeout(syncAppHeight, 800);
-}
-
 registerSW({ immediate: true });
 
 const app = mount(App, {

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -131,4 +131,34 @@ test.describe("Top bar visibility", () => {
         await expect(shell.songsTab).toHaveClass(/active/);
         await expect(shell.rollTab).not.toHaveClass(/active/);
     });
+
+    test("app chrome anchors the bottom nav to the viewport bottom", async ({ page, app }) => {
+        await page.setViewportSize({ width: 390, height: 600 });
+        await app.seed(buildSeed());
+        await app.goto();
+        await app.waitForReady();
+
+        const chrome = await page.locator(".app-shell").evaluate((shell) => {
+            const nav = shell.querySelector("nav.bottom-nav");
+            const main = shell.querySelector(".main-content");
+            const navRect = nav?.getBoundingClientRect();
+            const shellStyles = getComputedStyle(shell);
+            const mainStyles = main ? getComputedStyle(main) : null;
+
+            return {
+                shellPosition: shellStyles.position,
+                shellInsetTop: shellStyles.top,
+                shellInsetBottom: shellStyles.bottom,
+                mainOverflowY: mainStyles?.overflowY,
+                navBottom: navRect?.bottom ?? 0,
+                viewportHeight: window.innerHeight,
+            };
+        });
+
+        expect(chrome.shellPosition).toBe("fixed");
+        expect(chrome.shellInsetTop).toBe("0px");
+        expect(chrome.shellInsetBottom).toBe("0px");
+        expect(chrome.mainOverflowY).toBe("auto");
+        expect(Math.abs(chrome.viewportHeight - chrome.navBottom)).toBeLessThanOrEqual(1);
+    });
 });

--- a/tests/e2e/roll.spec.ts
+++ b/tests/e2e/roll.spec.ts
@@ -325,14 +325,11 @@ test.describe("Roll screen — hero scroll behavior", () => {
         // top: var(--top-bar-height).
         //
         // Earlier iterations of this test depended on a rolled setlist's
-        // size to make the page tall enough to scroll. That was flaky on
-        // desktop chromium — a short rolled setlist plus a 600px viewport
-        // means scrollIntoViewIfNeeded sees nothing to do, and
-        // window.scrollTo silently no-ops. Decouple the test from
-        // generation entirely: inject a tall spacer at the bottom of the
-        // body so the document is guaranteed to overflow, then drive a
-        // known scroll amount via document.documentElement.scrollTop and
-        // confirm it committed before reading the hero's bbox.
+        // size to make the page tall enough to scroll. Decouple the test
+        // from generation entirely: inject a tall spacer into the app's
+        // dedicated scroll region, then drive a known scroll amount on
+        // .main-content and confirm it committed before reading the hero's
+        // bbox.
         await app.seed(seedWithCatalog());
         await app.goto();
         await app.waitForReady();
@@ -344,25 +341,25 @@ test.describe("Roll screen — hero scroll behavior", () => {
         expect(initialBox).not.toBeNull();
         const initialTop = initialBox?.y ?? 0;
 
-        // Force scrollable height on body.
+        // Force scrollable height inside the app's scroll container.
         await page.evaluate(() => {
             const spacer = document.createElement("div");
             spacer.id = "__hero_scroll_spacer";
             spacer.style.cssText = "height: 2000px; pointer-events: none;";
-            document.body.appendChild(spacer);
+            document.querySelector(".roll-screen")?.appendChild(spacer);
         });
 
         const SCROLL_BY = 600;
         await page.evaluate((y) => {
-            const se = (document.scrollingElement || document.documentElement) as HTMLElement;
-            se.scrollTop = y;
+            const se = document.querySelector(".main-content") as HTMLElement | null;
+            if (se) se.scrollTop = y;
         }, SCROLL_BY);
         // Verify the scroll commit so we don't false-pass when scrollTop
         // is silently rejected (would mean a scroll-trapping bug).
         await page.waitForFunction(
             (y) => {
-                const se = (document.scrollingElement || document.documentElement) as HTMLElement;
-                return se.scrollTop >= y - 1;
+                const se = document.querySelector(".main-content") as HTMLElement | null;
+                return !!se && se.scrollTop >= y - 1;
             },
             SCROLL_BY,
             { timeout: 2_000 },


### PR DESCRIPTION
## Summary
- Replace the JS-measured viewport-height app shell with a fixed inset grid shell.
- Keep the top bar and bottom nav as normal shell rows while only .main-content scrolls.
- Remove obsolete iOS PWA viewport measurement and scroll nudge code.
- Add mobile regression coverage for bottom-nav viewport anchoring and main-content scrolling.

## Verification
- npm run build
- npm run lint
- npx @sveltejs/mcp svelte-autofixer ./src/App.svelte --svelte-version 5
- npx @sveltejs/mcp svelte-autofixer ./src/lib/components/layout/TopBar.svelte --svelte-version 5
- npx @sveltejs/mcp svelte-autofixer ./src/lib/components/layout/BottomNav.svelte --svelte-version 5
- npx playwright test tests/e2e/navigation.spec.ts tests/e2e/roll.spec.ts --project=mobile
- npx vitest run src tests --exclude ".claude/**" --exclude "tests/e2e/**" --exclude "tests/real-e2e/**" --exclude "tests/pages/**" --exclude "tests/fixtures/**" --exclude "node_modules/**" --exclude "dist/**"

Note: plain npm test is currently affected by local .claude/worktrees test copies being collected by Vitest in this workspace; CI should not have those local worktrees.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured app layout system for improved viewport handling and responsive behavior.
  * Simplified navigation bar positioning and layout calculations.
  * Removed iOS-specific scroll restoration logic for streamlined performance.

* **Tests**
  * Updated end-to-end tests to verify updated navigation and content scroll behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/setlist-roller/pull/116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->