### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,43 @@ only step down when you have a clear visual reason.
 When adding a new input, take 30 seconds to confirm the rendered size in
 DevTools' computed styles panel. The bug is silent on desktop and only shows
 up the first time someone opens the app on an actual iPhone.
+
+## Cursor Cloud specific instructions
+
+Setlist Roller is a client-side Svelte 5 + Vite PWA with no backend of its own.
+Data persistence uses [remoteStorage](https://remotestorage.io).
+
+### Quick reference
+
+| Task | Command |
+|------|---------|
+| Dev server | `npm run dev` (port 4173) |
+| Lint | `npm run lint` (Biome) |
+| Unit tests | `npm test` (Vitest) |
+| E2E tests | `npm run test:e2e` (Playwright + Chromium) |
+| Build | `npm run build` |
+
+### E2E test prerequisites
+
+E2E tests require Docker and the armadietto remoteStorage server:
+
+1. Docker must be running (`sudo dockerd` if not already started).
+2. Start armadietto: `npm run armadietto:up` (port 8000).
+3. Install Playwright browsers: `npx playwright install --with-deps chromium`.
+4. The Playwright `webServer` config auto-starts the Vite dev server for E2E
+   runs, so you do not need to start it separately.
+
+### Docker-in-Docker gotchas
+
+The Cloud Agent VM runs inside a container. To get Docker working:
+
+- Use `fuse-overlayfs` storage driver (`/etc/docker/daemon.json`).
+- Switch iptables to legacy: `sudo update-alternatives --set iptables /usr/sbin/iptables-legacy`.
+- Fix socket permissions after starting dockerd: `sudo chmod 666 /var/run/docker.sock`.
+
+### Notes
+
+- The `songs.spec.ts › clearing search restores full list` E2E test is
+  occasionally flaky (timing-sensitive); it passes on re-run.
+- The dev server binds to `0.0.0.0:4173`; Playwright expects `localhost:4173`
+  for OAuth redirect URI matching with armadietto.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with guidance for future cloud agents:

- Quick reference table for common dev commands (dev server, lint, test, build)
- E2E test prerequisites (Docker, armadietto, Playwright browsers)
- Docker-in-Docker gotchas specific to Cloud Agent VMs (fuse-overlayfs, iptables-legacy, socket permissions)
- Notes on known flaky test and dev server hostname for OAuth

### Demo

[demo_setlist_roller_app.mp4](https://cursor.com/agents/bc-fc8cb8d5-edae-4361-9cdc-c5a7c5e8a7e3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_setlist_roller_app.mp4)

Connected to armadietto, created songs, and generated a setlist — full end-to-end flow working.

[Generated setlist with two songs](https://cursor.com/agents/bc-fc8cb8d5-edae-4361-9cdc-c5a7c5e8a7e3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_final_setlist.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc8cb8d5-edae-4361-9cdc-c5a7c5e8a7e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc8cb8d5-edae-4361-9cdc-c5a7c5e8a7e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added updated setup and workflow guidance for the app, including common development, lint, test, and build commands.
  * Expanded testing instructions with prerequisites for end-to-end runs, local service startup steps, and browser setup.
  * Added troubleshooting notes for container-based development and OAuth redirect behavior.
  * Included a note about an occasionally flaky end-to-end test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->