### PR TITLE
In-app destructive-confirm modal + Content-Security-Policy

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,15 +23,10 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="theme-color" content="#e15b37" />
-    <!-- SYNC: key + resolution logic duplicated from src/lib/theme.svelte.js to avoid FOITC -->
-    <script>
-      try {
-        var p = localStorage.getItem("setlist-roller-theme") || "system";
-        var e = p === "dark" ? "dark" : p === "light" ? "light"
-          : window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-        document.documentElement.dataset.theme = e;
-      } catch(x) {}
-    </script>
+    <!-- Blocking theme init (external, not inline, so the CSP can stay
+         script-src 'self' — see the csp plugin in vite.config.js). Runs
+         before first paint to avoid a flash of the wrong theme. -->
+    <script src="/theme-init.js"></script>
   </head>
   <body>
     <div id="app"></div>

--- a/public/theme-init.js
+++ b/public/theme-init.js
@@ -1,0 +1,19 @@
+// Applies the persisted theme before first paint to avoid a flash of the
+// wrong theme (FOITC). Loaded as a blocking external script (not inline) so
+// the Content-Security-Policy can stay `script-src 'self'` with no inline
+// allowances or hashes.
+// SYNC: key + resolution logic duplicated from src/lib/theme.svelte.js.
+try {
+    const preference = localStorage.getItem("setlist-roller-theme") || "system";
+    const effective =
+        preference === "dark"
+            ? "dark"
+            : preference === "light"
+              ? "light"
+              : window.matchMedia("(prefers-color-scheme: dark)").matches
+                ? "dark"
+                : "light";
+    document.documentElement.dataset.theme = effective;
+} catch (_e) {
+    /* storage unavailable — default theme applies */
+}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -21,6 +21,34 @@
     // TopBar carries the in-app badge.
     const isStaging = import.meta.env.MODE === "staging";
 
+    // ---- destructive-confirm modal ----
+    let confirmTypedText = $state("");
+    // Reset the typed-verification text whenever a new request opens.
+    $effect(() => {
+        void store.confirmRequest;
+        confirmTypedText = "";
+    });
+
+    function handleConfirmKeydown(e) {
+        if (store.confirmRequest && e.key === "Escape") {
+            e.preventDefault();
+            store.resolveConfirm(false);
+        }
+    }
+
+    async function confirmForget(account) {
+        const label = account.metadata?.bandName
+            ? `${account.metadata.bandName} (${account.address})`
+            : account.address;
+        const confirmed = await store.requestConfirm({
+            title: `Forget ${label}?`,
+            message:
+                "Removes this account's saved songs, setlists, and sign-in from this device. Data on the remoteStorage server is untouched.",
+            confirmLabel: "Forget",
+        });
+        if (confirmed) store.forgetAccount(account.address);
+    }
+
     // Prompt-style service-worker updates. autoUpdate reloaded the page the
     // moment a new deploy activated — mid-gig, that could eat an unsaved
     // setlist. Instead we surface a persistent toast and let the user pick
@@ -154,7 +182,7 @@
                                 <span class="recent-band">{account.metadata?.bandName || "Unnamed"}</span>
                                 <span class="recent-address">{account.address}</span>
                             </button>
-                            <button type="button" class="recent-forget" onclick={() => store.forgetAccount(account.address)} aria-label="Forget account">&times;</button>
+                            <button type="button" class="recent-forget" onclick={() => confirmForget(account)} aria-label="Forget account">&times;</button>
                         </div>
                     {/each}
                 </div>
@@ -179,6 +207,48 @@
                 />
             </label>
             <button type="button" class="btn primary" onclick={store.finishFirstRun}>Save</button>
