### PR TITLE
fix(ui): lower bottom nav tab content

### DIFF
--- a/src/lib/components/layout/BottomNav.svelte
+++ b/src/lib/components/layout/BottomNav.svelte
@@ -55,7 +55,7 @@
     background: none;
     cursor: pointer;
     color: var(--muted);
-    padding: 6px 0;
+    padding: 11px 0 1px;
     -webkit-tap-highlight-color: transparent;
     touch-action: manipulation;
     transition: color 0.15s ease;


### PR DESCRIPTION
## Summary
- shift bottom nav tab icon/label content about 5px lower
- keep the overall nav bar height unchanged
- keep button min-height/tap targets unchanged

## Testing
- npx @sveltejs/mcp svelte-autofixer ./src/lib/components/layout/BottomNav.svelte --svelte-version 5
- npm run lint
- npm run build
- npx vitest run src tests --exclude ".claude/**" --exclude "tests/e2e/**" --exclude "tests/real-e2e/**" --exclude "tests/pages/**" --exclude "tests/fixtures/**" --exclude "node_modules/**" --exclude "dist/**"