### PR TITLE
test(e2e): wait for sync before non-retrying catalog assertions

### DIFF
--- a/tests/e2e/band.spec.ts
+++ b/tests/e2e/band.spec.ts
@@ -226,6 +226,7 @@ test.describe("Band screen — die color", () => {
         await app.seed(buildSeed());
         await app.goto();
         await app.waitForReady();
+        await app.waitForSynced();
         await new AppShell(page).gotoBand();
 
         const band = new BandPage(page);

--- a/tests/e2e/data-management.spec.ts
+++ b/tests/e2e/data-management.spec.ts
@@ -24,6 +24,7 @@ test.describe("Export", () => {
         );
         await app.goto();
         await app.waitForReady();
+        await app.waitForSynced();
         await new AppShell(page).gotoBand();
 
         const band = new BandPage(page);
@@ -83,6 +84,7 @@ test.describe("Import", () => {
         );
         await app.goto();
         await app.waitForReady();
+        await app.waitForSynced();
         const shell = new AppShell(page);
         await shell.gotoBand();
 

--- a/tests/e2e/songs.spec.ts
+++ b/tests/e2e/songs.spec.ts
@@ -102,6 +102,7 @@ test.describe("Songs catalog — search", () => {
 
     test("matches by name substring (case-insensitive)", async ({ page, app }) => {
         await app.goto();
+        await app.waitForSynced();
         await new AppShell(page).gotoSongs();
 
         const songs = new SongsPage(page);
@@ -113,6 +114,7 @@ test.describe("Songs catalog — search", () => {
 
     test("clearing search restores full list", async ({ page, app }) => {
         await app.goto();
+        await app.waitForSynced();
         await new AppShell(page).gotoSongs();
 
         const songs = new SongsPage(page);
@@ -135,6 +137,7 @@ test.describe("Songs catalog — type filter", () => {
             }),
         );
         await app.goto();
+        await app.waitForSynced();
         await new AppShell(page).gotoSongs();
 
         const songs = new SongsPage(page);


### PR DESCRIPTION
## Summary

- Tests using `getVisibleSongNames()` or `getState()` read the DOM/store exactly once — no Playwright retry. With the 250ms debounce from #130, the first `reloadAll()` on connect returns an empty catalog (rs.js cache is cold on first boot), and the real data arrives only after the debounce fires.
- Tests using retrying assertions (`toBeVisible`, `toContainText`) pass because Playwright polls for up to 5s, which covers the 250ms gap. Non-retrying reads see the empty state and fail.
- Adds `await app.waitForSynced()` before the first non-retrying assertion in the 5 affected tests: songs search ×2, songs type-filter, export, import, and band die-color.

## Test plan

- [ ] E2E shard 1: data-management export + import pass
- [ ] E2E shard 1: band die-color passes
- [ ] E2E shard 2: songs search + type-filter pass