### PR TITLE
fix: restore unlocked current setlist after a reload

### DIFF
--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -595,10 +595,20 @@ export function createAppStore(repo) {
     // Load all per-user localStorage data (called on connect when we know the user)
     function loadUserLocalData() {
         const current = loadCurrentSetlist();
-        const locked = current?._locked || false;
-        if (locked) generatedSetlist = current;
-        else clearGeneratedSetlist();
-        setlistLocked = locked;
+        // Restore the persisted current set whether or not it was locked.
+        // Previously only locked sets survived a reload — but the page can
+        // reload without the user asking for it (service-worker update,
+        // browser crash, iOS killing a backgrounded PWA), and losing a
+        // rolled-but-unlocked set to any of those mid-gig is unacceptable.
+        // The lock flag still means what it meant: it only guards against
+        // the NEXT ROLL clobbering the list, not against persistence.
+        if (current) {
+            generatedSetlist = current;
+            setlistLocked = current._locked || false;
+        } else {
+            clearGeneratedSetlist();
+            setlistLocked = false;
+        }
         setlistSaved = false;
         generationOptions = loadStoredGenerationOptions();
     }


### PR DESCRIPTION
loadUserLocalData only restored the persisted current set when it was
locked; an unlocked rolled set was silently discarded on any page
reload. Reloads aren't always user-initiated — a service-worker
update, a browser crash, or iOS killing the backgrounded PWA all
count — and eating a rolled set mid-gig is exactly the failure this
app exists to prevent.

Now the persisted set is restored regardless of lock state, and the
lock flag keeps its original meaning: it guards against the next roll
clobbering the list, not against persistence.
