### PR TITLE
fix(ios): avoid translucent PWA status bar gap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,14 @@
 
 Notes for anyone (human or AI) writing code in this repo.
 
+## Pull requests
+
+Always update from the latest `origin/master` before creating a PR. Branch new
+PR work from current `origin/master`, not from an older local branch or a branch
+whose predecessor PR has not yet been merged/deployed. If a PR is merged while
+work continues, rebase or recreate the follow-up branch on the updated
+`origin/master` before opening the next PR.
+
 ## CSS / UI
 
 ### Inputs must never be smaller than 16px on iOS

--- a/index.html
+++ b/index.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <!-- viewport-fit=cover is required for env(safe-area-inset-*) to expose
-         non-zero values on notched iPhones. Combined with the
-         apple-mobile-web-app-status-bar-style=black-translucent below, the
-         status bar overlays the page, so any element near the top edge
-         (modal close buttons, the top bar) MUST inset itself by
-         env(safe-area-inset-top) or it sits under the status bar. This is
-         the canonical viewport meta — App.svelte does not duplicate it. -->
+         non-zero values on notched iPhones. The PWA status bar must stay
+         non-translucent: black-translucent makes iOS start the webview at
+         physical y=0 while reporting only screen-height - safe-top, which
+         duplicates that missing safe-top-sized region as blank space at the
+         bottom of the installed app. This is the canonical viewport meta —
+         App.svelte does not duplicate it. -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta
       name="description"
@@ -17,7 +17,7 @@
     <title>Setlist Roller</title>
     <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="theme-color" content="#e15b37" />
     <!-- SYNC: key + resolution logic duplicated from src/lib/theme.svelte.js to avoid FOITC -->
     <script>

--- a/src/app.css
+++ b/src/app.css
@@ -70,7 +70,6 @@
        the outer fixed height. */
     --top-bar-height: calc(48px + env(safe-area-inset-top, 0px));
     --bottom-nav-height: calc(56px + env(safe-area-inset-bottom, 0px));
-    --fixed-bottom-offset: 0px;
     --safe-top: env(safe-area-inset-top, 0px);
     --safe-bottom: env(safe-area-inset-bottom, 0px);
 }

