### PR TITLE
Show only the latest full-width toast

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -282,9 +282,9 @@
     </div>
 {/if}
 
-{#if store.toastMessages.length > 0}
+{#if store.toastMessages[0]}
+    {@const toast = store.toastMessages[0]}
     <div class="toast-stack" class:with-busy={!!store.busyMessage} aria-live="polite">
-        {@const toast = store.toastMessages[0]}
         <div class="toast-pill {toast.tone}">
             {toast.message}
         </div>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -284,11 +284,10 @@
 
 {#if store.toastMessages.length > 0}
     <div class="toast-stack" class:with-busy={!!store.busyMessage} aria-live="polite">
-        {#each store.toastMessages as toast (toast.id)}
-            <div class="toast-pill {toast.tone}">
-                {toast.message}
-            </div>
-        {/each}
+        {@const toast = store.toastMessages[0]}
+        <div class="toast-pill {toast.tone}">
+            {toast.message}
+        </div>
     </div>
 {/if}
 
@@ -685,14 +684,10 @@
     .toast-stack {
         position: fixed;
         top: var(--top-bar-height);
-        left: 50%;
-        transform: translateX(-50%);
+        left: 0;
+        right: 0;
         z-index: 300;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: var(--space-1);
-        max-width: calc(100vw - 2rem);
+        width: 100%;
         pointer-events: none;
     }
 
@@ -704,7 +699,9 @@
     }
 
     .toast-pill {
-        max-width: 100%;
+        width: 100%;
+        min-width: 0;
+        box-sizing: border-box;
         padding: 5px 14px;
         font-size: 0.78rem;
         font-weight: 600;
@@ -714,10 +711,9 @@
         border: none;
         border-radius: 0 0 var(--radius-md, 12px) var(--radius-md, 12px);
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-        /* Allow long error/info messages to wrap instead of getting truncated
-           with an ellipsis — the user needs to read the whole error. */
-        white-space: normal;
-        overflow-wrap: anywhere;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
         animation: toast-slide-down 200ms ease;
     }
 

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -18,9 +18,7 @@ const TOAST_TONE = Object.freeze({
     DANGER: "danger",
 });
 const VALID_TOAST_TONES = new Set(Object.values(TOAST_TONE));
-// Stack cap. New toasts past this drop the oldest so each one is visible.
-const MAX_TOASTS = 3;
-// Danger gets a longer dwell so multi-line error messages can actually be read.
+// Danger gets a longer dwell so more severe messages remain visible longer.
 const TOAST_DURATION_MS = { default: 6000, danger: 12000 };
 // Cap on the in-memory sync log surfaced in the diagnostic panel. Old entries
 // roll off so the list doesn't grow unbounded across a long session.
@@ -606,9 +604,7 @@ export function createAppStore(repo) {
         // default style with no semantic class (e.g. "warn" vs "warning").
         const validTone = VALID_TOAST_TONES.has(tone) ? tone : TOAST_TONE.INFO;
         const id = uid("toast");
-        // Cap the stack — drop oldest so a fresh toast is always visible.
-        const next = [...toastMessages, { id, message, tone: validTone }];
-        toastMessages = next.length > MAX_TOASTS ? next.slice(-MAX_TOASTS) : next;
+        toastMessages = [{ id, message, tone: validTone }];
         const duration = validTone === TOAST_TONE.DANGER ? TOAST_DURATION_MS.danger : TOAST_DURATION_MS.default;
         setTimeout(() => {
             toastMessages = toastMessages.filter((t) => t.id !== id);

--- a/src/lib/stores/app.test.js
+++ b/src/lib/stores/app.test.js
@@ -53,6 +53,29 @@ describe("retrySync", () => {
     });
 });
 
+describe("toasts", () => {
+    it("keeps only the latest toast and ignores stale dismiss timers", () => {
+        vi.useFakeTimers();
+        const store = createAppStore({});
+
+        store.toastInfo("First message");
+        store.toastError("Latest message");
+
+        expect(store.toastMessages).toHaveLength(1);
+        expect(store.toastMessages[0]).toMatchObject({
+            message: "Latest message",
+            tone: "danger",
+        });
+
+        vi.advanceTimersByTime(6000);
+        expect(store.toastMessages).toHaveLength(1);
+        expect(store.toastMessages[0]?.message).toBe("Latest message");
+
+        vi.advanceTimersByTime(6000);
+        expect(store.toastMessages).toHaveLength(0);
+    });
+});
+
 describe("setlist v2 migration", () => {
     it("collapses a fat saved setlist to lean references and hoists the relaxed flags", () => {
         const fat = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- change toast state to replace the previous message with the latest one
- render a single toast and style it full width below the top bar
- truncate toast text to one line with ellipsis to avoid overlapping controls

## Tests
- `npm test -- src/lib/stores/app.test.js`
- `npx @sveltejs/mcp svelte-autofixer ./src/App.svelte --svelte-version 5`
- `npm run lint`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7227d106-ce34-4cf5-ae0b-18d6a02ab301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7227d106-ce34-4cf5-ae0b-18d6a02ab301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface**
  * Toast notifications now display one message at a time instead of stacking multiple notifications for a clearer user experience
  * Toast container spans the full viewport width for improved visibility and consistent layout across all screen sizes
  * Notification text displays as single-line with automatic ellipsis truncation instead of wrapping to multiple lines

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/silverbucket/setlist-roller/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->