### PR TITLE
perf: coalesce change-driven reloads with a trailing debounce

### DIFF
--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -207,6 +207,11 @@ export function createAppStore(repo) {
     // pending → disconnected fallback (init() below); this covers the
     // gap once the connection has succeeded but the data load hangs.
     const SYNC_STALL_TIMEOUT_MS = 15000;
+    // Trailing debounce for change-driven reloads (see the onChange
+    // handler in init). Short enough that a lone remote edit still shows
+    // up near-instantly; long enough to swallow rs.js's per-document
+    // event bursts during sync rounds.
+    const CHANGE_RELOAD_DEBOUNCE_MS = 250;
     let syncStalled = $state(false);
     let syncStalledTimer = null;
 
@@ -2639,24 +2644,47 @@ export function createAppStore(repo) {
             }
         });
 
-        const detachChange = repo.onChange(async (event) => {
+        // Coalesce change-driven reloads. rs.js streams one change event per
+        // document while pulling remote data, so a bootstrap of a ~150-song
+        // catalog fires ~150 events — without a debounce, each one kicked a
+        // full reloadAll() (five slice reads + normalize + sort). The
+        // reloadGen guard already discards stale *results*, but all that
+        // wasted work still ran on the main thread: an O(N²) bootstrap.
+        // A trailing debounce collapses each burst into one reload. The
+        // settle-window logic tolerates the delay because every event still
+        // bumpSyncActivity()s immediately below, keeping the pill honest
+        // while the timer is pending.
+        let changeReloadTimer = null;
+        // True if any event in the current burst was remote-origin; picks
+        // the sync label when the coalesced reload finally runs.
+        let changeBurstHadRemote = false;
+        // Session pinned at the LATEST event of the burst. If the user swaps
+        // accounts mid-burst, the swap bumps activeSession, and reloadAll's
+        // own session guard drops the stale results.
+        let changeBurstSession = 0;
+        const detachChange = repo.onChange((event) => {
             dbg(`rs.js change: path=${event?.relativePath || event?.path || "?"} origin=${event?.origin} oldVal=${typeof event?.oldValue} newVal=${typeof event?.newValue}`);
             if (connectionStatus !== "connected" || event?.origin === "window") return;
             // Remote-origin events mean rs.js is streaming bodies in. Show
-            // activity in the pill even if no reload runs (defensive — the
-            // reload below will normally handle this), and cancel any
-            // pending settle-window flip since data is still arriving.
+            // activity in the pill even though the reload is deferred, and
+            // cancel any pending settle-window flip since data is still
+            // arriving.
             if (event?.origin === "remote") {
+                changeBurstHadRemote = true;
                 bumpSyncActivity("remote onChange");
                 if (syncState !== "error") setSyncState("syncing");
             }
-            // Pin the session at the moment the event fired. If the user
-            // swaps accounts mid-reload, the awaited reloadAll() returns
-            // into a different session and we drop its results.
-            const session = activeSession;
-            beginSync(event?.origin === "remote" ? "Pulling remote changes" : "Syncing");
-            try { await reloadAll({ quiet: true, session }); }
-            finally { endSync(); }
+            changeBurstSession = activeSession;
+            if (changeReloadTimer) clearTimeout(changeReloadTimer);
+            changeReloadTimer = setTimeout(async () => {
+                changeReloadTimer = null;
+                const hadRemote = changeBurstHadRemote;
+                changeBurstHadRemote = false;
+                const session = changeBurstSession;
+                beginSync(hadRemote ? "Pulling remote changes" : "Syncing");
+                try { await reloadAll({ quiet: true, session }); }
+                finally { endSync(); }
+            }, CHANGE_RELOAD_DEBOUNCE_MS);
         });
 
         return () => {
@@ -2668,6 +2696,7 @@ export function createAppStore(repo) {
             if (syncStalledTimer) clearTimeout(syncStalledTimer);
             if (switchingWatchdog) clearTimeout(switchingWatchdog);
             if (pendingSwapDisconnectTimer) clearTimeout(pendingSwapDisconnectTimer);
+            if (changeReloadTimer) clearTimeout(changeReloadTimer);
             detachConnecting();
             detachAuthing();
             detachStandaloneRedirect();

--- a/src/lib/stores/app.test.js
+++ b/src/lib/stores/app.test.js
@@ -219,6 +219,7 @@ describe("change-driven reload coalescing", () => {
                 members: {},
                 errors: {},
             })),
+            getRawConfig: vi.fn(async () => null),
             isConnected: () => true,
             getUserAddress: () => "user@example.com",
             getToken: () => "stub-token",

--- a/src/lib/stores/app.test.js
+++ b/src/lib/stores/app.test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DEFAULT_APP_CONFIG } from "../defaults.js";
 import { migrator } from "../migrations.js";
@@ -156,5 +156,133 @@ describe("setlist v2 migration", () => {
         expect(twice.songs).toEqual([{ songId: "song-9", performance: {} }]);
         expect(twice.summary).toBeUndefined();
         expect(twice.minimumsRelaxed).toBe(false);
+    });
+});
+
+describe("change-driven reload coalescing", () => {
+    // The store's init() needs window + localStorage; we're in node, so
+    // polyfill exactly those (same approach as account-switching.test.js —
+    // jsdom would trip Svelte's top-level-$effect validation).
+    let _origLocalStorage;
+    let _origWindow;
+    beforeEach(() => {
+        _origLocalStorage = globalThis.localStorage;
+        _origWindow = globalThis.window;
+        const map = new Map();
+        globalThis.localStorage = {
+            getItem: (k) => (map.has(k) ? map.get(k) : null),
+            setItem: (k, v) => map.set(k, String(v)),
+            removeItem: (k) => map.delete(k),
+            clear: () => map.clear(),
+        };
+        globalThis.window = {
+            location: { hash: "" },
+            addEventListener: () => {},
+            removeEventListener: () => {},
+        };
+    });
+    afterEach(() => {
+        vi.useRealTimers();
+        if (typeof _origLocalStorage === "undefined") delete globalThis.localStorage;
+        else globalThis.localStorage = _origLocalStorage;
+        if (typeof _origWindow === "undefined") delete globalThis.window;
+        else globalThis.window = _origWindow;
+    });
+
+    function buildRepo() {
+        const listeners = new Map();
+        let changeHandler = null;
+        return {
+            on(eventName, handler) {
+                if (!listeners.has(eventName)) listeners.set(eventName, new Set());
+                listeners.get(eventName).add(handler);
+                return () => listeners.get(eventName)?.delete(handler);
+            },
+            fire(eventName, payload) {
+                for (const handler of [...(listeners.get(eventName) || [])]) handler(payload);
+            },
+            onChange(handler) {
+                changeHandler = handler;
+                return () => {
+                    changeHandler = null;
+                };
+            },
+            fireChange(event) {
+                changeHandler?.(event);
+            },
+            loadAll: vi.fn(async () => ({
+                songs: [],
+                pendingBodies: 0,
+                bootstrap: null,
+                config: DEFAULT_APP_CONFIG,
+                setlists: [],
+                members: {},
+                errors: {},
+            })),
+            isConnected: () => true,
+            getUserAddress: () => "user@example.com",
+            getToken: () => "stub-token",
+            connect: vi.fn(),
+            disconnect: vi.fn(),
+        };
+    }
+
+    it("collapses a burst of change events into a single reload", async () => {
+        vi.useFakeTimers();
+        const repo = buildRepo();
+        const store = createAppStore(repo);
+        const teardown = store.init();
+
+        repo.fire("connected");
+        // Let the connected handler's own reloadAll settle.
+        await vi.runOnlyPendingTimersAsync();
+        const baseline = repo.loadAll.mock.calls.length;
+
+        // Simulate rs.js streaming a 150-song catalog: one remote-origin
+        // change event per document body.
+        for (let i = 0; i < 150; i += 1) {
+            repo.fireChange({ relativePath: `songs/id-${i}`, origin: "remote", newValue: {} });
+        }
+        expect(repo.loadAll.mock.calls.length).toBe(baseline);
+
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(repo.loadAll.mock.calls.length).toBe(baseline + 1);
+        expect(store.songs).toEqual([]);
+
+        teardown();
+    });
+
+    it("still reloads promptly after a lone remote change", async () => {
+        vi.useFakeTimers();
+        const repo = buildRepo();
+        const store = createAppStore(repo);
+        const teardown = store.init();
+
+        repo.fire("connected");
+        await vi.runOnlyPendingTimersAsync();
+        const baseline = repo.loadAll.mock.calls.length;
+
+        repo.fireChange({ relativePath: "songs/id-1", origin: "remote", newValue: {} });
+        await vi.advanceTimersByTimeAsync(300);
+        expect(repo.loadAll.mock.calls.length).toBe(baseline + 1);
+
+        teardown();
+    });
+
+    it("ignores window-origin events and does not schedule a reload", async () => {
+        vi.useFakeTimers();
+        const repo = buildRepo();
+        const store = createAppStore(repo);
+        const teardown = store.init();
+
+        repo.fire("connected");
+        await vi.runOnlyPendingTimersAsync();
+        const baseline = repo.loadAll.mock.calls.length;
+
+        repo.fireChange({ relativePath: "songs/id-1", origin: "window", newValue: {} });
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(repo.loadAll.mock.calls.length).toBe(baseline);
+
+        teardown();
     });
 });


### PR DESCRIPTION
rs.js streams one change event per document while pulling remote data,
and the onChange handler kicked a full reloadAll() for every one of
them. Bootstrapping a ~150-song catalog therefore ran ~150 full reloads
(five slice reads + normalize + sort each) — an O(N^2) bootstrap. The
reloadGen guard already discarded stale results, but the wasted work
still ran on the main thread.

A 250 ms trailing debounce collapses each event burst into a single
reload. Every event still calls bumpSyncActivity() immediately, so the
settle-window logic and sync pill stay honest while the timer is
pending. The session is pinned at the latest event of the burst;
reloadAll's existing session guard drops results if an account swap
lands mid-burst.

Adds regression tests: a 150-event burst triggers exactly one reload,
a lone event still reloads promptly, and window-origin events schedule
nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced redundant reloads during rapid sync activity, making change handling smoother and more efficient.
  * Improved sync status messaging so remote updates are labeled more clearly when pulling changes.
  * Prevented delayed reloads from running after listeners are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->