### PR TITLE
chore(ios): add viewport diagnostics panel

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -18,6 +18,9 @@
     setContext("app", store);
 
     // TEMP(iOS diagnostics): remove after the installed-PWA viewport gap is fixed.
+    const viewportDiagnosticsEnabled = import.meta.env.DEV || (typeof window !== "undefined" && (
+        window.matchMedia?.("(display-mode: standalone)").matches || window.navigator?.standalone === true
+    ));
     let diagnosticsOpen = $state(false);
 
     if (typeof window !== "undefined" && window.__SR_TEST__) {
@@ -74,9 +77,11 @@
                 Connect to remoteStorage so your songs survive the tour bus.
             </p>
 
-            <button type="button" class="debug-link" onclick={() => { diagnosticsOpen = true; }}>
-                Viewport Diagnostics
-            </button>
+            {#if viewportDiagnosticsEnabled}
+                <button type="button" class="debug-link" onclick={() => { diagnosticsOpen = true; }}>
+                    Viewport Diagnostics
+                </button>
+            {/if}
 
             <label class="field">
                 <span>remoteStorage address</span>
@@ -127,9 +132,11 @@
                 <span class="spinner"></span>
                 {store.syncStatusLabel}
             </div>
-            <button type="button" class="debug-link" onclick={() => { diagnosticsOpen = true; }}>
-                Viewport Diagnostics
-            </button>
+            {#if viewportDiagnosticsEnabled}
+                <button type="button" class="debug-link" onclick={() => { diagnosticsOpen = true; }}>
+                    Viewport Diagnostics
+                </button>
+            {/if}
             {#if store.syncLogEntries.length > 0}
                 <div class="sync-console" role="log" aria-live="polite">
                     {#each store.syncLogEntries as entry (entry.id)}
@@ -173,7 +180,7 @@
     </div>
 {/if}
 
-{#if diagnosticsOpen}
+{#if viewportDiagnosticsEnabled && diagnosticsOpen}
     <ViewportDiagnostics onClose={() => { diagnosticsOpen = false; }} />
 {/if}
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -4,6 +4,7 @@
     import HelpScreen from "./lib/components/help/HelpScreen.svelte";
     import BottomNav from "./lib/components/layout/BottomNav.svelte";
     import TopBar from "./lib/components/layout/TopBar.svelte";
+    import ViewportDiagnostics from "./lib/components/layout/ViewportDiagnostics.svelte";
     import RollScreen from "./lib/components/roll/RollScreen.svelte";
     import SavedScreen from "./lib/components/saved/SavedScreen.svelte";
     import SongsScreen from "./lib/components/songs/SongsScreen.svelte";
@@ -15,6 +16,9 @@
     const repo = createRemoteStorageRepository();
     const store = createAppStore(repo);
     setContext("app", store);
+
+    // TEMP(iOS diagnostics): remove after the installed-PWA viewport gap is fixed.
+    let diagnosticsOpen = $state(false);
 
     if (typeof window !== "undefined" && window.__SR_TEST__) {
         // Test-mode escape hatch: expose the store + repo on window so
@@ -70,6 +74,10 @@
                 Connect to remoteStorage so your songs survive the tour bus.
             </p>
 
+            <button type="button" class="debug-link" onclick={() => { diagnosticsOpen = true; }}>
+                Viewport Diagnostics
+            </button>
+
             <label class="field">
                 <span>remoteStorage address</span>
                 <input
@@ -119,6 +127,9 @@
                 <span class="spinner"></span>
                 {store.syncStatusLabel}
             </div>
+            <button type="button" class="debug-link" onclick={() => { diagnosticsOpen = true; }}>
+                Viewport Diagnostics
+            </button>
             {#if store.syncLogEntries.length > 0}
                 <div class="sync-console" role="log" aria-live="polite">
                     {#each store.syncLogEntries as entry (entry.id)}
@@ -160,6 +171,10 @@
 
         <BottomNav />
     </div>
+{/if}
+
+{#if diagnosticsOpen}
+    <ViewportDiagnostics onClose={() => { diagnosticsOpen = false; }} />
 {/if}
 
 {#if store.showFirstRunPrompt}
@@ -238,6 +253,18 @@
 
     .lede {
         color: var(--muted);
+    }
+
+    .debug-link {
+        justify-self: start;
+        min-height: 44px;
+        padding: 0.6rem 0.85rem;
+        border: 1px dashed var(--accent-line);
+        border-radius: var(--radius-md);
+        background: var(--accent-soft);
+        color: var(--accent-strong);
+        font-size: 16px;
+        font-weight: 800;
     }
 
     /* ---- Sync screen ---- */

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -1,10 +1,12 @@
 <script>
   import { getContext, tick } from "svelte";
   import { cycleTheme, getThemePreference } from "../../theme.svelte.js";
+  import ViewportDiagnostics from "./ViewportDiagnostics.svelte";
 
   const store = getContext("app");
 
   let menuOpen = $state(false);
+  let diagnosticsOpen = $state(false);
   let menuBtnEl = $state();
   let dropdownEl = $state();
   const themeLabel = { system: "◐ System", light: "☀ Light", dark: "☽ Dark" };
@@ -15,6 +17,11 @@
 
   function closeMenu() {
     menuOpen = false;
+  }
+
+  function openDiagnostics() {
+    closeMenu();
+    diagnosticsOpen = true;
   }
 
   let currentAccount = $derived(
@@ -176,11 +183,18 @@
 
           <div class="dropdown-divider"></div>
           <button type="button" class="dropdown-item" onclick={cycleTheme}>Theme: {themeLabel[getThemePreference()]}</button>
+
+          <div class="dropdown-divider"></div>
+          <button type="button" class="dropdown-item" onclick={openDiagnostics}>Viewport Diagnostics</button>
         </div>
       {/if}
     </div>
   </div>
 </header>
+
+{#if diagnosticsOpen}
+  <ViewportDiagnostics onClose={() => { diagnosticsOpen = false; }} />
+{/if}
 
 <style>
   .top-bar {

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -24,6 +24,12 @@
     diagnosticsOpen = true;
   }
 
+  async function closeDiagnostics() {
+    diagnosticsOpen = false;
+    await tick();
+    menuBtnEl?.focus();
+  }
+
   let currentAccount = $derived(
     store.knownAccounts.find((a) => a.address === store.connectAddress)
   );
@@ -193,7 +199,7 @@
 </header>
 
 {#if diagnosticsOpen}
-  <ViewportDiagnostics onClose={() => { diagnosticsOpen = false; }} />
+  <ViewportDiagnostics onClose={closeDiagnostics} />
 {/if}
 
 <style>

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -4,6 +4,11 @@
   import ViewportDiagnostics from "./ViewportDiagnostics.svelte";
 
   const store = getContext("app");
+  // TEMP(iOS diagnostics): keep this reachable in installed PWA builds until
+  // the viewport gap is measured and fixed.
+  const viewportDiagnosticsEnabled = import.meta.env.DEV || (typeof window !== "undefined" && (
+    window.matchMedia?.("(display-mode: standalone)").matches || window.navigator?.standalone === true
+  ));
 
   let menuOpen = $state(false);
   let diagnosticsOpen = $state(false);
@@ -190,15 +195,17 @@
           <div class="dropdown-divider"></div>
           <button type="button" class="dropdown-item" onclick={cycleTheme}>Theme: {themeLabel[getThemePreference()]}</button>
 
-          <div class="dropdown-divider"></div>
-          <button type="button" class="dropdown-item" onclick={openDiagnostics}>Viewport Diagnostics</button>
+          {#if viewportDiagnosticsEnabled}
+            <div class="dropdown-divider"></div>
+            <button type="button" class="dropdown-item" onclick={openDiagnostics}>Viewport Diagnostics</button>
+          {/if}
         </div>
       {/if}
     </div>
   </div>
 </header>
 
-{#if diagnosticsOpen}
+{#if viewportDiagnosticsEnabled && diagnosticsOpen}
   <ViewportDiagnostics onClose={closeDiagnostics} />
 {/if}
 

--- a/src/lib/components/layout/ViewportDiagnostics.svelte
+++ b/src/lib/components/layout/ViewportDiagnostics.svelte
@@ -1,0 +1,252 @@
+<script>
+  import { onMount } from "svelte";
+
+  let { onClose } = $props();
+
+  let diagnostics = $state({});
+  let copied = $state(false);
+
+  function round(value) {
+    return typeof value === "number" ? Math.round(value * 100) / 100 : value;
+  }
+
+  function rectFor(selector) {
+    const el = document.querySelector(selector);
+    if (!el) return null;
+    const rect = el.getBoundingClientRect();
+    return {
+      top: round(rect.top),
+      bottom: round(rect.bottom),
+      height: round(rect.height),
+      left: round(rect.left),
+      right: round(rect.right),
+      width: round(rect.width),
+    };
+  }
+
+  function collectDiagnostics() {
+    const root = document.documentElement;
+    const body = document.body;
+    const app = document.getElementById("app");
+    const shell = document.querySelector(".app-shell");
+    const main = document.querySelector(".main-content");
+    const navRect = rectFor("nav.bottom-nav");
+    const rootStyles = getComputedStyle(root);
+
+    diagnostics = {
+      capturedAt: new Date().toISOString(),
+      mode: {
+        userAgent: navigator.userAgent,
+        standaloneMedia: window.matchMedia?.("(display-mode: standalone)").matches ?? null,
+        navigatorStandalone: navigator.standalone ?? null,
+      },
+      window: {
+        innerWidth: round(window.innerWidth),
+        innerHeight: round(window.innerHeight),
+        outerWidth: round(window.outerWidth),
+        outerHeight: round(window.outerHeight),
+        scrollX: round(window.scrollX),
+        scrollY: round(window.scrollY),
+        devicePixelRatio: round(window.devicePixelRatio),
+      },
+      screen: {
+        width: round(screen.width),
+        height: round(screen.height),
+        availWidth: round(screen.availWidth),
+        availHeight: round(screen.availHeight),
+        orientation: screen.orientation?.type ?? null,
+      },
+      visualViewport: window.visualViewport
+        ? {
+            width: round(window.visualViewport.width),
+            height: round(window.visualViewport.height),
+            offsetTop: round(window.visualViewport.offsetTop),
+            offsetLeft: round(window.visualViewport.offsetLeft),
+            pageTop: round(window.visualViewport.pageTop),
+            pageLeft: round(window.visualViewport.pageLeft),
+            scale: round(window.visualViewport.scale),
+          }
+        : null,
+      document: {
+        documentElementClientHeight: round(root.clientHeight),
+        documentElementScrollHeight: round(root.scrollHeight),
+        bodyClientHeight: round(body?.clientHeight),
+        bodyScrollHeight: round(body?.scrollHeight),
+        appClientHeight: round(app?.clientHeight),
+        appScrollHeight: round(app?.scrollHeight),
+      },
+      css: {
+        realVh: rootStyles.getPropertyValue("--real-vh").trim() || null,
+        safeTop: rootStyles.getPropertyValue("--safe-top").trim() || null,
+        safeBottom: rootStyles.getPropertyValue("--safe-bottom").trim() || null,
+        topBarHeight: rootStyles.getPropertyValue("--top-bar-height").trim() || null,
+        bottomNavHeight: rootStyles.getPropertyValue("--bottom-nav-height").trim() || null,
+      },
+      layout: {
+        appShellHeight: shell ? round(shell.getBoundingClientRect().height) : null,
+        mainContentHeight: main ? round(main.getBoundingClientRect().height) : null,
+        topBarRect: rectFor("header.top-bar"),
+        bottomNavRect: navRect,
+        gapBelowNavFromInnerHeight: navRect ? round(window.innerHeight - navRect.bottom) : null,
+        gapBelowNavFromDocumentClientHeight: navRect ? round(root.clientHeight - navRect.bottom) : null,
+        gapBelowNavFromVisualViewport: navRect && window.visualViewport
+          ? round(window.visualViewport.height - navRect.bottom)
+          : null,
+      },
+    };
+  }
+
+  let diagnosticsText = $derived(JSON.stringify(diagnostics, null, 2));
+
+  async function copyDiagnostics() {
+    copied = false;
+    await navigator.clipboard.writeText(diagnosticsText);
+    copied = true;
+  }
+
+  onMount(() => {
+    let timeoutIds = [];
+    let intervalId;
+
+    collectDiagnostics();
+
+    const schedule = () => requestAnimationFrame(collectDiagnostics);
+    window.addEventListener("resize", schedule);
+    window.addEventListener("orientationchange", schedule);
+    window.addEventListener("pageshow", schedule);
+    window.visualViewport?.addEventListener("resize", schedule);
+    window.visualViewport?.addEventListener("scroll", schedule);
+
+    intervalId = window.setInterval(collectDiagnostics, 250);
+    timeoutIds.push(window.setTimeout(() => window.clearInterval(intervalId), 5000));
+    for (const delay of [50, 120, 350, 800, 1500, 3000]) {
+      timeoutIds.push(window.setTimeout(collectDiagnostics, delay));
+    }
+
+    return () => {
+      window.removeEventListener("resize", schedule);
+      window.removeEventListener("orientationchange", schedule);
+      window.removeEventListener("pageshow", schedule);
+      window.visualViewport?.removeEventListener("resize", schedule);
+      window.visualViewport?.removeEventListener("scroll", schedule);
+      window.clearInterval(intervalId);
+      for (const timeoutId of timeoutIds) window.clearTimeout(timeoutId);
+    };
+  });
+</script>
+
+<div class="diagnostics-backdrop" role="presentation" onclick={onClose}></div>
+<div class="diagnostics-sheet" role="dialog" aria-modal="true" aria-labelledby="viewport-diagnostics-title">
+  <div class="diagnostics-header">
+    <div>
+      <p class="eyebrow">Debug</p>
+      <h2 id="viewport-diagnostics-title">Viewport Diagnostics</h2>
+    </div>
+    <button type="button" class="icon-btn" onclick={onClose} aria-label="Close viewport diagnostics">&times;</button>
+  </div>
+
+  <div class="diagnostics-actions">
+    <button type="button" class="diag-btn primary" onclick={copyDiagnostics}>
+      {copied ? "Copied" : "Copy diagnostics"}
+    </button>
+    <button type="button" class="diag-btn" onclick={collectDiagnostics}>Refresh</button>
+  </div>
+
+  <pre>{diagnosticsText}</pre>
+</div>
+
+<style>
+  .diagnostics-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 500;
+    background: rgba(18, 24, 36, 0.42);
+    backdrop-filter: blur(4px);
+  }
+
+  .diagnostics-sheet {
+    position: fixed;
+    left: 12px;
+    right: 12px;
+    top: calc(var(--safe-top) + 12px);
+    bottom: calc(var(--safe-bottom) + 12px);
+    z-index: 501;
+    display: grid;
+    grid-template-rows: auto auto minmax(0, 1fr);
+    gap: 12px;
+    padding: 16px;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-lg);
+    background: var(--paper-strong);
+    box-shadow: var(--shadow);
+  }
+
+  .diagnostics-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .eyebrow {
+    margin: 0 0 4px;
+    color: var(--accent);
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+  }
+
+  h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    line-height: 1.1;
+  }
+
+  .icon-btn {
+    width: 44px;
+    min-height: 44px;
+    border: none;
+    border-radius: var(--radius-md);
+    background: var(--paper-soft);
+    color: var(--ink);
+    font-size: 24px;
+    line-height: 1;
+  }
+
+  .diagnostics-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .diag-btn {
+    min-height: 44px;
+    padding: 10px 14px;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-md);
+    background: var(--surface);
+    color: var(--ink);
+    font-size: 16px;
+    font-weight: 800;
+  }
+
+  .diag-btn.primary {
+    border-color: var(--accent-line);
+    background: var(--accent);
+    color: var(--on-accent);
+  }
+
+  pre {
+    min-height: 0;
+    margin: 0;
+    overflow: auto;
+    padding: 12px;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-md);
+    background: rgba(13, 18, 28, 0.92);
+    color: #edf2ff;
+    font: 12px/1.45 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    white-space: pre-wrap;
+  }
+</style>

--- a/src/lib/components/layout/ViewportDiagnostics.svelte
+++ b/src/lib/components/layout/ViewportDiagnostics.svelte
@@ -1,10 +1,17 @@
 <script>
-  import { onMount } from "svelte";
+  import { onMount, tick } from "svelte";
+
+  // TEMP(iOS diagnostics): remove this component after the installed-PWA
+  // viewport gap is measured and fixed.
 
   let { onClose } = $props();
 
   let diagnostics = $state({});
   let copied = $state(false);
+  let copyError = $state("");
+  let sheetEl = $state();
+  let closeBtnEl = $state();
+  let previousFocus = null;
 
   function round(value) {
     return typeof value === "number" ? Math.round(value * 100) / 100 : value;
@@ -97,52 +104,157 @@
   }
 
   let diagnosticsText = $derived(JSON.stringify(diagnostics, null, 2));
+  let findings = $derived.by(() => {
+    const layout = diagnostics.layout || {};
+    const mode = diagnostics.mode || {};
+    const viewport = diagnostics.visualViewport;
+    const items = [];
+
+    if (!mode.standaloneMedia && mode.navigatorStandalone !== true) {
+      items.push("Not detected as standalone PWA.");
+    }
+    if (Math.abs(layout.gapBelowNavFromInnerHeight || 0) > 2) {
+      items.push(`innerHeight/nav gap: ${layout.gapBelowNavFromInnerHeight}px`);
+    }
+    if (Math.abs(layout.gapBelowNavFromVisualViewport || 0) > 2) {
+      items.push(`visualViewport/nav gap: ${layout.gapBelowNavFromVisualViewport}px`);
+    }
+    if (viewport?.scale && viewport.scale !== 1) {
+      items.push(`visualViewport scale is ${viewport.scale}.`);
+    }
+    if (!diagnostics.css?.realVh) {
+      items.push("--real-vh is missing.");
+    }
+
+    return items.length > 0 ? items : ["No obvious viewport mismatch in current sample."];
+  });
+
+  function getFocusableElements() {
+    if (!sheetEl) return [];
+    return [
+      ...sheetEl.querySelectorAll(
+        'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    ];
+  }
+
+  function handleKeydown(e) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onClose?.();
+      return;
+    }
+
+    if (e.key === "Tab") {
+      const focusable = getFocusableElements();
+      if (focusable.length === 0) {
+        e.preventDefault();
+        sheetEl?.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (!sheetEl?.contains(active)) {
+        e.preventDefault();
+        first.focus();
+        return;
+      }
+
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
 
   async function copyDiagnostics() {
     copied = false;
-    await navigator.clipboard.writeText(diagnosticsText);
-    copied = true;
+    copyError = "";
+    try {
+      await navigator.clipboard.writeText(diagnosticsText);
+      copied = true;
+    } catch (error) {
+      copyError = error instanceof Error ? error.message : "Clipboard copy failed";
+    }
   }
 
   onMount(() => {
-    let timeoutIds = [];
-    let intervalId;
+    const timeoutIds = [];
+    let rafId = 0;
 
+    previousFocus = document.activeElement;
     collectDiagnostics();
 
-    const schedule = () => requestAnimationFrame(collectDiagnostics);
+    const schedule = () => {
+      if (rafId) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = 0;
+        collectDiagnostics();
+      });
+    };
+
+    tick().then(() => {
+      closeBtnEl?.focus();
+    });
+
+    window.addEventListener("keydown", handleKeydown);
     window.addEventListener("resize", schedule);
     window.addEventListener("orientationchange", schedule);
     window.addEventListener("pageshow", schedule);
     window.visualViewport?.addEventListener("resize", schedule);
     window.visualViewport?.addEventListener("scroll", schedule);
 
-    intervalId = window.setInterval(collectDiagnostics, 250);
-    timeoutIds.push(window.setTimeout(() => window.clearInterval(intervalId), 5000));
-    for (const delay of [50, 120, 350, 800, 1500, 3000]) {
+    for (const delay of [50, 250, 1000]) {
       timeoutIds.push(window.setTimeout(collectDiagnostics, delay));
     }
 
     return () => {
+      window.removeEventListener("keydown", handleKeydown);
       window.removeEventListener("resize", schedule);
       window.removeEventListener("orientationchange", schedule);
       window.removeEventListener("pageshow", schedule);
       window.visualViewport?.removeEventListener("resize", schedule);
       window.visualViewport?.removeEventListener("scroll", schedule);
-      window.clearInterval(intervalId);
+      if (rafId) cancelAnimationFrame(rafId);
       for (const timeoutId of timeoutIds) window.clearTimeout(timeoutId);
+      if (
+        previousFocus &&
+        typeof previousFocus.focus === "function" &&
+        document.body.contains(previousFocus)
+      ) {
+        previousFocus.focus();
+      }
+      previousFocus = null;
     };
   });
 </script>
 
-<div class="diagnostics-backdrop" role="presentation" onclick={onClose}></div>
-<div class="diagnostics-sheet" role="dialog" aria-modal="true" aria-labelledby="viewport-diagnostics-title">
+<div
+  class="diagnostics-sheet"
+  bind:this={sheetEl}
+  role="dialog"
+  aria-modal="false"
+  aria-labelledby="viewport-diagnostics-title"
+  tabindex="-1"
+>
   <div class="diagnostics-header">
     <div>
       <p class="eyebrow">Debug</p>
       <h2 id="viewport-diagnostics-title">Viewport Diagnostics</h2>
     </div>
-    <button type="button" class="icon-btn" onclick={onClose} aria-label="Close viewport diagnostics">&times;</button>
+    <button bind:this={closeBtnEl} type="button" class="icon-btn" onclick={onClose} aria-label="Close viewport diagnostics">&times;</button>
+  </div>
+
+  <div class="findings" aria-live="polite">
+    {#each findings as finding (finding)}
+      <p>{finding}</p>
+    {/each}
   </div>
 
   <div class="diagnostics-actions">
@@ -152,33 +264,33 @@
     <button type="button" class="diag-btn" onclick={collectDiagnostics}>Refresh</button>
   </div>
 
+  {#if copyError}
+    <p class="copy-error" role="alert">Copy failed: {copyError}</p>
+  {/if}
+
   <pre>{diagnosticsText}</pre>
 </div>
 
 <style>
-  .diagnostics-backdrop {
-    position: fixed;
-    inset: 0;
-    z-index: 500;
-    background: rgba(18, 24, 36, 0.42);
-    backdrop-filter: blur(4px);
-  }
-
   .diagnostics-sheet {
     position: fixed;
     left: 12px;
     right: 12px;
-    top: calc(var(--safe-top) + 12px);
-    bottom: calc(var(--safe-bottom) + 12px);
-    z-index: 501;
+    top: calc(var(--top-bar-height) + 8px);
+    bottom: calc(var(--bottom-nav-height) + 8px);
+    z-index: 250;
     display: grid;
-    grid-template-rows: auto auto minmax(0, 1fr);
+    grid-template-rows: auto auto auto auto minmax(0, 1fr);
     gap: 12px;
     padding: 16px;
     border: 1px solid var(--line);
     border-radius: var(--radius-lg);
     background: var(--paper-strong);
     box-shadow: var(--shadow);
+  }
+
+  .diagnostics-sheet:focus {
+    outline: none;
   }
 
   .diagnostics-header {
@@ -220,6 +332,26 @@
     gap: 8px;
   }
 
+  .findings {
+    display: grid;
+    gap: 4px;
+    padding: 10px 12px;
+    border: 1px solid var(--accent-line);
+    border-radius: var(--radius-md);
+    background: var(--accent-soft);
+  }
+
+  .findings p,
+  .copy-error {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.35;
+  }
+
+  .copy-error {
+    color: var(--danger);
+  }
+
   .diag-btn {
     min-height: 44px;
     padding: 10px 14px;
@@ -246,7 +378,7 @@
     border-radius: var(--radius-md);
     background: rgba(13, 18, 28, 0.92);
     color: #edf2ff;
-    font: 12px/1.45 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font: 13px/1.45 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
     white-space: pre-wrap;
   }
 </style>

--- a/src/lib/components/layout/ViewportDiagnostics.svelte
+++ b/src/lib/components/layout/ViewportDiagnostics.svelte
@@ -129,47 +129,10 @@
     return items.length > 0 ? items : ["No obvious viewport mismatch in current sample."];
   });
 
-  function getFocusableElements() {
-    if (!sheetEl) return [];
-    return [
-      ...sheetEl.querySelectorAll(
-        'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-      ),
-    ];
-  }
-
   function handleKeydown(e) {
     if (e.key === "Escape") {
       e.preventDefault();
       onClose?.();
-      return;
-    }
-
-    if (e.key === "Tab") {
-      const focusable = getFocusableElements();
-      if (focusable.length === 0) {
-        e.preventDefault();
-        sheetEl?.focus();
-        return;
-      }
-
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      const active = document.activeElement;
-
-      if (!sheetEl?.contains(active)) {
-        e.preventDefault();
-        first.focus();
-        return;
-      }
-
-      if (e.shiftKey && active === first) {
-        e.preventDefault();
-        last.focus();
-      } else if (!e.shiftKey && active === last) {
-        e.preventDefault();
-        first.focus();
-      }
     }
   }
 


### PR DESCRIPTION
## Summary
- add a temporary Viewport Diagnostics item to the top-bar menu
- collect live iOS PWA viewport, screen, document, CSS variable, and layout measurements
- provide copy/refresh controls so real-device diagnostics can be pasted back for analysis

## Testing
- npm run build
- npm run lint

Note: build still emits existing unrelated Svelte warnings in RollScreen, SavedScreen, SongEditor, and theme.svelte.js.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Viewport Diagnostics overlay added and conditionally enabled (iOS/standalone or dev); accessible from the top-bar menu and debug links on disconnected/initial sync screens.
  * Live captures of viewport, safe-area, visualViewport, document/app sizing and CSS vars, shown as pretty JSON with highlighted findings.
  * Refresh and copy-to-clipboard actions with transient feedback; Escape-to-close and focus restored to the invoking control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/setlist-roller/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->