### PR TITLE
fix(ui): shorten bottom nav chrome

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -64,13 +64,12 @@
     --space-8: 2rem;
 
     /* Layout
-       These are the fixed chrome OUTER heights. They include the safe-area
-       inset so content can reserve the full covered region. TopBar/BottomNav
-       also apply the same inset as internal padding; with global border-box
-       sizing that positions controls away from device edges without increasing
-       the outer fixed height. */
+       These are the fixed chrome OUTER heights. TopBar reserves the full
+       top safe-area inset. BottomNav only uses part of the bottom inset so the
+       bar stays compact while tab buttons keep their 44px+ tap targets. */
     --top-bar-height: calc(48px + env(safe-area-inset-top, 0px));
-    --bottom-nav-height: calc(56px + env(safe-area-inset-bottom, 0px));
+    --bottom-nav-safe-padding: calc(env(safe-area-inset-bottom, 0px) * 0.5);
+    --bottom-nav-height: calc(48px + var(--bottom-nav-safe-padding));
     --safe-top: env(safe-area-inset-top, 0px);
     --safe-bottom: env(safe-area-inset-bottom, 0px);
 }

--- a/src/lib/components/layout/BottomNav.svelte
+++ b/src/lib/components/layout/BottomNav.svelte
@@ -38,7 +38,7 @@
     border-top: 1px solid var(--line);
     backdrop-filter: blur(20px);
     -webkit-backdrop-filter: blur(20px);
-    padding-bottom: env(safe-area-inset-bottom, 0px);
+    padding-bottom: var(--bottom-nav-safe-padding);
     z-index: 100;
   }
 


### PR DESCRIPTION
## Summary
- reduce the bottom nav chrome height from 56px base to 48px base
- reserve half of the iOS bottom safe-area inset instead of the full inset
- keep tab buttons at their existing 44px+ tap target size

## Testing
- npx @sveltejs/mcp svelte-autofixer ./src/lib/components/layout/BottomNav.svelte --svelte-version 5
- npm run lint
- npm run build
- npx vitest run src tests --exclude ".claude/**" --exclude "tests/e2e/**" --exclude "tests/real-e2e/**" --exclude "tests/pages/**" --exclude "tests/fixtures/**" --exclude "node_modules/**" --exclude "dist/**"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bottom navigation bar layout to maintain compact sizing while ensuring adequate touch target sizes (44px+) for better mobile usability.
  * Enhanced safe area inset handling on devices with notches or curved edges for improved layout adaptation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/setlist-roller/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->