### PR TITLE
fix(ios): allow fresh launch viewport correction

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -9,7 +9,7 @@
     import SavedScreen from "./lib/components/saved/SavedScreen.svelte";
     import SongsScreen from "./lib/components/songs/SongsScreen.svelte";
     import { generateDieSvgString, updatePwaIcons } from "./lib/pwa-icon.js";
-    import { createRemoteStorageRepository } from "./lib/remotestorage.js";
+    import { createRemoteStorageRepository, isIosStandaloneAuthContext } from "./lib/remotestorage.js";
     import { createAppStore } from "./lib/stores/app.svelte.js";
     import { DEFAULT_DIE_COLOR, darkenHex, hexToRgb, hexToRgba } from "./lib/utils.js";
 
@@ -56,6 +56,29 @@
         root.style.setProperty("--accent-strong", darkenHex(dieColor, 0.85));
         root.style.setProperty("--accent-soft", hexToRgba(dieColor, 0.12));
         root.style.setProperty("--accent-line", hexToRgba(dieColor, 0.24));
+    });
+
+    let iosViewportNudged = false;
+    $effect(() => {
+        if (iosViewportNudged) return;
+        if (!store.initialSyncComplete || !isIosStandaloneAuthContext()) return;
+
+        iosViewportNudged = true;
+        requestAnimationFrame(() => {
+            // Short first screens may not naturally scroll. Give iOS standalone
+            // one root-scroll frame so it performs the same viewport correction
+            // that a long Songs list triggers manually.
+            const spacer = document.createElement("div");
+            spacer.setAttribute("aria-hidden", "true");
+            spacer.style.cssText = "height:1px;width:1px;pointer-events:none;opacity:0;";
+            document.body.appendChild(spacer);
+
+            window.scrollTo(0, 1);
+            requestAnimationFrame(() => {
+                window.scrollTo(0, 0);
+                requestAnimationFrame(() => spacer.remove());
+            });
+        });
     });
 
 </script>
@@ -380,16 +403,10 @@
 
     /* ---- App shell ---- */
     .app-shell {
-        height: var(--real-vh, 100dvh);
-        overflow: hidden;
+        min-height: 100dvh;
     }
 
     .main-content {
-        height: 100%;
-        min-height: 0;
-        overflow-y: auto;
-        -webkit-overflow-scrolling: touch;
-        overscroll-behavior: contain;
         padding: var(--space-3);
         padding-top: calc(var(--top-bar-height) + var(--space-3));
         padding-bottom: calc(var(--bottom-nav-height) + var(--space-3));

--- a/src/app.css
+++ b/src/app.css
@@ -123,17 +123,11 @@ html,
 body,
 #app {
     margin: 0;
-    height: 100%;
+    min-height: 100%;
     /* Prevent iOS Safari from auto-inflating text (which can interact with the
        16px input-zoom threshold below). Keep text sizing deterministic. */
     -webkit-text-size-adjust: 100%;
     text-size-adjust: 100%;
-}
-
-html,
-body {
-    overflow: hidden;
-    overscroll-behavior: none;
 }
 
 body {

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -167,7 +167,7 @@ test.describe("Top bar visibility", () => {
         expect(Math.abs(chrome.topTop)).toBeLessThanOrEqual(1);
         expect(chrome.navPosition).toBe("fixed");
         expect(chrome.navBottomStyle).toBe("0px");
-        expect(chrome.mainOverflowY).toBe("auto");
+        expect(chrome.mainOverflowY).toBe("visible");
         expect(Math.abs(chrome.viewportHeight - chrome.navBottom)).toBeLessThanOrEqual(1);
     });
 });


### PR DESCRIPTION
## Summary
- stop hard-locking the root/app shell to the bad initial iOS standalone viewport height
- restore document-level scrolling so WebKit can perform the same correction that long Songs lists were triggering manually
- add an iOS-standalone-only one-frame 1px root-scroll nudge after initial sync so short first screens like Roll can trigger that correction too
- update the fixed-chrome E2E invariant to expect main content in document flow instead of the internal-scroll shell model

## Why
The original bug was not that the bottom area was permanently outside the webview. On fresh installed-PWA launch, iOS starts the app in a too-short layout/compositor state. Long content or user scroll could correct it. Recent fixes locked the app to innerHeight / real-vh, which made that bad initial state permanent.

## Testing
- npx @sveltejs/mcp svelte-autofixer ./src/App.svelte --svelte-version 5
- npm run lint
- npm run build
- npx vitest run src tests --exclude ".claude/**" --exclude "tests/e2e/**" --exclude "tests/real-e2e/**" --exclude "tests/pages/**" --exclude "tests/fixtures/**" --exclude "node_modules/**" --exclude "dist/**"

## Real-device check needed
After deploy, kill and reopen the installed iOS PWA directly to the Roll screen. Success means the bottom nav reaches the physical bottom without needing to switch to Songs or manually scroll.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed viewport and scrolling behavior on iOS standalone mode.
  * Improved layout sizing to ensure content properly fills the screen at all viewport heights.
  * Updated overflow handling for better CSS behavior on mobile devices.

* **Tests**
  * Updated e2e tests to reflect CSS behavior changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/setlist-roller/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->