### PR TITLE
fix(ios): restore fixed app chrome

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -344,19 +344,20 @@
 
     /* ---- App shell ---- */
     .app-shell {
-        position: fixed;
-        inset: 0;
-        display: grid;
-        grid-template-rows: auto minmax(0, 1fr) auto;
-        overflow: hidden;
+        height: var(--real-vh, 100dvh);
+        display: flex;
+        flex-direction: column;
     }
 
     .main-content {
+        flex: 1;
         min-height: 0;
         overflow-y: auto;
         -webkit-overflow-scrolling: touch;
         overscroll-behavior: contain;
         padding: var(--space-3);
+        padding-top: calc(var(--top-bar-height) + var(--space-3));
+        padding-bottom: calc(var(--bottom-nav-height) + var(--space-3));
         max-width: 640px;
         width: 100%;
         margin: 0 auto;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -204,9 +204,10 @@
 <style>
     /* ---- Connect screen ---- */
     .connect-shell {
-        min-height: 100svh;
+        height: 100%;
         display: grid;
         place-items: center;
+        overflow-y: auto;
         padding: var(--space-4);
     }
 
@@ -241,9 +242,10 @@
 
     /* ---- Sync screen ---- */
     .sync-shell {
-        min-height: 100svh;
+        height: 100%;
         display: grid;
         place-items: center;
+        overflow-y: auto;
         padding: var(--space-4);
     }
 
@@ -345,12 +347,11 @@
     /* ---- App shell ---- */
     .app-shell {
         height: var(--real-vh, 100dvh);
-        display: flex;
-        flex-direction: column;
+        overflow: hidden;
     }
 
     .main-content {
-        flex: 1;
+        height: 100%;
         min-height: 0;
         overflow-y: auto;
         -webkit-overflow-scrolling: touch;

--- a/src/app.css
+++ b/src/app.css
@@ -131,6 +131,7 @@ body,
 html,
 body {
     overflow: hidden;
+    overscroll-behavior: none;
 }
 
 body {

--- a/src/app.css
+++ b/src/app.css
@@ -62,7 +62,12 @@
     --space-6: 1.5rem;
     --space-8: 2rem;
 
-    /* Layout */
+    /* Layout
+       These are the fixed chrome OUTER heights. They include the safe-area
+       inset so content can reserve the full covered region. TopBar/BottomNav
+       also apply the same inset as internal padding; with global border-box
+       sizing that positions controls away from device edges without increasing
+       the outer fixed height. */
     --top-bar-height: calc(48px + env(safe-area-inset-top, 0px));
     --bottom-nav-height: calc(56px + env(safe-area-inset-bottom, 0px));
     --safe-top: env(safe-area-inset-top, 0px);
@@ -116,11 +121,16 @@ html,
 body,
 #app {
     margin: 0;
-    min-height: 100%;
+    height: 100%;
     /* Prevent iOS Safari from auto-inflating text (which can interact with the
        16px input-zoom threshold below). Keep text sizing deterministic. */
     -webkit-text-size-adjust: 100%;
     text-size-adjust: 100%;
+}
+
+html,
+body {
+    overflow: hidden;
 }
 
 body {

--- a/src/lib/components/layout/BottomNav.svelte
+++ b/src/lib/components/layout/BottomNav.svelte
@@ -27,8 +27,10 @@
 
 <style>
   .bottom-nav {
-    /* The app shell owns viewport anchoring; this row stays in normal grid
-       flow and extends through the bottom safe area. */
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
     height: var(--bottom-nav-height);
     display: flex;
     align-items: stretch;

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -184,7 +184,10 @@
 
 <style>
   .top-bar {
-    position: relative;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
     height: var(--top-bar-height);
     padding-top: env(safe-area-inset-top, 0px);
     display: grid;

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,27 @@ import "./app.css";
 import { registerSW } from "virtual:pwa-register";
 import App from "./App.svelte";
 
+// Prevent the browser / iOS PWA runtime from restoring a stale scroll
+// position on cold-start. Without this, iOS can replay a scrollY from the
+// previous session onto the freshly-mounted app shell.
+if ("scrollRestoration" in history) {
+    history.scrollRestoration = "manual";
+}
+
+// Keep the shell height tied to the initial layout viewport value that iOS
+// standalone exposes most consistently for fixed chrome. The fixed top/bottom
+// bars do not depend on this for anchoring; content uses it for its scroll box.
+function syncAppHeight() {
+    document.documentElement.style.setProperty("--real-vh", `${window.innerHeight}px`);
+}
+
+syncAppHeight();
+window.addEventListener("resize", syncAppHeight);
+window.addEventListener("pageshow", syncAppHeight);
+if (window.visualViewport) {
+    window.visualViewport.addEventListener("resize", syncAppHeight);
+}
+
 registerSW({ immediate: true });
 
 const app = mount(App, {

--- a/src/main.js
+++ b/src/main.js
@@ -28,6 +28,8 @@ function syncAppHeight() {
 
 setAppHeight();
 window.addEventListener("resize", syncAppHeight);
+// Rotation should also re-sync even on iOS builds that coalesce or delay resize.
+window.addEventListener("orientationchange", syncAppHeight);
 // Re-sync on bfcache restore: iOS may change orientation while backgrounded.
 window.addEventListener("pageshow", syncAppHeight);
 if (window.visualViewport) {

--- a/src/main.js
+++ b/src/main.js
@@ -10,15 +10,25 @@ if ("scrollRestoration" in history) {
     history.scrollRestoration = "manual";
 }
 
-// Keep the shell height tied to the initial layout viewport value that iOS
-// standalone exposes most consistently for fixed chrome. The fixed top/bottom
-// bars do not depend on this for anchoring; content uses it for its scroll box.
-function syncAppHeight() {
+function setAppHeight() {
     document.documentElement.style.setProperty("--real-vh", `${window.innerHeight}px`);
 }
 
-syncAppHeight();
+// Keep the shell height tied to the initial layout viewport value that iOS
+// standalone exposes most consistently for fixed chrome. The fixed top/bottom
+// bars do not depend on this for anchoring; content uses it for its scroll box.
+let appHeightRaf = 0;
+function syncAppHeight() {
+    if (appHeightRaf) return;
+    appHeightRaf = requestAnimationFrame(() => {
+        appHeightRaf = 0;
+        setAppHeight();
+    });
+}
+
+setAppHeight();
 window.addEventListener("resize", syncAppHeight);
+// Re-sync on bfcache restore: iOS may change orientation while backgrounded.
 window.addEventListener("pageshow", syncAppHeight);
 if (window.visualViewport) {
     window.visualViewport.addEventListener("resize", syncAppHeight);

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -143,12 +143,15 @@ test.describe("Top bar visibility", () => {
             const top = document.querySelector("header.top-bar");
             const main = document.querySelector(".main-content");
             const navRect = nav?.getBoundingClientRect();
+            const topRect = top?.getBoundingClientRect();
             const topStyles = top ? getComputedStyle(top) : null;
             const navStyles = nav ? getComputedStyle(nav) : null;
             const mainStyles = main ? getComputedStyle(main) : null;
 
             return {
                 topPosition: topStyles?.position,
+                topTopStyle: topStyles?.top,
+                topTop: topRect?.top ?? -1,
                 navPosition: navStyles?.position,
                 navBottomStyle: navStyles?.bottom,
                 mainOverflowY: mainStyles?.overflowY,
@@ -158,6 +161,8 @@ test.describe("Top bar visibility", () => {
         });
 
         expect(chrome.topPosition).toBe("fixed");
+        expect(chrome.topTopStyle).toBe("0px");
+        expect(Math.abs(chrome.topTop)).toBeLessThanOrEqual(1);
         expect(chrome.navPosition).toBe("fixed");
         expect(chrome.navBottomStyle).toBe("0px");
         expect(chrome.mainOverflowY).toBe("auto");

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -132,32 +132,34 @@ test.describe("Top bar visibility", () => {
         await expect(shell.rollTab).not.toHaveClass(/active/);
     });
 
-    test("app chrome anchors the bottom nav to the viewport bottom", async ({ page, app }) => {
+    test("fixed chrome anchors the bottom nav to the viewport bottom", async ({ page, app }) => {
         await page.setViewportSize({ width: 390, height: 600 });
         await app.seed(buildSeed());
         await app.goto();
         await app.waitForReady();
 
-        const chrome = await page.locator(".app-shell").evaluate((shell) => {
-            const nav = shell.querySelector("nav.bottom-nav");
-            const main = shell.querySelector(".main-content");
+        const chrome = await page.evaluate(() => {
+            const nav = document.querySelector("nav.bottom-nav");
+            const top = document.querySelector("header.top-bar");
+            const main = document.querySelector(".main-content");
             const navRect = nav?.getBoundingClientRect();
-            const shellStyles = getComputedStyle(shell);
+            const topStyles = top ? getComputedStyle(top) : null;
+            const navStyles = nav ? getComputedStyle(nav) : null;
             const mainStyles = main ? getComputedStyle(main) : null;
 
             return {
-                shellPosition: shellStyles.position,
-                shellInsetTop: shellStyles.top,
-                shellInsetBottom: shellStyles.bottom,
+                topPosition: topStyles?.position,
+                navPosition: navStyles?.position,
+                navBottomStyle: navStyles?.bottom,
                 mainOverflowY: mainStyles?.overflowY,
                 navBottom: navRect?.bottom ?? 0,
                 viewportHeight: window.innerHeight,
             };
         });
 
-        expect(chrome.shellPosition).toBe("fixed");
-        expect(chrome.shellInsetTop).toBe("0px");
-        expect(chrome.shellInsetBottom).toBe("0px");
+        expect(chrome.topPosition).toBe("fixed");
+        expect(chrome.navPosition).toBe("fixed");
+        expect(chrome.navBottomStyle).toBe("0px");
         expect(chrome.mainOverflowY).toBe("auto");
         expect(Math.abs(chrome.viewportHeight - chrome.navBottom)).toBeLessThanOrEqual(1);
     });

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -133,6 +133,8 @@ test.describe("Top bar visibility", () => {
     });
 
     test("fixed chrome anchors the bottom nav to the viewport bottom", async ({ page, app }) => {
+        // Chromium cannot reproduce installed iOS PWA rubber-band/safe-area bugs;
+        // this guards the static CSS invariant before real-device verification.
         await page.setViewportSize({ width: 390, height: 600 });
         await app.seed(buildSeed());
         await app.goto();


### PR DESCRIPTION
## Summary
- Restore the app's fixed chrome invariant: TopBar and BottomNav are independently position:fixed.
- Return .main-content to reserving top/bottom chrome space with padding.
- Restore lightweight innerHeight-based --real-vh sync for the content shell only; nav placement no longer depends on shell flow.
- Update the nav anchoring regression to assert fixed chrome instead of fixed app-shell rows.

## Backstory / Review Context
The app is intended to have fixed chrome:
- Top bar: band name, connection status, menu.
- Bottom bar: tab navigation.
- Middle area: scrollable screen content.

The top and bottom chrome should not move with content scroll.

Previous fix attempts changed the shell architecture so the top bar, content, and bottom nav became rows inside a fixed app-shell grid. That looked reasonable in desktop/mobile browser tests, but on a real installed iOS PWA it still left a persistent white area below the bottom nav. During touch-drag/rubber-band scrolling, the bottom nav visibly moved with the page layer, proving the nav was participating in the app shell's scroll/compositor layer instead of being independent fixed chrome.

Historically, the app worked better when TopBar and BottomNav were independently position:fixed, with .main-content reserving space using top/bottom padding. The bug was initially only visible on cold/first render with short content; navigating to a longer screen caused iOS/WebKit to settle the layout and the fixed nav stayed correctly anchored afterward.

This PR intentionally returns to that working invariant. It is not trying to invent a new layout model. The fixed-grid shell made iOS PWA rubber-band behavior affect the nav, so this restores independent fixed chrome and keeps scrolling isolated to content.

## Review Focus
- Confirm TopBar and BottomNav are independent fixed chrome.
- Confirm .main-content reserves enough top/bottom space for fixed bars and remains the scroll region.
- Confirm --real-vh is only used for content shell sizing, not for determining nav placement.
- Confirm the regression test asserts the fixed chrome invariant rather than the reverted fixed-grid shell model.

## Local verification
- npm run build
- npm run lint
- npx @sveltejs/mcp svelte-autofixer ./src/App.svelte --svelte-version 5
- npx @sveltejs/mcp svelte-autofixer ./src/lib/components/layout/BottomNav.svelte --svelte-version 5
- npx @sveltejs/mcp svelte-autofixer ./src/lib/components/layout/TopBar.svelte --svelte-version 5
- npx vitest run src tests --exclude ".claude/**" --exclude "tests/e2e/**" --exclude "tests/real-e2e/**" --exclude "tests/pages/**" --exclude "tests/fixtures/**" --exclude "node_modules/**" --exclude "dist/**"

Docker-backed Playwright validation intentionally left to PR CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Top and bottom navigation bars now remain fixed while scrolling; main content is a dedicated scroll container.
* **New Features**
  * Improved handling of viewport height on mobile/PWA to keep layout consistent across resizes and orientation changes.
* **Tests**
  * End-to-end tests updated to validate fixed header/footer positioning and main-content scrolling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/setlist-roller/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->