### PR TITLE
ci: staging deploy fixes + debug-friendly staging builds with UI badge

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -41,6 +41,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # Full history: 5apps' git server rejects pushes from shallow
+          # clones ("shallow update not allowed"), and checkout's default
+          # is a depth-1 clone. Same reason release.yml fetches full depth.
+          fetch-depth: 0
           persist-credentials: false
 
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Two staging improvements on top of the initial workflow:

### Fix: deploy push rejected
The first dispatch failed with `! [remote rejected] HEAD -> master (shallow update not allowed)` — 5apps' git server refuses pushes from shallow clones and `actions/checkout` defaults to depth 1. The deploy job now checks out with `fetch-depth: 0` (same as `release.yml`). Verified: [re-run succeeded](https://github.com/silverbucket/setlist-roller/actions/runs/28708116207) and setlist-staging.5apps.com is serving.

### Staging builds are debug-friendly and self-identifying
The workflow now builds with `npm run build:staging` (`vite build --mode staging`), which:
- **emits sourcemaps** for the deployed JS/CSS
- **keeps function/class names** through minification (`esbuild.keepNames`) so stack traces read well even before a map loads
- suffixes the app version → the Band-screen footer shows e.g. `v2.3.0-staging`
- renames the **PWA manifest** to "Setlist Roller (Staging)" / "SR Staging" so the installed staging app is distinguishable from prod on a home screen
- shows a small amber **STAGING** badge next to the band name in the TopBar, and marks the connect screen's eyebrow

Production builds are unaffected: no sourcemaps, no badge, unchanged manifest and version (verified by building both modes and diffing for the markers).

## Testing
- `npm run build` → 0 `.map` files, manifest "Setlist Roller", no STAGING string in the bundle.
- `npm run build:staging` → sourcemaps present, manifest "Setlist Roller (Staging)", badge + `-staging` version in the bundle.
- Unit tests and lint green; workflow YAML validated.

## Note
The `v3` branch will need a rebase onto master after this merges to pick up the staging-mode build for its own staging dispatches (its current copy only has the fetch-depth fix).