### PR TITLE
test(e2e): assert hero scrolls with page

### DIFF
--- a/tests/e2e/roll.spec.ts
+++ b/tests/e2e/roll.spec.ts
@@ -326,10 +326,9 @@ test.describe("Roll screen — hero scroll behavior", () => {
         //
         // Earlier iterations of this test depended on a rolled setlist's
         // size to make the page tall enough to scroll. Decouple the test
-        // from generation entirely: inject a tall spacer into the app's
-        // dedicated scroll region, then drive a known scroll amount on
-        // .main-content and confirm it committed before reading the hero's
-        // bbox.
+        // from generation entirely: inject a tall spacer into the Roll screen,
+        // then drive root page scroll and confirm it committed before reading
+        // the hero's bbox.
         await app.seed(seedWithCatalog());
         await app.goto();
         await app.waitForReady();
@@ -341,7 +340,7 @@ test.describe("Roll screen — hero scroll behavior", () => {
         expect(initialBox).not.toBeNull();
         const initialTop = initialBox?.y ?? 0;
 
-        // Force scrollable height inside the app's scroll container.
+        // Force scrollable page height.
         await page.evaluate(() => {
             const spacer = document.createElement("div");
             spacer.id = "__hero_scroll_spacer";
@@ -350,20 +349,10 @@ test.describe("Roll screen — hero scroll behavior", () => {
         });
 
         const SCROLL_BY = 600;
-        await page.evaluate((y) => {
-            const se = document.querySelector(".main-content") as HTMLElement | null;
-            if (se) se.scrollTop = y;
-        }, SCROLL_BY);
+        await page.evaluate((y) => window.scrollTo(0, y), SCROLL_BY);
         // Verify the scroll commit so we don't false-pass when scrollTop
         // is silently rejected (would mean a scroll-trapping bug).
-        await page.waitForFunction(
-            (y) => {
-                const se = document.querySelector(".main-content") as HTMLElement | null;
-                return !!se && se.scrollTop >= y - 1;
-            },
-            SCROLL_BY,
-            { timeout: 2_000 },
-        );
+        await page.waitForFunction((y) => window.scrollY >= y - 1, SCROLL_BY, { timeout: 2_000 });
 
         const afterBox = await hero.boundingBox();
         // Sticky hero would keep y === initialTop. We expect the hero to


### PR DESCRIPTION
## Summary
- follow-up to merged #123
- update the Roll hero scroll regression test to use root page scroll instead of `.main-content.scrollTop`
- keep the test aligned with the restored document-level scrolling model from #123

## Why
#123 intentionally moved the app away from an internal `.main-content` scroll container so iOS standalone can perform the same viewport correction that long-content pages triggered manually. The E2E test still targeted the removed scroll container and failed in CI.

## Testing
- npm run lint
- npm run build
- npx vitest run src tests --exclude ".claude/**" --exclude "tests/e2e/**" --exclude "tests/real-e2e/**" --exclude "tests/pages/**" --exclude "tests/fixtures/**" --exclude "node_modules/**" --exclude "dist/**"

## Notes
- Local Playwright was not run because the Docker-backed armadietto service is not available locally; PR CI should validate the affected E2E shard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated scroll behavior validation in the Roll screen end-to-end test to verify page-level scroll functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/setlist-roller/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->