### PR TITLE
fix(ios): strengthen startup viewport nudge

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -58,27 +58,73 @@
         root.style.setProperty("--accent-line", hexToRgba(dieColor, 0.24));
     });
 
+    function nextFrame() {
+        return new Promise((resolve) => requestAnimationFrame(resolve));
+    }
+
+    function wait(ms) {
+        return new Promise((resolve) => setTimeout(resolve, ms));
+    }
+
+    async function nudgeIosStandaloneViewport() {
+        const status = {
+            startedAt: new Date().toISOString(),
+            attempts: 0,
+            maxScrollY: 0,
+            finishedAt: null,
+        };
+        window.__SR_IOS_VIEWPORT_NUDGE__ = status;
+
+        await nextFrame();
+        await nextFrame();
+
+        const existing = document.getElementById("sr-ios-viewport-spacer");
+        existing?.remove();
+
+        const spacer = document.createElement("div");
+        spacer.id = "sr-ios-viewport-spacer";
+        spacer.setAttribute("aria-hidden", "true");
+        spacer.style.cssText = [
+            `height:${Math.max(window.innerHeight, screen.height, 1200)}px`,
+            "width:1px",
+            "opacity:0",
+            "pointer-events:none",
+            "contain:layout",
+        ].join(";");
+        document.body.appendChild(spacer);
+
+        try {
+            await nextFrame();
+            await nextFrame();
+
+            for (let attempt = 1; attempt <= 3; attempt += 1) {
+                status.attempts = attempt;
+                const scrollRange = Math.max(0, document.documentElement.scrollHeight - window.innerHeight);
+                const targetY = Math.min(160, scrollRange);
+
+                window.scrollTo(0, targetY);
+                await nextFrame();
+                await nextFrame();
+                status.maxScrollY = Math.max(status.maxScrollY, window.scrollY);
+
+                window.scrollTo(0, 0);
+                await nextFrame();
+                await wait(120);
+            }
+        } finally {
+            spacer.remove();
+            window.scrollTo(0, 0);
+            status.finishedAt = new Date().toISOString();
+        }
+    }
+
     let iosViewportNudged = false;
     $effect(() => {
         if (iosViewportNudged) return;
         if (!store.initialSyncComplete || !isIosStandaloneAuthContext()) return;
 
         iosViewportNudged = true;
-        requestAnimationFrame(() => {
-            // Short first screens may not naturally scroll. Give iOS standalone
-            // one root-scroll frame so it performs the same viewport correction
-            // that a long Songs list triggers manually.
-            const spacer = document.createElement("div");
-            spacer.setAttribute("aria-hidden", "true");
-            spacer.style.cssText = "height:1px;width:1px;pointer-events:none;opacity:0;";
-            document.body.appendChild(spacer);
-
-            window.scrollTo(0, 1);
-            requestAnimationFrame(() => {
-                window.scrollTo(0, 0);
-                requestAnimationFrame(() => spacer.remove());
-            });
-        });
+        void nudgeIosStandaloneViewport();
     });
 
 </script>

--- a/src/lib/components/layout/ViewportDiagnostics.svelte
+++ b/src/lib/components/layout/ViewportDiagnostics.svelte
@@ -46,6 +46,7 @@
         userAgent: navigator.userAgent,
         standaloneMedia: window.matchMedia?.("(display-mode: standalone)").matches ?? null,
         navigatorStandalone: navigator.standalone ?? null,
+        iosViewportNudge: window.__SR_IOS_VIEWPORT_NUDGE__ ?? null,
       },
       window: {
         innerWidth: round(window.innerWidth),


### PR DESCRIPTION
## Summary
- make the installed-iOS startup viewport correction stronger and measurable
- use a temporary root spacer at least one viewport tall instead of a 1px spacer
- wait multiple frames, perform three root-scroll attempts, then clean up and reset to top
- expose the nudge status in Viewport Diagnostics as `mode.iosViewportNudge`

## Why
The current restored behavior confirms the original issue: the white strip exists on fresh launch, then disappears after visiting a naturally scrollable screen like Songs. This patch keeps option 1 focused on reproducing that root-scroll correction automatically for short startup screens like Roll.

## Testing
- npx @sveltejs/mcp svelte-autofixer ./src/App.svelte --svelte-version 5
- npx @sveltejs/mcp svelte-autofixer ./src/lib/components/layout/ViewportDiagnostics.svelte --svelte-version 5
- npm run lint
- npm run build
- npx vitest run src tests --exclude ".claude/**" --exclude "tests/e2e/**" --exclude "tests/real-e2e/**" --exclude "tests/pages/**" --exclude "tests/fixtures/**" --exclude "node_modules/**" --exclude "dist/**"

## Real-device check needed
After deploy, kill and reopen the installed iOS PWA directly to Roll. If whitespace remains, open Viewport Diagnostics and check `mode.iosViewportNudge` for attempts and maxScrollY.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS standalone app viewport handling with enhanced scroll positioning recovery and automatic cleanup for better stability.

* **Diagnostics**
  * Added viewport diagnostic tracking for iOS to help identify and monitor viewport-related issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/setlist-roller/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->