+        </div>
+    </div>
+{/if}
+
+<svelte:window onkeydown={handleConfirmKeydown} />
+
+{#if store.confirmRequest}
+    {@const confirm = store.confirmRequest}
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div class="modal-backdrop confirm-backdrop" onclick={() => store.resolveConfirm(false)}>
+        <div
+            class="modal"
+            role="alertdialog"
+            aria-modal="true"
+            aria-label={confirm.title}
+            onclick={(e) => e.stopPropagation()}
+        >
+            <h3>{confirm.title}</h3>
+            {#if confirm.message}
+                <p class="modal-desc">{confirm.message}</p>
+            {/if}
+            {#if confirm.requireText}
+                <label class="field">
+                    <span>Type <strong>{confirm.requireText}</strong> to confirm</span>
+                    <input
+                        value={confirmTypedText}
+                        oninput={(e) => { confirmTypedText = e.currentTarget.value; }}
+                        placeholder={confirm.requireText}
+                        autocomplete="off"
+                    />
+                </label>
+            {/if}
+            <div class="confirm-actions">
+                <button type="button" class="btn" onclick={() => store.resolveConfirm(false)}>{confirm.cancelLabel}</button>
+                <button
+                    type="button"
+                    class="btn danger"
+                    disabled={!!confirm.requireText && confirmTypedText.trim() !== confirm.requireText}
+                    onclick={() => store.resolveConfirm(true)}
+                >{confirm.confirmLabel}</button>
+            </div>
         </div>
     </div>
 {/if}
@@ -475,6 +545,32 @@
     .modal-desc {
         color: var(--muted);
         font-size: 0.9rem;
+    }
+
+    /* Destructive-confirm modal sits above everything, including the
+       song-editor overlay (z-index 300). */
+    .confirm-backdrop {
+        z-index: 400;
+    }
+
+    .confirm-actions {
+        display: flex;
+        gap: var(--space-2);
+        justify-content: flex-end;
+    }
+
+    .confirm-actions .btn {
+        flex: 1;
+    }
+
+    .btn.danger {
+        color: var(--on-accent);
+        background: var(--danger);
+        border-color: transparent;
+    }
+
+    .btn.danger:disabled {
+        opacity: 0.4;
     }
 
     /* ---- Busy overlay ---- */

--- a/src/lib/components/songs/SongEditor.svelte
+++ b/src/lib/components/songs/SongEditor.svelte
@@ -17,7 +17,6 @@
     );
 
     let expandedMember = $state("");
-    let confirmingDelete = $state(false);
     // Per-instrument-row "New instrument" naming state, keyed member::index.
     let namingInstrument = $state({});
     // Local drafts for the tuning/technique quick-add inputs (staged into
@@ -34,8 +33,16 @@
         return `${memberName}::${index}`;
     }
 
-    function handleBack() {
-        if (isDirty && !window.confirm("Discard unsaved changes to this song?")) return;
+    async function handleBack() {
+        if (isDirty) {
+            const confirmed = await store.requestConfirm({
+                title: "Discard changes?",
+                message: "Your edits to this song will be lost.",
+                confirmLabel: "Discard",
+                cancelLabel: "Keep editing",
+            });
+            if (!confirmed) return;
+        }
         store.closeEditor();
     }
 
@@ -187,16 +194,9 @@
     }
 
     function handleDelete() {
-        if (confirmingDelete) {
-            store.deleteSong(store.editorSong);
-            confirmingDelete = false;
-        } else {
-            confirmingDelete = true;
-        }
-    }
-
-    function cancelDelete() {
-        confirmingDelete = false;
+        // store.deleteSong shows the app-wide destructive-confirm modal —
+        // no inline second step needed here anymore.
+        store.deleteSong(store.editorSong);
     }
 </script>
 
@@ -498,15 +498,7 @@
         <div class="bottom-actions">
             <button type="button" class="secondary-btn full-width" onclick={() => store.duplicateSong(store.editorSong)}>Duplicate song</button>
 
-            {#if confirmingDelete}
-                <div class="delete-confirm">
-                    <span class="delete-warn">Are you sure? This cannot be undone.</span>
-                    <div class="delete-confirm-btns">
-                        <button type="button" class="danger-btn" onclick={handleDelete}>Yes, delete</button>
-                        <button type="button" class="secondary-btn" onclick={cancelDelete}>Cancel</button>
-                    </div>
-                </div>
-            {:else if !isNewSong}
+            {#if !isNewSong}
                 <button type="button" class="danger-text-btn full-width" onclick={handleDelete}>Delete song</button>
             {/if}
         </div>
@@ -954,23 +946,6 @@
         background: rgba(200, 40, 40, 0.06);
     }
 
-    .danger-btn {
-        min-height: 2.8rem;
-        padding: 0.55rem 1rem;
-        border: none;
-        border-radius: var(--radius-md, 12px);
-        background: var(--danger, #d33);
-        color: var(--on-accent);
-        font-weight: 700;
-        font-size: 0.88rem;
-        cursor: pointer;
-        touch-action: manipulation;
-    }
-
-    .danger-btn:active {
-        opacity: 0.85;
-    }
-
     .full-width {
         width: 100%;
     }
@@ -979,25 +954,5 @@
         display: grid;
         gap: 0.6rem;
         padding-top: 0.5rem;
-    }
-
-    .delete-confirm {
-        display: grid;
-        gap: 0.5rem;
-        padding: 1rem;
-        border-radius: var(--radius-md, 12px);
-        background: rgba(200, 40, 40, 0.05);
-        border: 1px solid rgba(200, 40, 40, 0.15);
-    }
-
-    .delete-warn {
-        font-weight: 600;
-        font-size: 0.88rem;
-        color: var(--danger, #d33);
-    }
-
-    .delete-confirm-btns {
-        display: flex;
-        gap: 0.5rem;
     }
 </style>

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -534,6 +534,43 @@ export function createAppStore(repo) {
     function dismissToast(id) {
         toastMessages = toastMessages.filter((t) => t.id !== id);
     }
+
+    // ---- destructive confirm ----
+    // In-app replacement for window.confirm (#60): native dialogs look
+    // foreign in the installed PWA and the chained deleteAllData confirms
+    // were easy to misclick through. One request at a time; App.svelte
+    // renders the modal and calls resolveConfirm.
+    let confirmRequest = $state(null);
+
+    /**
+     * Ask the user to confirm a destructive action. Resolves true/false.
+     * options: { title, message?, confirmLabel?, cancelLabel?, requireText? }
+     * — requireText demands the user type the given string (e.g. the band
+     * name) before the confirm button enables.
+     */
+    function requestConfirm(options) {
+        return new Promise((resolve) => {
+            // A newer request supersedes a pending one, which resolves as
+            // cancelled — never leave a caller hanging.
+            if (confirmRequest) confirmRequest.resolve(false);
+            confirmRequest = {
+                title: "Are you sure?",
+                message: "",
+                confirmLabel: "Confirm",
+                cancelLabel: "Cancel",
+                requireText: "",
+                ...options,
+                resolve,
+            };
+        });
+    }
+
+    function resolveConfirm(result) {
+        const request = confirmRequest;
+        confirmRequest = null;
+        request?.resolve(Boolean(result));
+    }
+
     /**
      * Run a toast's action button and dismiss it. Lives here (not inline in
      * the template) because the template's {@const toast} re-evaluates the
@@ -1702,7 +1739,12 @@ export function createAppStore(repo) {
     }
 
     async function deleteSong(song) {
-        if (!window.confirm(`Delete "${song.name}"?`)) return;
+        const confirmed = await requestConfirm({
+            title: `Delete "${song.name}"?`,
+            message: "This cannot be undone.",
+            confirmLabel: "Delete",
+        });
+        if (!confirmed) return;
         const sessionAlive = sessionGuard();
         try {
             busyMessage = `Deleting "${song.name}"...`;
@@ -1719,8 +1761,17 @@ export function createAppStore(repo) {
     }
 
     async function deleteAllData() {
-        if (!window.confirm("This will delete ALL songs, band config, and saved setlists. This cannot be undone.\n\nAre you sure?")) return;
-        if (!window.confirm("Really? Everything will be gone forever.")) return;
+        // Typed-name verification instead of the old chained double
+        // window.confirm (near-identical wording made it easy to click
+        // through both without reading).
+        const confirmed = await requestConfirm({
+            title: "Delete ALL data?",
+            message:
+                "Every song, saved setlist, band member, and setting will be permanently deleted — locally and from your remoteStorage. This cannot be undone.",
+            confirmLabel: "Delete everything",
+            requireText: appConfig?.bandName || "",
+        });
+        if (!confirmed) return;
         const sessionAlive = sessionGuard();
         // Bail out cleanly if the user switches accounts mid-wipe: any
         // further deletes would run against the NEW account's storage paths.
@@ -2029,15 +2080,17 @@ export function createAppStore(repo) {
 
     async function removeBandMember(memberName) {
         const usedIn = songsUsingMember(memberName);
-        if (usedIn.length > 0) {
-            const names = usedIn.slice(0, 5).map((s) => s.name).join(", ");
-            const extra = usedIn.length > 5 ? ` and ${usedIn.length - 5} more` : "";
-            if (!window.confirm(
-                `"${memberName}" is referenced in ${usedIn.length} song${usedIn.length === 1 ? "" : "s"}: ${names}${extra}.\n\nRemoving this member from the band config won't change existing songs, but new setlists won't account for their setup.\n\nAre you sure?`
-            )) return;
-        } else {
-            if (!window.confirm(`Remove "${memberName}" from the band?`)) return;
-        }
+        const names = usedIn.slice(0, 5).map((s) => s.name).join(", ");
+        const extra = usedIn.length > 5 ? ` and ${usedIn.length - 5} more` : "";
+        const confirmed = await requestConfirm({
+            title: `Remove "${memberName}" from the band?`,
+            message:
+                usedIn.length > 0
+                    ? `${memberName} is referenced in ${usedIn.length} song${usedIn.length === 1 ? "" : "s"} (${names}${extra}). Existing songs keep their setups, but new setlists won't account for ${memberName}.`
+                    : "",
+            confirmLabel: "Remove",
+        });
+        if (!confirmed) return;
         const sessionAlive = sessionGuard();
         try {
             await withSync("Removing member", () => repo.deleteMember(memberName));
@@ -2066,15 +2119,17 @@ export function createAppStore(repo) {
 
     async function removeBandMemberInstrument(memberName, instrumentName) {
         const usedIn = songsUsingInstrument(memberName, instrumentName);
-        if (usedIn.length > 0) {
-            const names = usedIn.slice(0, 5).map((s) => s.name).join(", ");
-            const extra = usedIn.length > 5 ? ` and ${usedIn.length - 5} more` : "";
-            if (!window.confirm(
-                `"${instrumentName}" for ${memberName} is used in ${usedIn.length} song${usedIn.length === 1 ? "" : "s"}: ${names}${extra}.\n\nRemoving it from the band config won't change existing songs, but the instrument won't appear as a choice for new songs.\n\nAre you sure?`
-            )) return;
-        } else {
-            if (!window.confirm(`Remove "${instrumentName}" from ${memberName}?`)) return;
-        }
+        const names = usedIn.slice(0, 5).map((s) => s.name).join(", ");
+        const extra = usedIn.length > 5 ? ` and ${usedIn.length - 5} more` : "";
+        const confirmed = await requestConfirm({
+            title: `Remove "${instrumentName}" from ${memberName}?`,
+            message:
+                usedIn.length > 0
+                    ? `It's used in ${usedIn.length} song${usedIn.length === 1 ? "" : "s"} (${names}${extra}). Existing songs keep it, but it won't be offered for new songs.`
+                    : "",
+            confirmLabel: "Remove",
+        });
+        if (!confirmed) return;
         const member = bandMembers[memberName] || { instruments: [] };
         const updated = { ...member, instruments: (member.instruments || []).filter((i) => i.name !== instrumentName) };
         if (await persistMemberEdit(memberName, updated)) toastInfo(`Removed ${instrumentName} from ${memberName}.`);
@@ -2118,9 +2173,12 @@ export function createAppStore(repo) {
         if (usedIn.length > 0) {
             const names = usedIn.slice(0, 5).map((s) => s.name).join(", ");
             const extra = usedIn.length > 5 ? ` and ${usedIn.length - 5} more` : "";
-            if (!window.confirm(
-                `"${tuning}" tuning for ${memberName}'s ${instrumentName} is used in ${usedIn.length} song${usedIn.length === 1 ? "" : "s"}: ${names}${extra}.\n\nRemoving it won't change existing songs, but the tuning won't appear as a choice for new songs.\n\nAre you sure?`
-            )) return;
+            const confirmed = await requestConfirm({
+                title: `Remove "${tuning}" from ${instrumentName}?`,
+                message: `It's used in ${usedIn.length} song${usedIn.length === 1 ? "" : "s"} (${names}${extra}). Existing songs keep it, but it won't be offered for new songs.`,
+                confirmLabel: "Remove",
+            });
+            if (!confirmed) return;
         }
         const member = bandMembers[memberName] || { instruments: [] };
         const currentInstruments = member.instruments || [];
@@ -2170,9 +2228,12 @@ export function createAppStore(repo) {
         if (usedIn.length > 0) {
             const names = usedIn.slice(0, 5).map((s) => s.name).join(", ");
             const extra = usedIn.length > 5 ? ` and ${usedIn.length - 5} more` : "";
-            if (!window.confirm(
-                `"${technique}" technique for ${memberName}'s ${instrumentName} is used in ${usedIn.length} song${usedIn.length === 1 ? "" : "s"}: ${names}${extra}.\n\nRemoving it won't change existing songs, but the technique won't appear as a choice for new songs.\n\nAre you sure?`
-            )) return;
+            const confirmed = await requestConfirm({
+                title: `Remove "${technique}" from ${instrumentName}?`,
+                message: `It's used in ${usedIn.length} song${usedIn.length === 1 ? "" : "s"} (${names}${extra}). Existing songs keep it, but it won't be offered for new songs.`,
+                confirmLabel: "Remove",
+            });
+            if (!confirmed) return;
         }
         const member = bandMembers[memberName] || { instruments: [] };
         const currentInstruments = member.instruments || [];
@@ -2724,6 +2785,9 @@ export function createAppStore(repo) {
         toastAction,
         dismissToast,
         runToastAction,
+        get confirmRequest() { return confirmRequest; },
+        requestConfirm,
+        resolveConfirm,
         songsUsingMember,
         songsUsingInstrument,
         songsUsingTuning,

--- a/src/lib/stores/app.test.js
+++ b/src/lib/stores/app.test.js
@@ -174,6 +174,40 @@ describe("sticky action toasts", () => {
     });
 });
 
+describe("destructive confirm", () => {
+    it("resolves with the user's choice and supersedes pending requests", async () => {
+        const store = createAppStore({});
+        const first = store.requestConfirm({ title: "First?" });
+        expect(store.confirmRequest.title).toBe("First?");
+
+        // A newer request supersedes the pending one, which resolves as
+        // cancelled — callers are never left hanging.
+        const second = store.requestConfirm({ title: "Second?" });
+        await expect(first).resolves.toBe(false);
+        expect(store.confirmRequest.title).toBe("Second?");
+
+        store.resolveConfirm(true);
+        await expect(second).resolves.toBe(true);
+        expect(store.confirmRequest).toBeNull();
+    });
+
+    it("deleteSong runs only after the confirm resolves true", async () => {
+        const repo = { deleteSong: vi.fn(async () => {}) };
+        const store = createAppStore(repo);
+
+        const cancelled = store.deleteSong({ id: "s1", name: "Doomed" });
+        expect(store.confirmRequest.title).toContain("Doomed");
+        store.resolveConfirm(false);
+        await cancelled;
+        expect(repo.deleteSong).not.toHaveBeenCalled();
+
+        const confirmed = store.deleteSong({ id: "s1", name: "Doomed" });
+        store.resolveConfirm(true);
+        await confirmed;
+        expect(repo.deleteSong).toHaveBeenCalledTimes(1);
+    });
+});
+
 describe("incremental remote sync", () => {
     // The store's init() needs window + localStorage; we're in node, so
     // polyfill exactly those. (jsdom would trip Svelte's top-level-$effect

--- a/tests/e2e/band.spec.ts
+++ b/tests/e2e/band.spec.ts
@@ -123,9 +123,9 @@ test.describe("Band screen — members", () => {
 
         const band = new BandPage(page);
         await band.openMemberEdit("Alice");
-        // The store calls window.confirm — auto-accept it.
-        page.once("dialog", (d) => d.accept());
         await band.removeMemberButton.click();
+        // Confirm via the in-app destructive modal.
+        await page.locator(".confirm-backdrop .modal").getByRole("button", { name: "Remove", exact: true }).click();
         await band.expectMemberAbsent("Alice");
     });
 });

--- a/tests/e2e/data-management.spec.ts
+++ b/tests/e2e/data-management.spec.ts
@@ -254,7 +254,7 @@ test.describe("Delete all data", () => {
         expect(state.appConfig).toBeNull();
     });
 
-    test("cancelling the first confirm leaves data intact", async ({ page, app }) => {
+    test("cancelling the confirm leaves data intact", async ({ page, app }) => {
         await app.seed(
             buildSeed({
                 songs: { s1: makeSong({ id: "s1", name: "Survives" }) },
@@ -266,7 +266,7 @@ test.describe("Delete all data", () => {
         await shell.gotoBand();
 
         const band = new BandPage(page);
-        await band.cancelDeleteAllData(page, 1);
+        await band.cancelDeleteAllData(page);
 
         // No first-run prompt; data still there
         await expect(shell.firstRunModal).toBeHidden();
@@ -274,7 +274,7 @@ test.describe("Delete all data", () => {
         await expect(new SongsPage(page).songRow("Survives")).toBeVisible();
     });
 
-    test("cancelling the second confirm leaves data intact", async ({ page, app }) => {
+    test("cancelling after typing the band name still leaves data intact", async ({ page, app }) => {
         await app.seed(
             buildSeed({
                 songs: { s1: makeSong({ id: "s1", name: "AlsoSurvives" }) },
@@ -286,10 +286,28 @@ test.describe("Delete all data", () => {
         await shell.gotoBand();
 
         const band = new BandPage(page);
-        await band.cancelDeleteAllData(page, 2);
+        await band.cancelDeleteAllData(page, { typeName: "Test Band" });
 
         await expect(shell.firstRunModal).toBeHidden();
         await shell.gotoSongs();
         await expect(new SongsPage(page).songRow("AlsoSurvives")).toBeVisible();
+    });
+
+    test("the delete button stays disabled until the band name is typed", async ({ page, app }) => {
+        await app.seed(buildSeed());
+        await app.goto();
+        await app.waitForReady();
+        await new AppShell(page).gotoBand();
+
+        await new BandPage(page).deleteAllButton.click();
+        const modal = page.locator(".confirm-backdrop .modal");
+        await expect(modal).toBeVisible();
+        const confirmBtn = modal.getByRole("button", { name: "Delete everything" });
+        await expect(confirmBtn).toBeDisabled();
+        await modal.locator("input").fill("Wrong Name");
+        await expect(confirmBtn).toBeDisabled();
+        await modal.locator("input").fill("Test Band");
+        await expect(confirmBtn).toBeEnabled();
+        await modal.getByRole("button", { name: "Cancel" }).click();
     });
 });

--- a/tests/e2e/song-editor.spec.ts
+++ b/tests/e2e/song-editor.spec.ts
@@ -94,9 +94,9 @@ test.describe("Song editor — basics", () => {
         await editor.waitForVisible();
         await editor.fillName("Changed In Memory");
 
-        // Cancel the discard confirm — nothing is lost.
-        page.once("dialog", (d) => d.dismiss());
+        // Cancel the discard confirm (in-app modal) — nothing is lost.
         await editor.backButton.click();
+        await editor.confirmModal().getByRole("button", { name: "Keep editing" }).click();
         await expect(editor.overlay).toBeVisible();
         await expect(editor.nameInput).toHaveValue("Changed In Memory");
     });

--- a/tests/pages/BandPage.ts
+++ b/tests/pages/BandPage.ts
@@ -141,46 +141,30 @@ export class BandPage {
     }
 
     /**
-     * Delete-all is gated behind TWO sequential window.confirm dialogs, so
-     * tests need to register both handlers before clicking the button.
+     * Delete-all is gated behind the in-app confirm modal with typed
+     * band-name verification: type the name, then click Delete everything.
      */
-    async confirmDeleteAllData(page: Page) {
-        let dialogsSeen = 0;
-        const onDialog = (d: import("@playwright/test").Dialog) => {
-            dialogsSeen += 1;
-            d.accept();
-        };
-        page.on("dialog", onDialog);
-        try {
-            await this.deleteAllButton.click();
-            // Wait until both confirms have appeared. Using a short poll
-            // because dialogs fire on a microtask after click.
-            await expect.poll(() => dialogsSeen, { timeout: 5_000 }).toBe(2);
-        } finally {
-            page.off("dialog", onDialog);
-        }
+    async confirmDeleteAllData(page: Page, bandName = "Test Band") {
+        await this.deleteAllButton.click();
+        const modal = page.locator(".confirm-backdrop .modal");
+        await expect(modal).toBeVisible();
+        await modal.locator("input").fill(bandName);
+        await modal.getByRole("button", { name: "Delete everything" }).click();
+        await expect(modal).toBeHidden();
     }
 
     /**
-     * Click delete-all but cancel one of the confirms — used to verify the
-     * abort path doesn't wipe data.
+     * Open the delete-all confirm but cancel — used to verify the abort
+     * path doesn't wipe data. Optionally type the band name first (the
+     * "got all the way there and still bailed" path).
      */
-    async cancelDeleteAllData(page: Page, atStep: 1 | 2 = 1) {
-        let dialogsSeen = 0;
-        const onDialog = (d: import("@playwright/test").Dialog) => {
-            dialogsSeen += 1;
-            if (dialogsSeen === atStep) d.dismiss();
-            else d.accept();
-        };
-        page.on("dialog", onDialog);
-        try {
-            await this.deleteAllButton.click();
-            await expect.poll(() => dialogsSeen, { timeout: 5_000 }).toBeGreaterThanOrEqual(atStep);
-        } finally {
-            // Allow a beat for any trailing dialog before unsubscribing.
-            await page.waitForTimeout(100);
-            page.off("dialog", onDialog);
-        }
+    async cancelDeleteAllData(page: Page, { typeName = "" } = {}) {
+        await this.deleteAllButton.click();
+        const modal = page.locator(".confirm-backdrop .modal");
+        await expect(modal).toBeVisible();
+        if (typeName) await modal.locator("input").fill(typeName);
+        await modal.getByRole("button", { name: "Cancel" }).click();
+        await expect(modal).toBeHidden();
     }
 
     /**

--- a/tests/pages/ConnectPage.ts
+++ b/tests/pages/ConnectPage.ts
@@ -66,5 +66,9 @@ export class ConnectPage {
 
     async forgetAccount(address: string) {
         await this.recentAccountByAddress(address).getByRole("button", { name: "Forget account" }).click();
+        // Forgetting now asks via the in-app confirm modal (#67).
+        const modal = this.page.locator(".confirm-backdrop .modal");
+        await modal.getByRole("button", { name: "Forget" }).click();
+        await modal.waitFor({ state: "hidden" });
     }
 }

--- a/tests/pages/SongEditorPage.ts
+++ b/tests/pages/SongEditorPage.ts
@@ -62,25 +62,28 @@ export class SongEditorPage {
         await expect(this.overlay).toBeHidden();
     }
 
+    /** The app-wide destructive-confirm modal (replaces window.confirm). */
+    confirmModal(): Locator {
+        return this.page.locator(".confirm-backdrop .modal");
+    }
+
     /** Close a dirty editor, accepting the discard-changes confirm. */
     async closeDiscarding() {
-        this.page.once("dialog", (d) => d.accept());
         await this.backButton.click();
+        await this.confirmModal().getByRole("button", { name: "Discard" }).click();
         await expect(this.overlay).toBeHidden();
     }
 
     async confirmDelete() {
-        // First click reveals the confirm; second commits.
         await this.deleteButton.click();
-        // The store's deleteSong() also calls window.confirm() — auto-accept it.
-        this.page.once("dialog", (d) => d.accept());
-        await this.overlay.getByRole("button", { name: "Yes, delete" }).click();
+        await this.confirmModal().getByRole("button", { name: "Delete", exact: true }).click();
         await expect(this.overlay).toBeHidden();
     }
 
     async cancelDelete() {
         await this.deleteButton.click();
-        await this.overlay.getByRole("button", { name: "Cancel" }).click();
+        await this.confirmModal().getByRole("button", { name: "Cancel" }).click();
+        await expect(this.confirmModal()).toBeHidden();
     }
 
     async duplicate() {

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,48 @@ import { VitePWA } from "vite-plugin-pwa";
 
 const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
 
+// Content-Security-Policy (#79). remoteStorage tokens live in localStorage
+// (the standard unhosted-app pattern); the app loads no third-party JS, and
+// this policy makes that a guarantee — any injected inline/external script
+// is refused by the browser. Notes:
+// - script-src 'self': no inline scripts anywhere (theme init is an
+//   external file in /public for exactly this reason).
+// - style-src 'unsafe-inline': Svelte sets style attributes (e.g. dynamic
+//   accent colors); component CSS itself is an external file.
+// - connect-src https: http:: rs.js talks to whatever storage host the
+//   user's WebFinger points at, including plain-HTTP LAN servers.
+// - Injected at build time only, so the dev server (HMR websockets,
+//   plugin injections) stays unrestricted.
+const CSP_POLICY = [
+    "default-src 'self'",
+    "script-src 'self'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob:",
+    "font-src 'self'",
+    "connect-src 'self' https: http:",
+    "worker-src 'self' blob:",
+    "manifest-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+].join("; ");
+
+function cspPlugin() {
+    return {
+        name: "inject-csp",
+        apply: "build",
+        transformIndexHtml() {
+            return [
+                {
+                    tag: "meta",
+                    attrs: { "http-equiv": "Content-Security-Policy", content: CSP_POLICY },
+                    injectTo: "head-prepend",
+                },
+            ];
+        },
+    };
+}
+
 // Staging builds (vite build --mode staging, via npm run build:staging and
 // .github/workflows/staging.yml) trade a few bytes for debuggability:
 // sourcemaps, preserved function/class names in stack traces, a "-staging"
@@ -16,6 +58,7 @@ export default defineConfig(({ mode }) => {
     return {
         plugins: [
             svelte(),
+            cspPlugin(),
             VitePWA({
                 // Update flow: "prompt" means a new deploy waits until the user
                 // taps Refresh (see registerSW in App.svelte) instead of


### PR DESCRIPTION
Closes #60
Closes #67
Closes #79

## In-app destructive confirm (#60, #67)

- New store primitive `requestConfirm(options) → Promise<boolean>` with a single globally-rendered modal (sits above the song-editor overlay; Escape/backdrop cancel; a newer request supersedes a pending one as cancelled).
- **All ten `window.confirm` sites converted**: song delete, delete-all-data, member/instrument/tuning/technique removal, and the song editor's discard-changes guard. The editor's redundant inline two-step delete is removed — one confirm pattern everywhere, styled like the app instead of the system dialog.
- **`deleteAllData` now requires typing the band name** ("Delete everything" stays disabled until it matches) — replacing the old chained double confirm whose near-identical wording was easy to click through.
- **Forget (×) on the login screen confirms first** (#67) — it deletes the account's entire local mirror, so a bare mistappable 44×44 target was no longer acceptable.

## Content-Security-Policy (#79)

- Strict policy injected as a meta tag **at build time only** (the dev server stays unrestricted for HMR): `default-src 'self'`, `script-src 'self'` (no inline allowance), `style-src 'self' 'unsafe-inline'` (Svelte style attributes), `img-src 'self' data: blob:`, `connect-src 'self' https: http:` (rs.js talks to whatever host the user's WebFinger points at, including plain-HTTP LAN servers), `worker-src 'self' blob:`, `object-src 'none'`, `base-uri 'self'`, `form-action 'self'`.
- To keep `script-src 'self'` hash-free, the inline FOITC theme script moved to `/public/theme-init.js` (blocking external script, precached by the SW).
- With no third-party JS and now no inline script surface, localStorage-token exfiltration via injected script is refused by the browser — the property #79 asked to formalize.

## Testing

- 336 unit tests (new: confirm request/supersede semantics; deleteSong gated on confirm).
- 158/158 chromium e2e and 158/158 mobile (WebKit) e2e — page objects/specs updated from native-dialog handlers to the modal, plus new coverage: typed-name gating for delete-all, cancel-after-typing, and the discard-confirm keep-editing path.
- Real-browser smoke against the CSP'd production build: boot, offline mirror hydrate, theme init, favicon, toast actions — zero CSP violations.

## Note for staging verification

Worth one pass on setlist-staging.5apps.com after deploy: the OAuth redirect + `auth-relay.html` flow under CSP, and an installed-PWA session (Workbox + dynamic icons run under `worker-src`/`img-src blob:`).