### PR TITLE
fix: block maybeMarkSynced while a debounced change-reload is pending

### DIFF
--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -212,6 +212,9 @@ export function createAppStore(repo) {
     // up near-instantly; long enough to swallow rs.js's per-document
     // event bursts during sync rounds.
     const CHANGE_RELOAD_DEBOUNCE_MS = 250;
+    // True while a debounced change-reload timer is pending. Exposed to
+    // maybeMarkSynced so it doesn't flip to "synced" before that reload runs.
+    let changeReloadPending = false;
     let syncStalled = $state(false);
     let syncStalledTimer = null;
 
@@ -800,9 +803,10 @@ export function createAppStore(repo) {
             reloadInFlight > 0 ? `reloadInFlight=${reloadInFlight}` :
             pendingBodies > 0 ? `pendingBodies=${pendingBodies}` :
             !syncRoundCompleted ? "syncRoundCompleted=false" :
+            changeReloadPending ? "changeReloadPending" :
             loadError ? "loadError" :
             null;
-        dbg(`maybeMarkSynced: ${reason ? `blocked by ${reason}` : "scheduling flip"} (state=${syncState} reload=${reloadInFlight} pending=${pendingBodies} round=${syncRoundCompleted})`);
+        dbg(`maybeMarkSynced: ${reason ? `blocked by ${reason}` : "scheduling flip"} (state=${syncState} reload=${reloadInFlight} pending=${pendingBodies} round=${syncRoundCompleted} changeReloadPending=${changeReloadPending})`);
         if (reason) return;
         // Already scheduled — let the existing timer run; nothing has changed
         // that would justify resetting it.
@@ -816,6 +820,7 @@ export function createAppStore(repo) {
                 reloadInFlight > 0 ? `reloadInFlight=${reloadInFlight}` :
                 pendingBodies > 0 ? `pendingBodies=${pendingBodies}` :
                 !syncRoundCompleted ? "syncRoundCompleted=false" :
+                changeReloadPending ? "changeReloadPending" :
                 loadError ? "loadError" :
                 null;
             if (blocker) {
@@ -2547,6 +2552,7 @@ export function createAppStore(repo) {
             syncRoundCompleted = false;
             pendingBodies = 0;
             initialSyncSettled = false;
+            if (changeReloadTimer) { clearTimeout(changeReloadTimer); changeReloadTimer = null; changeReloadPending = false; }
             bumpSyncActivity("connected");
             // Cold connect / OAuth path: ensure rs.js is in bootstrap-pace
             // polling. (connectToAccount already does this for swaps.)
@@ -2708,8 +2714,10 @@ export function createAppStore(repo) {
             }
             changeBurstSession = activeSession;
             if (changeReloadTimer) clearTimeout(changeReloadTimer);
+            changeReloadPending = true;
             changeReloadTimer = setTimeout(async () => {
                 changeReloadTimer = null;
+                changeReloadPending = false;
                 const hadRemote = changeBurstHadRemote;
                 changeBurstHadRemote = false;
                 const session = changeBurstSession;
@@ -2728,7 +2736,7 @@ export function createAppStore(repo) {
             if (syncStalledTimer) clearTimeout(syncStalledTimer);
             if (switchingWatchdog) clearTimeout(switchingWatchdog);
             if (pendingSwapDisconnectTimer) clearTimeout(pendingSwapDisconnectTimer);
-            if (changeReloadTimer) clearTimeout(changeReloadTimer);
+            if (changeReloadTimer) { clearTimeout(changeReloadTimer); changeReloadPending = false; }
             detachConnecting();
             detachAuthing();
             detachStandaloneRedirect();


### PR DESCRIPTION
## Summary

- On first boot with an empty rs.js cache, the `connected` handler's `reloadAll` sees `pendingBodies=0` (nothing cached yet). When `sync-done` fires, `maybeMarkSynced` had no blockers and scheduled the 2500ms flip — but the 250ms debounce timer from `#130` hadn't run yet, so songs weren't loaded when `syncState` flipped to `"synced"`. E2E tests that assert catalog contents without `waitForSynced()` raced the timer and failed.
- Adds `changeReloadPending` (set when the debounce arms, cleared when it fires or is cancelled) as a gate in `maybeMarkSynced`, alongside the existing `reloadInFlight` and `pendingBodies` guards.
- Also clears it on reconnect to prevent a stale burst from a previous account blocking the new session's sync gate.

## Test plan

- [ ] Unit tests still pass (`npm test`)
- [ ] E2E: data-management export/import tests pass
- [ ] E2E: songs catalog search/filter tests pass
- [ ] E2E: song-editor tests pass