--- a/src/lib/components/layout/BottomNav.svelte
+++ b/src/lib/components/layout/BottomNav.svelte
@@ -28,7 +28,7 @@
 <style>
   .bottom-nav {
     position: fixed;
-    bottom: var(--fixed-bottom-offset, 0px);
+    bottom: 0;
     left: 0;
     right: 0;
     height: var(--bottom-nav-height);

--- a/src/lib/components/layout/ViewportDiagnostics.svelte
+++ b/src/lib/components/layout/ViewportDiagnostics.svelte
@@ -84,7 +84,6 @@
       },
       css: {
         realVh: rootStyles.getPropertyValue("--real-vh").trim() || null,
-        fixedBottomOffset: rootStyles.getPropertyValue("--fixed-bottom-offset").trim() || null,
         safeTop: rootStyles.getPropertyValue("--safe-top").trim() || null,
         safeBottom: rootStyles.getPropertyValue("--safe-bottom").trim() || null,
         topBarHeight: rootStyles.getPropertyValue("--top-bar-height").trim() || null,

--- a/src/main.js
+++ b/src/main.js
@@ -10,46 +10,14 @@ if ("scrollRestoration" in history) {
     history.scrollRestoration = "manual";
 }
 
-function readPxCustomProperty(name) {
-    const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
-    const parsed = Number.parseFloat(value);
-    return Number.isFinite(parsed) ? parsed : 0;
-}
-
-function isStandalonePwa() {
-    return window.matchMedia?.("(display-mode: standalone)").matches || window.navigator?.standalone === true;
-}
-
-function getAppHeight() {
-    const viewportHeight = window.innerHeight;
-
-    if (!isStandalonePwa()) return viewportHeight;
-
-    const physicalHeight = Math.max(screen.height || 0, window.outerHeight || 0);
-    const missingHeight = physicalHeight - viewportHeight;
-    const safeTop = readPxCustomProperty("--safe-top");
-
-    // iOS standalone can report innerHeight/visualViewport.height as the area
-    // below the status bar while still painting the full physical screen. When
-    // the missing region exactly matches safe-area-inset-top, use the physical
-    // height and offset fixed bottom chrome into that recovered space.
-    if (physicalHeight > viewportHeight && safeTop > 0 && Math.abs(missingHeight - safeTop) <= 2) {
-        return physicalHeight;
-    }
-
-    return viewportHeight;
-}
-
 function setAppHeight() {
-    const appHeight = getAppHeight();
-    const fixedBottomOffset = Math.min(0, window.innerHeight - appHeight);
-
-    document.documentElement.style.setProperty("--real-vh", `${appHeight}px`);
-    document.documentElement.style.setProperty("--fixed-bottom-offset", `${fixedBottomOffset}px`);
+    document.documentElement.style.setProperty("--real-vh", `${window.innerHeight}px`);
 }
 
-// Keep shell/chrome sizing in sync with the viewport values iOS standalone
-// actually paints. Installed PWAs can under-report innerHeight by safe-top.
+// Keep the shell height tied to the layout viewport. In standalone mode, the
+// status bar must not be translucent; otherwise iOS lays the viewport out at
+// physical y=0 but reports only screen-height - safe-top, leaving that missing
+// safe-top-sized region at the bottom of the webview.
 let appHeightRaf = 0;
 function syncAppHeight() {
     if (appHeightRaf) return;

--- a/tests/e2e/saved.spec.ts
+++ b/tests/e2e/saved.spec.ts
@@ -336,11 +336,10 @@ test.describe("Saved screen — dark mode legibility", () => {
 
 test.describe("Saved screen — iOS safe-area handling", () => {
     /**
-     * Regression: on iOS PWAs with the translucent status bar overlaying the
-     * page (apple-mobile-web-app-status-bar-style=black-translucent), the
-     * modal-close (X) button at the top-right of the sheet ended up under
-     * the status bar because the centered modal had no top safe-area
-     * padding. Two pieces wire this up:
+     * Regression: on iOS PWAs with a notched display, the modal-close (X)
+     * button at the top-right of the sheet ended up under the status bar
+     * because the centered modal had no top safe-area padding. Two pieces
+     * wire this up:
      *   1) index.html declares viewport-fit=cover so iOS exposes the real
      *      env(safe-area-inset-*) values (without it, env() returns 0).
      *   2) The modal-backdrop's padding-top uses max(1rem, var(--safe-top))


### PR DESCRIPTION
## Summary
- replace the failed physical-height/bottom-offset experiment with a status-bar configuration fix
- change `apple-mobile-web-app-status-bar-style` from `black-translucent` to `black`
- keep `--real-vh` tied to `window.innerHeight` and bottom nav anchored to `bottom: 0`
- update comments/tests that described the old translucent-status-bar assumption

## Diagnostic basis
The installed PWA reported `screen.height` / `outerHeight` as 874, but `innerHeight` / `visualViewport.height` as 812, with `safe-area-inset-top` equal to 62. Forcing the app/nav to 874 moved the nav into a region that WebKit still did not paint as web content; the white area then covered the bottom part of the nav.

That means the webview was being laid out at physical y=0 with only `screen - safeTop` height, duplicating the missing top inset as blank bottom space. The root cause is the translucent PWA status bar mode, not a missing height calculation.

## Expected follow-up diagnostic
After deploy in the installed PWA, expected values are either:
- `screen.height - innerHeight` no longer equals `safeTop`, or
- `safeTop` becomes 0 / no bottom white area appears.

## Testing
- Svelte autofixer on BottomNav and ViewportDiagnostics
- npm run lint
- non-E2E Vitest suite: 293 tests
- npm run build

Build still emits existing unrelated Svelte warnings in RollScreen, SavedScreen, SongEditor, and theme.svelte.js.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Switched Apple web app status bar from translucent to solid black to improve layout consistency on iOS devices.

* **Bug Fixes**
  * Simplified viewport/height handling to reduce layout issues and ensure safe-area spacing behaves reliably in standalone iOS mode.

* **Documentation**
  * Clarified comments and test descriptions about safe-area/status-bar behavior; added PR workflow guidance to contributor docs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/setlist-roller/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->