### PR TITLE
Improve setlist selection and add song pinning

### DIFF
--- a/src/lib/components/roll/RollScreen.svelte
+++ b/src/lib/components/roll/RollScreen.svelte
@@ -15,7 +15,10 @@
   let showAddSongPicker = $state(false);
   let addSongSearch = $state("");
   let setlistSongIds = $derived(
-    new Set((store.displayedSetlist?.songs || []).map((s) => s.id))
+    new Set([
+      ...(store.displayedSetlist?.songs || []).map((s) => s.id),
+      ...(store.preRollPinnedSongs || []).map((s) => s.id),
+    ])
   );
   // Unpracticed songs stay listed — adding one to a set is a deliberate
   // band decision (the roller itself won't pick them unless allowed in
@@ -113,11 +116,6 @@
   function selectedTuningCount(memberName, instName) {
     return (store.generationOptions.show?.members?.[memberName]?.allowedTunings?.[instName] || []).length;
   }
-
-  // Variety slider: maps 0-100 to temperature 0.3-2.0
-  function varietyToTemp(v) { return 0.3 + (v / 100) * 1.7; }
-  function tempToVariety(t) { return Math.round(((t - 0.3) / 1.7) * 100); }
-  let varietyValue = $derived(tempToVariety(store.generationOptions.randomness?.temperature ?? 0.85));
 
   let settingsTab = $state("constraints");
   let hasConstraints = $derived(membersWithChoices().length > 0);
@@ -335,7 +333,7 @@
             {/each}
           </svg>
         </span>
-        <span class="roll-label">{store.isGenerating ? "Rolling..." : "Roll"}</span>
+        <span class="roll-label">{store.isGenerating ? "Rolling..." : store.pinnedSongCount ? "Reroll" : "Roll"}</span>
         {#if showConfetti}
           <span class="confetti-burst">
             {#each Array(12) as _, i}
@@ -356,11 +354,41 @@
       {#if hasConstraints}
         <div class="settings-tabs">
           <button type="button" class="settings-tab" class:active={settingsTab === "constraints"} onclick={() => { settingsTab = "constraints"; }}>Demands</button>
-          <button type="button" class="settings-tab" class:active={settingsTab === "chaos"} onclick={() => { settingsTab = "chaos"; }}>Tweak the Chaos</button>
+          <button type="button" class="settings-tab" class:active={settingsTab === "chaos"} onclick={() => { settingsTab = "chaos"; }}>Shape the Set</button>
         </div>
       {/if}
 
       {#if settingsTab === "chaos" || !hasConstraints}
+        <div class="quick-row">
+          <label class="adv-field">
+            <span>Set shape</span>
+            <select value={store.generationOptions.setShape || "build"} onchange={(e) => store.updateGenerationField("setShape", e.currentTarget.value)}>
+              <option value="build">Build steadily</option>
+              <option value="big-ends">Big start and finish</option>
+              <option value="alternating">Alternating energy</option>
+              <option value="lively">Keep it lively</option>
+              <option value="none">No preference</option>
+            </select>
+          </label>
+          <label class="adv-field">
+            <span>Song mix</span>
+            <select value={store.generationOptions.rotation || "balanced"} onchange={(e) => store.updateGenerationField("rotation", e.currentTarget.value)}>
+              <option value="hits">Greatest hits</option>
+              <option value="balanced">Balanced</option>
+              <option value="deep">Dig deeper</option>
+            </select>
+          </label>
+        </div>
+
+        <label class="adv-field">
+          <span>Transition smoothness</span>
+          <select value={store.generationOptions.transitionSmoothness || "balanced"} onchange={(e) => store.updateGenerationField("transitionSmoothness", e.currentTarget.value)}>
+            <option value="smooth">Smooth</option>
+            <option value="balanced">Balanced</option>
+            <option value="adventurous">Anything goes</option>
+          </select>
+        </label>
+
         <div class="quick-row">
           <div class="adv-field">
             <span>Max covers</span>
@@ -404,8 +432,8 @@
 
         <div class="variety-field">
           <div class="variety-header">
-            <span class="variety-label">Variety</span>
-            <span class="variety-hint">{varietyValue >= 100 ? "YOLO 🤘" : varietyValue < 30 ? "Safe pick" : varietyValue > 70 ? "Hold my beer" : "Feels right"}</span>
+            <span class="variety-label">Selection variety</span>
+            <span class="variety-hint">{store.generationOptions.selectionVariety < 30 ? "Reliable picks" : store.generationOptions.selectionVariety > 70 ? "More surprises" : "Balanced"}</span>
           </div>
           <input
             class="variety-slider"
@@ -413,12 +441,12 @@
             min="0"
             max="100"
             step="1"
-            value={varietyValue}
-            oninput={(e) => store.updateGenerationField("randomness.temperature", varietyToTemp(Number(e.currentTarget.value)))}
+            value={store.generationOptions.selectionVariety ?? 50}
+            oninput={(e) => store.updateGenerationField("selectionVariety", Number(e.currentTarget.value))}
           />
           <div class="variety-labels">
-            <span>Safe pick</span>
-            <span>Hold my beer</span>
+            <span>Reliable picks</span>
+            <span>More surprises</span>
           </div>
         </div>
 
@@ -531,6 +559,28 @@
     </div>
   {/if}
 
+  {#if !store.displayedSetlist && store.preRollPinnedSongs.length > 0}
+    <section class="pre-roll-pins" aria-label="Pinned songs">
+      <div class="pre-roll-pins-header">
+        <div>
+          <h3>Pinned songs</h3>
+          <p>These are guaranteed a place when you roll.</p>
+        </div>
+        <button type="button" class="save-set-btn add-song-btn" onclick={() => { showAddSongPicker = true; }}>+ Pin song</button>
+      </div>
+      <div class="pre-roll-pin-list">
+        {#each store.preRollPinnedSongs as song}
+          <div class="pre-roll-pin">
+            <span>📌 {song.name}</span>
+            <button type="button" aria-label={`Unpin ${song.name}`} onclick={() => store.unpinSongBeforeRoll(song.id)}>×</button>
+          </div>
+        {/each}
+      </div>
+    </section>
+  {:else if !store.displayedSetlist && hasSongs}
+    <button type="button" class="pre-roll-add" onclick={() => { showAddSongPicker = true; }}>+ Pin songs before rolling</button>
+  {/if}
+
   <!-- Getting Started -->
   {#if !readyToRoll && store.syncState !== 'syncing'}
     <div class="onboarding-card">
@@ -591,6 +641,7 @@
               onDragStart={handleDragStart}
               onEdit={handleEditSong}
               onRemove={(idx) => store.removeSetlistSong(idx)}
+              onTogglePin={store.toggleSetlistSongPin}
               arming={dragArmingIndex === i}
               dragging={dragIndex === i}
             />
@@ -653,7 +704,12 @@
               class="add-song-item"
               class:in-setlist={inSetlist}
               disabled={inSetlist}
-              onclick={() => { store.addSetlistSong(song.id); showAddSongPicker = false; addSongSearch = ""; }}
+              onclick={() => {
+                if (store.displayedSetlist) store.addSetlistSong(song.id);
+                else store.pinSongBeforeRoll(song.id);
+                showAddSongPicker = false;
+                addSongSearch = "";
+              }}
             >
               {song.name}
               {#if song.unpracticed}<span class="unpracticed-tag">unpracticed</span>{/if}
@@ -677,6 +733,64 @@
     padding: 0.5rem;
     max-width: 540px;
     margin: 0 auto;
+  }
+
+  .pre-roll-add {
+    justify-self: center;
+    padding: 0.65rem 1rem;
+    border: 1px dashed var(--accent-line);
+    border-radius: var(--radius-md, 12px);
+    background: var(--accent-soft);
+    color: var(--accent);
+    font-size: 0.9rem;
+    font-weight: 700;
+    cursor: pointer;
+  }
+
+  .pre-roll-pins {
+    display: grid;
+    gap: 0.75rem;
+    padding: 0.9rem;
+    border: 1px solid var(--accent-line);
+    border-radius: var(--radius-lg, 16px);
+    background: var(--accent-soft);
+  }
+
+  .pre-roll-pins-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .pre-roll-pins h3,
+  .pre-roll-pins p {
+    margin: 0;
+  }
+
+  .pre-roll-pins h3 { font-size: 0.95rem; }
+  .pre-roll-pins p { margin-top: 0.15rem; color: var(--muted); font-size: 0.78rem; }
+
+  .pre-roll-pin-list { display: grid; gap: 0.4rem; }
+  .pre-roll-pin {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.5rem 0.65rem;
+    border-radius: var(--radius-sm, 8px);
+    background: var(--paper-strong);
+    font-weight: 700;
+  }
+
+  .pre-roll-pin button {
+    width: 32px;
+    min-height: 32px;
+    border: 0;
+    background: transparent;
+    color: var(--muted);
+    font-size: 20px;
+    cursor: pointer;
   }
 
   @media (min-width: 400px) {
@@ -1031,6 +1145,18 @@
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 0.65rem;
+  }
+
+  .adv-field select {
+    width: 100%;
+    min-height: 2.5rem;
+    padding: 0.45rem 0.55rem;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-sm, 8px);
+    background: var(--paper-strong);
+    color: var(--ink);
+    font: inherit;
+    font-size: 16px;
   }
 
   .variety-field {

--- a/src/lib/components/roll/SetlistSongCard.svelte
+++ b/src/lib/components/roll/SetlistSongCard.svelte
@@ -1,7 +1,7 @@
 <script>
   import { normalizeTechniqueValue, techniqueDisplay } from "../../technique-utils.js";
 
-  const { song, index, prevSong, onDragStart, onEdit, onRemove, arming = false, dragging = false } = $props();
+  const { song, index, prevSong, onDragStart, onEdit, onRemove, onTogglePin, arming = false, dragging = false } = $props();
 
   let expanded = $state(false);
 
@@ -46,7 +46,7 @@
   }
 </script>
 
-<div class="song-card" class:expanded class:dragging>
+<div class="song-card" class:expanded class:dragging class:pinned={song.pinned}>
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="card-main" onclick={toggleExpand} onkeydown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleExpand(); } }} role="button" tabindex="0">
     <span
@@ -71,6 +71,14 @@
       <div class="title-row">
         <span class="position">{song.position}.</span>
         <span class="song-name">{song.name}</span>
+        <button
+          type="button"
+          class="pin-btn"
+          class:pinned={song.pinned}
+          aria-label={song.pinned ? `Unpin ${song.name}` : `Pin ${song.name}`}
+          title={song.pinned ? "Unpin song" : "Keep this song and position on reroll"}
+          onclick={(e) => { e.stopPropagation(); onTogglePin?.(song.id); }}
+        >{song.pinned ? "📌" : "○"}</button>
         {#if song.key}
           <span class="key-badge">{song.key}</span>
         {/if}
@@ -137,6 +145,11 @@
 
   .song-card.expanded {
     border-color: var(--accent-line);
+  }
+
+  .song-card.pinned {
+    border-color: var(--accent-line);
+    background: var(--accent-soft);
   }
 
   /* When the parent wrapper marks this card as dragging, lift it visually so
@@ -277,6 +290,29 @@
     max-width: 100%;
   }
 
+  .pin-btn {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    min-height: 32px;
+    margin-left: auto;
+    padding: 0;
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    background: var(--surface);
+    color: var(--muted);
+    font-size: 16px;
+    cursor: pointer;
+  }
+
+  .pin-btn.pinned {
+    border-color: var(--accent-line);
+    background: var(--paper-strong);
+    color: var(--accent);
+  }
+
   .key-badge {
     margin-left: auto;
     flex-shrink: 0;
@@ -286,6 +322,10 @@
     border-radius: 999px;
     background: var(--line);
     color: var(--ink, #182230);
+  }
+
+  .pin-btn + .key-badge {
+    margin-left: 0;
   }
 
   .change-lines {

--- a/src/lib/components/songs/SongEditor.svelte
+++ b/src/lib/components/songs/SongEditor.svelte
@@ -295,6 +295,53 @@
                     onchange={(e) => store.updateSongField("unpracticed", e.currentTarget.checked)}
                 >Unpracticed</ChipToggle>
             </div>
+
+            <div class="song-programming-grid">
+                <label class="field">
+                    <span class="field-label">Play priority</span>
+                    <select
+                        class="field-input"
+                        value={store.editorSong.playPriority || "normal"}
+                        onchange={(e) => store.updateSongField("playPriority", e.currentTarget.value)}
+                    >
+                        <option value="must">Must play</option>
+                        <option value="prefer">Prefer</option>
+                        <option value="normal">Normal</option>
+                        <option value="rest">Rest</option>
+                    </select>
+                </label>
+
+                <label class="field">
+                    <span class="field-label">Energy</span>
+                    <select
+                        class="field-input"
+                        value={store.editorSong.energy || 3}
+                        onchange={(e) => store.updateSongField("energy", Number(e.currentTarget.value))}
+                    >
+                        <option value="1">1 · Very low</option>
+                        <option value="2">2 · Low</option>
+                        <option value="3">3 · Medium</option>
+                        <option value="4">4 · High</option>
+                        <option value="5">5 · Peak</option>
+                    </select>
+                </label>
+
+                <label class="field">
+                    <span class="field-label">Best position</span>
+                    <select
+                        class="field-input"
+                        value={store.editorSong.positionPreference || "anywhere"}
+                        onchange={(e) => store.updateSongField("positionPreference", e.currentTarget.value)}
+                    >
+                        <option value="anywhere">Anywhere</option>
+                        <option value="opener">Opener</option>
+                        <option value="early">Early</option>
+                        <option value="middle">Middle</option>
+                        <option value="late">Late</option>
+                        <option value="closer">Closer</option>
+                    </select>
+                </label>
+            </div>
         </section>
 
         <!-- Section 2: Members -->
@@ -676,6 +723,18 @@
         display: flex;
         gap: 0.6rem;
         flex-wrap: wrap;
+    }
+
+    .song-programming-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 0.75rem;
+    }
+
+    @media (max-width: 620px) {
+        .song-programming-grid {
+            grid-template-columns: 1fr;
+        }
     }
 
     /* Usual-setup rows (members with no song override) */

--- a/src/lib/components/songs/SongEditor.svelte
+++ b/src/lib/components/songs/SongEditor.svelte
@@ -318,11 +318,11 @@
                         value={store.editorSong.energy || 3}
                         onchange={(e) => store.updateSongField("energy", Number(e.currentTarget.value))}
                     >
-                        <option value="1">1 · Very low</option>
-                        <option value="2">2 · Low</option>
-                        <option value="3">3 · Medium</option>
-                        <option value="4">4 · High</option>
-                        <option value="5">5 · Peak</option>
+                        <option value={1}>1 · Very low</option>
+                        <option value={2}>2 · Low</option>
+                        <option value={3}>3 · Medium</option>
+                        <option value={4}>4 · High</option>
+                        <option value={5}>5 · Peak</option>
                     </select>
                 </label>
 

--- a/src/lib/defaults.js
+++ b/src/lib/defaults.js
@@ -119,6 +119,9 @@ export function blankSong() {
         notGoodOpener: false,
         notGoodCloser: false,
         unpracticed: false,
+        playPriority: "normal",
+        energy: 3,
+        positionPreference: "anywhere",
         key: "",
         notes: "",
         schemaVersion: SCHEMA_VERSION,
@@ -158,6 +161,13 @@ export function normalizeSongRecord(song) {
         notGoodOpener: Boolean(song.notGoodOpener),
         notGoodCloser: Boolean(song.notGoodCloser),
         unpracticed: Boolean(song.unpracticed),
+        playPriority: ["must", "prefer", "normal", "rest"].includes(song.playPriority) ? song.playPriority : "normal",
+        energy: Math.max(1, Math.min(5, Number.parseInt(song.energy, 10) || 3)),
+        positionPreference: ["anywhere", "opener", "early", "middle", "late", "closer"].includes(
+            song.positionPreference,
+        )
+            ? song.positionPreference
+            : "anywhere",
         key: song.key || "",
         notes: song.notes || "",
         schemaVersion: song.schemaVersion || SCHEMA_VERSION,

--- a/src/lib/defaults.test.js
+++ b/src/lib/defaults.test.js
@@ -102,6 +102,27 @@ describe("rigEqualsDefault", () => {
 });
 
 describe("normalizeSongRecord — member setups", () => {
+    it("adds safe programming defaults to legacy songs", () => {
+        const song = normalizeSongRecord({ id: "legacy", name: "Legacy" });
+
+        expect(song.playPriority).toBe("normal");
+        expect(song.energy).toBe(3);
+        expect(song.positionPreference).toBe("anywhere");
+    });
+
+    it("normalizes invalid programming metadata", () => {
+        const song = normalizeSongRecord({
+            id: "odd",
+            playPriority: "always-ish",
+            energy: 99,
+            positionPreference: "encore",
+        });
+
+        expect(song.playPriority).toBe("normal");
+        expect(song.energy).toBe(5);
+        expect(song.positionPreference).toBe("anywhere");
+    });
+
     it("strips the legacy 'none' technique sentinel", () => {
         const song = normalizeSongRecord({
             id: "s1",

--- a/src/lib/generator.js
+++ b/src/lib/generator.js
@@ -52,6 +52,20 @@ function createRng(seed) {
     };
 }
 
+function normalizeSeed(seed) {
+    if (seed === undefined || seed === null || seed === "" || seed === 0 || seed === "0") {
+        return Math.floor(Date.now() + Math.random() * 1000000);
+    }
+    const parsed = Number.parseInt(seed, 10);
+    if (!Number.isNaN(parsed)) return parsed >>> 0;
+    let hashed = 0;
+    for (const char of String(seed)) {
+        hashed = (hashed << 5) - hashed + char.charCodeAt(0);
+        hashed |= 0;
+    }
+    return hashed >>> 0;
+}
+
 function cartesianProduct(groups) {
     return groups.reduce(
         (product, group) => {
@@ -198,6 +212,9 @@ class SongsCatalog {
             instrumental: Boolean(song.instrumental),
             notGoodOpener: Boolean(song.notGoodOpener),
             notGoodCloser: Boolean(song.notGoodCloser),
+            playPriority: song.playPriority || "normal",
+            energy: Math.max(1, Math.min(5, Number(song.energy) || 3)),
+            positionPreference: song.positionPreference || "anywhere",
             key: song.key || null,
             notes: song.notes || "",
             performance,
@@ -213,6 +230,19 @@ class SetList {
         this._propConfig = this._config.props || {};
         this._weights = merge(DEFAULT_WEIGHTS, this._config.general?.weighting || {});
         this._options = this._normalizeOptions(options);
+        this._pinnedPositions = new Map(
+            (this._options.pinnedSongs || [])
+                .filter((pin) => Number.isInteger(pin.position) && pin.position > 0)
+                .map((pin) => [pin.position, String(pin.id)]),
+        );
+        this._pinnedPositionById = new Map(
+            Array.from(this._pinnedPositions.entries()).map(([position, id]) => [id, position]),
+        );
+        const smoothnessScale =
+            { smooth: 1.75, balanced: 1, adventurous: 0.35 }[this._options.transitionSmoothness] ?? 1;
+        ["tuning", "capo", "instrument", "technique", "keyFlow"].forEach((key) => {
+            this._weights[key] = (this._weights[key] || 0) * smoothnessScale;
+        });
         this._keyFlowEnabled = Boolean(this._options.keyFlow);
         this._show = deepMerge(this._config.show || {}, this._options.show || {});
         this._seed = this._normalizeSeed(this._options.seed);
@@ -231,7 +261,6 @@ class SetList {
             this._count = Math.min(this._options.count, this._catalog.length);
         }
         this._songBiasById = this._buildSongBiases(this._catalog);
-        this._songOrderBiasById = this._buildSongBiases(this._catalog);
         this._minConstraints = this._buildMinConstraints();
         this._minimumGroups = this._buildMinimumGroups();
         this._list = [];
@@ -269,21 +298,7 @@ class SetList {
     }
 
     _normalizeSeed(seed) {
-        if (seed === undefined || seed === null || seed === "" || seed === 0 || seed === "0") {
-            return Math.floor(Date.now() + Math.random() * 1000000);
-        }
-        const parsed = Number.parseInt(seed, 10);
-        if (Number.isNaN(parsed)) {
-            let hashed = 0;
-            String(seed)
-                .split("")
-                .forEach((char) => {
-                    hashed = (hashed << 5) - hashed + char.charCodeAt(0);
-                    hashed |= 0;
-                });
-            return hashed >>> 0;
-        }
-        return parsed >>> 0;
+        return normalizeSeed(seed);
     }
 
     _randomJitter(amount) {
@@ -308,20 +323,31 @@ class SetList {
     _buildSongBiases(songs) {
         const magnitude = clampFloat(this._randomness.songBias, 3, 0);
         return songs.reduce((result, song) => {
-            result[song.id] = this._randomJitter(magnitude);
+            const preferenceBias = this._options.selectionPhase ? this._selectionPreference(song) : 0;
+            result[song.id] = preferenceBias + this._randomJitter(magnitude);
             return result;
         }, {});
+    }
+
+    _selectionPreference(song) {
+        const rotation = this._options.rotation || "balanced";
+        const scores = {
+            hits: { must: -100, prefer: -16, normal: 2, rest: 30 },
+            balanced: { must: -100, prefer: -8, normal: 0, rest: 24 },
+            deep: { must: -100, prefer: -2, normal: -4, rest: 16 },
+        }[rotation];
+        return scores?.[song.playPriority || "normal"] ?? 0;
     }
 
     _songBias(songId) {
         return this._songBiasById[songId] || 0;
     }
 
-    _songOrderBias(songId) {
-        return this._songOrderBiasById[songId] || 0;
-    }
-
     _chaosAdjustment(prevItem, nextVariant) {
+        // The legacy Variety control used temperature to reward or punish
+        // awkward transitions. Modern rolls separate selection variety from
+        // transition smoothness, so temperature only explores alternatives.
+        if (this._options.selectionVariety !== undefined) return 0;
         const centeredChaos = this._chaosLevel * 2 - 1;
         if (!prevItem || centeredChaos === 0) {
             return 0;
@@ -751,6 +777,11 @@ class SetList {
                         if (state.usedIds[song.id]) {
                             continue;
                         }
+                        const pinnedId = this._pinnedPositions.get(position);
+                        const songPinnedAt = this._pinnedPositionById.get(song.id);
+                        if ((pinnedId && song.id !== pinnedId) || (songPinnedAt && songPinnedAt !== position)) {
+                            continue;
+                        }
 
                         const result = this._buildNextState(state, song, position, relaxPositionFilter);
                         if (!result) {
@@ -793,8 +824,7 @@ class SetList {
 
         const best = this._pickFinalState(states);
         const bestItems = this._collectItems(best);
-        const diversifiedItems = this._diversifyCompatibleRuns(bestItems);
-        const finalized = this._finalizeItems(diversifiedItems);
+        const finalized = this._finalizeItems(bestItems);
         this._list = finalized.items;
         this._summary = finalized.summary;
     }
@@ -899,109 +929,6 @@ class SetList {
         return pool[pool.length - 1];
     }
 
-    _diversifyCompatibleRuns(items) {
-        const result = items.slice();
-
-        for (let start = 0; start < result.length; ) {
-            const signature = this._performanceSignature(result[start].performance);
-            let end = start + 1;
-
-            while (end < result.length && this._performanceSignature(result[end].performance) === signature) {
-                end += 1;
-            }
-
-            if (end - start > 1) {
-                const reordered = this._reorderRun(result.slice(start, end), start + 1);
-                for (let index = 0; index < reordered.length; index += 1) {
-                    result[start + index] = reordered[index];
-                }
-            }
-
-            start = end;
-        }
-
-        return result;
-    }
-
-    _reorderRun(runItems, startPosition) {
-        const lastPosition = startPosition + runItems.length - 1;
-        const remaining = runItems.slice();
-        const ordered = new Array(runItems.length);
-        const temperature = clampFloat(this._randomness.blockShuffleTemperature, 1.4, 0.01);
-
-        const pickForPosition = (position) => {
-            const eligible = remaining.filter((item) => this._positionAllowsSong(position, item));
-            const pool = eligible.length ? eligible : remaining;
-            const ranked = pool
-                .map((item) => {
-                    const score = this._songOrderBias(item.id);
-                    return { item, score };
-                })
-                .sort((left, right) => left.score - right.score);
-
-            const bestScore = ranked[0].score;
-            const weights = ranked.map((entry) => Math.exp(-(entry.score - bestScore) / temperature));
-            const total = weights.reduce((sum, weight) => sum + weight, 0);
-            let target = this._rng() * total;
-            let chosenIndex = ranked.length - 1;
-
-            for (let index = 0; index < ranked.length; index += 1) {
-                target -= weights[index];
-                if (target <= 0) {
-                    chosenIndex = index;
-                    break;
-                }
-            }
-
-            const chosen = ranked[chosenIndex].item;
-            remaining.splice(remaining.indexOf(chosen), 1);
-            return chosen;
-        };
-
-        // Reserve edge positions first so flagged songs don't get forced into them.
-        if (startPosition === 1) {
-            ordered[0] = pickForPosition(1);
-        }
-        if (lastPosition === this._count && lastPosition !== startPosition) {
-            ordered[lastPosition - startPosition] = pickForPosition(this._count);
-        }
-
-        for (let offset = 0; offset < runItems.length; offset += 1) {
-            if (ordered[offset] !== undefined) {
-                continue;
-            }
-            ordered[offset] = pickForPosition(startPosition + offset);
-        }
-
-        return ordered;
-    }
-
-    _positionAllowsSong(position, item) {
-        if (position === 1 && item.notGoodOpener && !this._openerFilterRelaxed) {
-            return false;
-        }
-        if (position === this._count && item.notGoodCloser && !this._closerFilterRelaxed) {
-            return false;
-        }
-        return true;
-    }
-
-    _performanceSignature(performance) {
-        return Object.keys(performance)
-            .sort()
-            .map((member) => {
-                const setup = performance[member];
-                return [
-                    member,
-                    setup.instrument || "",
-                    setup.tuning || "",
-                    String(setup.capo || 0),
-                    String(setup.picking || ""),
-                ].join("|");
-            })
-            .join("::");
-    }
-
     _finalizeItems(items) {
         let state = this._initialState();
         const finalizedItems = [];
@@ -1013,6 +940,8 @@ class SetList {
                 name: item.name,
                 cover: item.cover,
                 instrumental: item.instrumental,
+                energy: item.energy,
+                positionPreference: item.positionPreference,
                 key: item.key,
                 notes: item.notes || "",
                 performance: item.performance,
@@ -1075,7 +1004,8 @@ class SetList {
     }
 
     _buildNextState(state, song, position, relaxPositionFilter = false) {
-        if (!relaxPositionFilter) {
+        const isPinnedHere = this._pinnedPositions.get(position) === song.id;
+        if (!relaxPositionFilter && !this._options.selectionPhase && !isPinnedHere) {
             if (position === 1 && song.notGoodOpener) {
                 return null;
             }
@@ -1151,7 +1081,8 @@ class SetList {
         for (let vi = 0; vi < variants.length; vi++) {
             const variant = variants[vi];
             const propTransition = this._scoreConfiguredPropsLite(prevItem, variant);
-            if (!this._isAllowedByPropRules(state, propTransition.changes, prevItem, position)) {
+            const isPinnedHere = this._pinnedPositions.get(position) === song.id;
+            if (!isPinnedHere && !this._isAllowedByPropRules(state, propTransition.changes, prevItem, position)) {
                 continue;
             }
 
@@ -1267,6 +1198,7 @@ class SetList {
 
     // Lite position scoring: returns just the numeric score
     _scorePositionLite(song, position) {
+        if (this._options.selectionPhase) return 0;
         let score = 0;
         const orderLabel = this._findOrderLabel(position);
         const orderRules = this._config.general?.order?.[orderLabel] || [];
@@ -1280,7 +1212,48 @@ class SetList {
             }
         }
 
+        score += this._scoreMusicalPosition(song, position);
+
         return score;
+    }
+
+    _targetEnergy(position) {
+        if (!this._options.setShape) {
+            return null;
+        }
+        const progress = this._count <= 1 ? 1 : (position - 1) / (this._count - 1);
+        if (this._options.setShape === "big-ends") {
+            return 5 - 3 * Math.sin(Math.PI * progress);
+        }
+        if (this._options.setShape === "alternating") {
+            return position % 2 === 1 ? 4.5 : 2.5;
+        }
+        if (this._options.setShape === "lively") {
+            return 4.5;
+        }
+        if (this._options.setShape === "none") {
+            return null;
+        }
+        return 2.5 + 2.5 * progress;
+    }
+
+    _scoreMusicalPosition(song, position) {
+        let score = 0;
+        const targetEnergy = this._targetEnergy(position);
+        if (targetEnergy !== null) {
+            score += Math.abs((song.energy || 3) - targetEnergy) * 1.5;
+        }
+
+        const preference = song.positionPreference || "anywhere";
+        if (preference === "anywhere") return score;
+        const progress = this._count <= 1 ? 1 : (position - 1) / (this._count - 1);
+        const matches =
+            (preference === "opener" && position === 1) ||
+            (preference === "closer" && position === this._count) ||
+            (preference === "early" && progress <= 0.34) ||
+            (preference === "middle" && progress > 0.25 && progress < 0.75) ||
+            (preference === "late" && progress >= 0.66);
+        return score + (matches ? -4 : 5);
     }
 
     _scoreConfiguredProps(prevItem, nextVariant) {
@@ -1397,6 +1370,8 @@ class SetList {
             }
         });
 
+        score += this._scoreMusicalPosition(song, position);
+
         return { score, notes };
     }
 
@@ -1444,8 +1419,54 @@ const DEFAULT_RANDOMNESS = {
 };
 
 export function generateSetlist(songs, config, options = {}) {
-    const generator = new SetList(songs, config, options);
+    const usesSelectionPreferences =
+        options.selectionVariety !== undefined || options.rotation !== undefined || options.setShape !== undefined;
+    const selectedSongs =
+        options.fixedSongIds || !usesSelectionPreferences ? songs : selectSongPool(songs, options, config);
+    const generator = new SetList(selectedSongs, config, {
+        ...options,
+        count: Math.min(options.count ?? config?.general?.count ?? 15, selectedSongs.length),
+    });
     return generator.toJSON();
+}
+
+function selectSongPool(songs, options = {}, config = {}) {
+    const count = Math.min(
+        Math.max(1, Number.parseInt(options.count, 10) || config?.general?.count || 15),
+        songs.length,
+    );
+    if (songs.length <= count) return songs.slice();
+
+    const pinnedIds = new Set((options.pinnedSongs || []).map((pin) => String(pin.id)));
+    const pinnedSongs = songs.filter((song) => pinnedIds.has(String(song.id))).slice(0, count);
+    const remainingCount = count - pinnedSongs.length;
+    if (remainingCount <= 0) return pinnedSongs;
+    const remainingSongs = songs.filter((song) => !pinnedIds.has(String(song.id)));
+
+    const variety = clampUnit((options.selectionVariety === undefined ? 50 : Number(options.selectionVariety)) / 100);
+    const selectionOptions = {
+        ...options,
+        count: remainingCount,
+        keyFlow: false,
+        setShape: "none",
+        transitionSmoothness: "adventurous",
+        selectionPhase: true,
+        pinnedSongs: [],
+        randomness: {
+            ...(options.randomness || {}),
+            songBias: 1 + variety * 12,
+            temperature: 0.35 + variety * 1.65,
+            stateJitter: variety * 3,
+            variantJitter: variety * 1.5,
+        },
+    };
+    const selectedIds = new Set(
+        new SetList(remainingSongs, config, selectionOptions).toJSON().songs.map((song) => song.id),
+    );
+    pinnedSongs.forEach((song) => {
+        selectedIds.add(String(song.id));
+    });
+    return songs.filter((song) => selectedIds.has(String(song.id)));
 }
 
 export function scoreFixedOrder(fixedSongs, config, options = {}) {

--- a/src/lib/generator.js
+++ b/src/lib/generator.js
@@ -241,7 +241,7 @@ class SetList {
         const smoothnessScale =
             { smooth: 1.75, balanced: 1, adventurous: 0.35 }[this._options.transitionSmoothness] ?? 1;
         ["tuning", "capo", "instrument", "technique", "keyFlow"].forEach((key) => {
-            this._weights[key] = (this._weights[key] || 0) * smoothnessScale;
+            this._weights[key] = (this._weights[key] ?? DEFAULT_WEIGHTS[key]) * smoothnessScale;
         });
         this._keyFlowEnabled = Boolean(this._options.keyFlow);
         this._show = deepMerge(this._config.show || {}, this._options.show || {});
@@ -1402,6 +1402,11 @@ class SetList {
 }
 
 const DEFAULT_WEIGHTS = {
+    tuning: 4,
+    capo: 2,
+    instrument: 3,
+    technique: 1,
+    keyFlow: 2,
     positionMiss: 8,
 };
 

--- a/src/lib/generator.test.js
+++ b/src/lib/generator.test.js
@@ -405,6 +405,105 @@ describe("generateSetlist — basics", () => {
 // ===================================================================
 // Determinism
 // ===================================================================
+describe("generateSetlist — programming preferences", () => {
+    it("always includes explicitly pinned songs", () => {
+        const songs = simpleCatalog(8);
+        songs[7].playPriority = "rest";
+
+        const result = generateSetlist(songs, makeConfig(), {
+            ...deterministicOptions({ count: 4, seed: 42 }),
+            rotation: "hits",
+            selectionVariety: 0,
+            pinnedSongs: [{ id: songs[7].id, position: null }],
+        });
+
+        expect(result.songs.map((song) => song.id)).toContain(songs[7].id);
+    });
+
+    it("keeps pinned songs at their positions while rerolling the rest", () => {
+        const songs = simpleCatalog(10);
+        const options = {
+            ...deterministicOptions({ count: 6, seed: 21 }),
+            rotation: "balanced",
+            selectionVariety: 80,
+            pinnedSongs: [
+                { id: songs[2].id, position: 2 },
+                { id: songs[7].id, position: 5 },
+            ],
+        };
+
+        const first = generateSetlist(songs, makeConfig(), options);
+        const second = generateSetlist(songs, makeConfig(), { ...options, seed: 99 });
+
+        expect(first.songs[1].id).toBe(songs[2].id);
+        expect(first.songs[4].id).toBe(songs[7].id);
+        expect(second.songs[1].id).toBe(songs[2].id);
+        expect(second.songs[4].id).toBe(songs[7].id);
+        expect(second.songs.map((song) => song.id)).not.toEqual(first.songs.map((song) => song.id));
+    });
+
+    it("selects must-play and preferred songs before normal songs", () => {
+        const songs = [makeSong("Must", { id: "must" }), makeSong("Prefer", { id: "prefer" }), ...simpleCatalog(8)];
+        songs[0].playPriority = "must";
+        songs[1].playPriority = "prefer";
+
+        const result = generateSetlist(songs, makeConfig(), {
+            ...deterministicOptions({ count: 4, seed: 42 }),
+            rotation: "balanced",
+            selectionVariety: 0,
+        });
+        const ids = result.songs.map((song) => song.id);
+
+        expect(ids).toContain("must");
+        expect(ids).toContain("prefer");
+    });
+
+    it("rests a song when enough normal songs are available", () => {
+        const songs = simpleCatalog(6);
+        songs[0].playPriority = "rest";
+
+        const result = generateSetlist(songs, makeConfig(), {
+            ...deterministicOptions({ count: 4, seed: 42 }),
+            rotation: "balanced",
+            selectionVariety: 0,
+        });
+
+        expect(result.songs.map((song) => song.id)).not.toContain(songs[0].id);
+    });
+
+    it("builds from lower energy to higher energy", () => {
+        const songs = Array.from({ length: 5 }, (_, index) => {
+            const song = makeSong(`Energy ${index + 1}`);
+            song.energy = index + 1;
+            return song;
+        });
+
+        const result = generateSetlist(songs, makeConfig({ props: {} }), {
+            ...deterministicOptions({ count: 5, seed: 42 }),
+            fixedSongIds: songs.map((song) => song.id),
+            setShape: "build",
+        });
+
+        expect(result.songs[0].name).toBe("Energy 1");
+        expect(result.songs.at(-1).name).toBe("Energy 5");
+    });
+
+    it("honors explicit opener and closer preferences", () => {
+        const songs = simpleCatalog(5);
+        songs[1].positionPreference = "opener";
+        songs[3].positionPreference = "closer";
+
+        const result = generateSetlist(songs, makeConfig({ props: {} }), {
+            ...deterministicOptions({ count: 5, seed: 42 }),
+            fixedSongIds: songs.map((song) => song.id),
+            setShape: "none",
+        });
+
+        expect(result.songs[0].id).toBe(songs[1].id);
+        expect(result.songs.at(-1).id).toBe(songs[3].id);
+    });
+});
+
 describe("generateSetlist — determinism", () => {
     it("same seed produces identical output", () => {
         const songs = simpleCatalog(20);

--- a/src/lib/generator.test.js
+++ b/src/lib/generator.test.js
@@ -406,6 +406,32 @@ describe("generateSetlist — basics", () => {
 // Determinism
 // ===================================================================
 describe("generateSetlist — programming preferences", () => {
+    it("scales established transition defaults when weighting config is partial", () => {
+        const songs = [
+            makeSong("Standard", {
+                members: {
+                    nick: { instruments: [{ name: "guitar", tuning: ["Standard"], capo: 0, picking: [] }] },
+                },
+            }),
+            makeSong("Drop D", {
+                members: {
+                    nick: { instruments: [{ name: "guitar", tuning: ["Drop D"], capo: 0, picking: [] }] },
+                },
+            }),
+        ];
+        const config = makeConfig({ general: { weighting: { positionMiss: 8 } } });
+
+        const result = generateSetlist(songs, config, {
+            ...deterministicOptions({ count: 2 }),
+            fixedSongIds: songs.map((song) => song.id),
+            setShape: "none",
+            transitionSmoothness: "smooth",
+            selectionVariety: 0,
+        });
+
+        expect(result.summary.score).toBe(7);
+    });
+
     it("always includes explicitly pinned songs", () => {
         const songs = simpleCatalog(8);
         songs[7].playPriority = "rest";

--- a/src/lib/stores/app.svelte.js
+++ b/src/lib/stores/app.svelte.js
@@ -82,6 +82,9 @@ export function createAppStore(repo) {
     let appConfig = $state(null);
     let bootstrapMeta = $state(null);
     let generatedSetlist = $state(null);
+    // Songs explicitly chosen before the first roll. Once a roll completes,
+    // pin state moves onto the lean setlist entries so positions can be kept.
+    let preRollPinnedIds = $state([]);
     let isGenerating = $state(false);
     let activeWorker = null;
     let generationId = 0;
@@ -240,6 +243,10 @@ export function createAppStore(repo) {
             maxInstrumentals: source.general?.limits?.instrumentals ?? -1,
             keyFlow: false,
             includeUnpracticed: false,
+            setShape: "build",
+            rotation: "balanced",
+            transitionSmoothness: "balanced",
+            selectionVariety: 50,
             seed: "",
             randomness: {
                 temperature: source.general?.randomness?.temperature ?? 0.85,
@@ -387,14 +394,15 @@ export function createAppStore(repo) {
         const fat = [];
         for (const entry of setlist.songs) {
             const song = songsById.get(entry.songId);
-            if (song) fat.push({ ...song, performance: entry.performance || {} });
+            if (song) fat.push({ ...song, performance: entry.performance || {}, pinned: !!entry.pinned });
         }
         const scored = scoreFixedOrder(fat, appConfig || DEFAULT_APP_CONFIG, {
             keyFlow: generationOptions?.keyFlow,
         });
+        const pinnedIds = new Set(fat.filter((song) => song.pinned).map((song) => song.id));
         return {
             ...setlist,
-            songs: scored.songs,
+            songs: scored.songs.map((song) => ({ ...song, pinned: pinnedIds.has(song.id) })),
             summary: {
                 ...scored.summary,
                 minimumsRelaxed: !!setlist.minimumsRelaxed,
@@ -435,6 +443,7 @@ export function createAppStore(repo) {
             songs: (result.songs || []).map((s) => ({
                 songId: s.id,
                 performance: s.performance || {},
+                pinned: !!s.pinned,
             })),
         };
     }
@@ -452,6 +461,7 @@ export function createAppStore(repo) {
         const songs = setlist.songs.map((s) => ({
             songId: s.songId || s.id,
             performance: s.performance || {},
+            pinned: !!s.pinned,
         }));
         const out = { ...setlist, songs };
         if (out.summary) {
@@ -503,9 +513,11 @@ export function createAppStore(repo) {
         // the NEXT ROLL clobbering the list, not against persistence.
         if (current) {
             generatedSetlist = current;
+            preRollPinnedIds = [];
             setlistLocked = current._locked || false;
         } else {
             clearGeneratedSetlist();
+            preRollPinnedIds = [];
             setlistLocked = false;
         }
         setlistSaved = false;
@@ -1146,7 +1158,11 @@ export function createAppStore(repo) {
     function confirmFreshRoll() {
         pendingRollConfirm = false;
         setlistLocked = false;
-        generate();
+        generatedSetlist = generatedSetlist
+            ? { ...generatedSetlist, songs: generatedSetlist.songs.map((entry) => ({ ...entry, pinned: false })) }
+            : null;
+        preRollPinnedIds = [];
+        generate({ _clearPins: true });
     }
 
     function confirmOptimizeOrder() {
@@ -1185,7 +1201,16 @@ export function createAppStore(repo) {
         // Unpracticed songs stay out of the pool unless the user opted in —
         // but songs explicitly pinned by "Optimize Order" (fixedSongIds)
         // always stay in, or the optimize pass would silently drop them.
-        const fixedIds = new Set(overrideOptions.fixedSongIds || []);
+        const currentPins = overrideOptions._clearPins
+            ? []
+            : (generatedSetlist?.songs || [])
+                  .map((entry, index) => (entry.pinned ? { id: entry.songId, position: index + 1 } : null))
+                  .filter(Boolean);
+        const queuedPins = overrideOptions._clearPins
+            ? []
+            : preRollPinnedIds.map((id) => ({ id, position: null }));
+        const pinsForRoll = overrideOptions.fixedSongIds ? [] : [...currentPins, ...queuedPins];
+        const fixedIds = new Set([...(overrideOptions.fixedSongIds || []), ...pinsForRoll.map((pin) => pin.id)]);
         const eligibleSongs = songs.filter(
             (s) => generationOptions.includeUnpracticed || !s.unpracticed || fixedIds.has(s.id),
         );
@@ -1206,6 +1231,12 @@ export function createAppStore(repo) {
         const thisSession = activeSession;
         const opts = clone(generationOptions);
         Object.assign(opts, overrideOptions);
+        delete opts._clearPins;
+        if (pinsForRoll.length) {
+            opts.pinnedSongs = pinsForRoll;
+            const lastPinnedPosition = Math.max(0, ...currentPins.map((pin) => pin.position));
+            opts.count = Math.max(opts.count, pinsForRoll.length, lastPinnedPosition);
+        }
 
         const worker = new GeneratorWorker();
         activeWorker = worker;
@@ -1237,7 +1268,13 @@ export function createAppStore(repo) {
                 ]));
                 return;
             }
-            generatedSetlist = leanFromGeneratorResult(result);
+            const pinnedIds = new Set(pinsForRoll.map((pin) => pin.id));
+            const lean = leanFromGeneratorResult(result);
+            generatedSetlist = {
+                ...lean,
+                songs: lean.songs.map((entry) => ({ ...entry, pinned: pinnedIds.has(entry.songId) })),
+            };
+            preRollPinnedIds = [];
             if (opts._keepLock) {
                 setlistSaved = false;
             } else {
@@ -1297,9 +1334,11 @@ export function createAppStore(repo) {
         // remotely but haven't loaded yet. When unsettled, we save the songs
         // verbatim — any truly-deleted entries will be pruned on the next save
         // once the catalog is stable.
-        const persistedSongs = catalogSettled
+        const currentSongs = catalogSettled
             ? clone(generatedSetlist.songs.filter((e) => songsById.has(e.songId)))
             : clone(generatedSetlist.songs);
+        // Pins are working-session state, not part of a saved historical set.
+        const persistedSongs = currentSongs.map(({ pinned: _pinned, ...entry }) => entry);
 
         const sessionAlive = sessionGuard();
 
@@ -1478,11 +1517,37 @@ export function createAppStore(repo) {
         );
         generatedSetlist = {
             ...generatedSetlist,
-            songs: [...generatedSetlist.songs, { songId, performance }],
+            songs: [...generatedSetlist.songs, { songId, performance, pinned: true }],
         };
         setlistSaved = false;
         persistCurrentSetlist();
     }
+
+    function pinSongBeforeRoll(songId) {
+        if (generatedSetlist || !songsById.has(songId) || preRollPinnedIds.includes(songId)) return;
+        preRollPinnedIds = [...preRollPinnedIds, songId];
+    }
+
+    function unpinSongBeforeRoll(songId) {
+        preRollPinnedIds = preRollPinnedIds.filter((id) => id !== songId);
+    }
+
+    function toggleSetlistSongPin(songId) {
+        if (!generatedSetlist) return;
+        generatedSetlist = {
+            ...generatedSetlist,
+            songs: generatedSetlist.songs.map((entry) =>
+                entry.songId === songId ? { ...entry, pinned: !entry.pinned } : entry,
+            ),
+        };
+        setlistSaved = false;
+        persistCurrentSetlist();
+    }
+
+    let preRollPinnedSongs = $derived(preRollPinnedIds.map((id) => songsById.get(id)).filter(Boolean));
+    let pinnedSongCount = $derived(
+        preRollPinnedIds.length + (generatedSetlist?.songs || []).filter((entry) => entry.pinned).length,
+    );
 
     // Unpracticed songs stay in this list on purpose: the roller won't pick
     // them, but the band can still add one to a set deliberately (the picker
@@ -2644,6 +2709,8 @@ export function createAppStore(repo) {
         get appConfig() { return appConfig; },
         get bandMembers() { return bandMembers; },
         get generatedSetlist() { return generatedSetlist; },
+        get preRollPinnedSongs() { return preRollPinnedSongs; },
+        get pinnedSongCount() { return pinnedSongCount; },
         get displayedSetlist() { return displayedSetlist; },
         get displayedSavedSetlists() { return displayedSavedSetlists; },
         get isGenerating() { return isGenerating; },
@@ -2735,6 +2802,9 @@ export function createAppStore(repo) {
         reorderSetlistSong,
         removeSetlistSong,
         addSetlistSong,
+        pinSongBeforeRoll,
+        unpinSongBeforeRoll,
+        toggleSetlistSongPin,
         get songsNotInSetlist() { return songsNotInSetlist; },
         updateGenerationField,
         toggleListValue,

--- a/src/lib/stores/app.test.js
+++ b/src/lib/stores/app.test.js
@@ -536,6 +536,48 @@ describe("incremental remote sync", () => {
         teardown();
     });
 
+    it("queues and removes songs pinned before the first roll", async () => {
+        const repo = buildRepo();
+        const store = createAppStore(repo);
+        const teardown = store.init();
+        repo.fire("connected");
+        await settle();
+        repo.fireChange({ relativePath: "songs/s1", origin: "remote", newValue: { id: "s1", name: "Anchor" } });
+
+        store.pinSongBeforeRoll("s1");
+        expect(store.preRollPinnedSongs.map((song) => song.id)).toEqual(["s1"]);
+        expect(store.pinnedSongCount).toBe(1);
+
+        store.unpinSongBeforeRoll("s1");
+        expect(store.preRollPinnedSongs).toEqual([]);
+        expect(store.pinnedSongCount).toBe(0);
+        teardown();
+    });
+
+    it("persists pin toggles on the working setlist", async () => {
+        globalThis.localStorage.setItem(
+            accountSlot("user@example.com").key("current-set"),
+            JSON.stringify({ seed: 1, songs: [{ songId: "s1", performance: {} }] }),
+        );
+        const repo = buildRepo();
+        const store = createAppStore(repo);
+        const teardown = store.init();
+        repo.fire("connected");
+        await settle();
+        repo.fireChange({ relativePath: "songs/s1", origin: "remote", newValue: { id: "s1", name: "Anchor" } });
+
+        store.toggleSetlistSongPin("s1");
+        expect(store.generatedSetlist.songs[0].pinned).toBe(true);
+        expect(store.displayedSetlist.songs[0].pinned).toBe(true);
+        expect(store.pinnedSongCount).toBe(1);
+
+        const persisted = JSON.parse(
+            globalThis.localStorage.getItem(accountSlot("user@example.com").key("current-set")),
+        );
+        expect(persisted.songs[0].pinned).toBe(true);
+        teardown();
+    });
+
     it("flips to synced after a quiet settle window and persists initialSyncDone", async () => {
         const repo = buildRepo();
         const store = createAppStore(repo);

--- a/tests/e2e/roll.spec.ts
+++ b/tests/e2e/roll.spec.ts
@@ -67,6 +67,44 @@ test.describe("Roll screen — onboarding & sync state", () => {
 });
 
 test.describe("Roll screen — generation flow", () => {
+    test("a song pinned before rolling is guaranteed a place", async ({ page, app }) => {
+        await app.seed(seedWithCatalog());
+        await app.goto();
+        await app.waitForReady();
+        await new AppShell(page).gotoRoll();
+        const roll = new RollPage(page);
+        await roll.setSongCount(5);
+
+        await roll.pinBeforeRoll("Jolene");
+        await expect(roll.screen.getByText("📌 Jolene")).toBeVisible();
+        await roll.clickRoll();
+        await roll.waitForRollResult();
+
+        expect(await roll.getSetlistSongNames()).toContain("Jolene");
+    });
+
+    test("pinned songs keep their positions when the rest is rerolled", async ({ page, app }) => {
+        await app.seed(seedWithCatalog());
+        await app.goto();
+        await app.waitForReady();
+        await new AppShell(page).gotoRoll();
+        const roll = new RollPage(page);
+        await roll.setSongCount(6);
+        await roll.setSeed(21);
+        await roll.clickRoll();
+        await roll.waitForRollResult();
+        const firstNames = await roll.getSetlistSongNames();
+        const pinnedName = firstNames[2];
+
+        await roll.pinButton(pinnedName).click();
+        await roll.setSeed(99);
+        await roll.clickRoll();
+        await roll.waitForRollResult();
+
+        const secondNames = await roll.getSetlistSongNames();
+        expect(secondNames[2]).toBe(pinnedName);
+    });
+
     test("clicking Roll generates a setlist", { tag: ["@smoke"] }, async ({ page, app }) => {
         await app.seed(seedWithCatalog());
         await app.goto();

--- a/tests/e2e/song-editor.spec.ts
+++ b/tests/e2e/song-editor.spec.ts
@@ -33,6 +33,27 @@ test.describe("Song editor — basics", () => {
         expect(created.notes).toBe("Capo on 2");
     });
 
+    test("energy selection sticks on the first change", async ({ page, app }) => {
+        await app.seed(buildSeed());
+        await app.goto();
+        await new AppShell(page).gotoSongs();
+
+        const songs = new SongsPage(page);
+        const editor = new SongEditorPage(page);
+        await songs.clickAdd();
+        await editor.waitForVisible();
+        await editor.fillName("High Energy");
+
+        await editor.selectEnergy(5);
+        await expect(editor.energySelect).toHaveValue("5");
+        const draft = await app.getState();
+        expect(draft.editorSong.energy).toBe(5);
+
+        await editor.save();
+        const saved = await app.getState();
+        expect(saved.songs.find((song: SeedSong) => song.name === "High Energy")?.energy).toBe(5);
+    });
+
     test("editing a song persists changes after closing/reopening", async ({ page, app }) => {
         await app.seed(
             buildSeed({

--- a/tests/pages/RollPage.ts
+++ b/tests/pages/RollPage.ts
@@ -113,7 +113,7 @@ export class RollPage {
     async activateTab(tab: "constraints" | "chaos") {
         const buttons = this.screen.locator(".settings-tab");
         if ((await buttons.count()) === 0) return; // no constraints to tab between
-        const label = tab === "constraints" ? "Demands" : "Tweak the Chaos";
+        const label = tab === "constraints" ? "Demands" : "Shape the Set";
         await buttons.filter({ hasText: label }).click();
     }
 
@@ -130,6 +130,17 @@ export class RollPage {
         await expect(this.addSongDialog).toBeVisible();
         await this.addSongSearch.fill(songName);
         await this.addSongDialog.getByRole("button", { name: songName, exact: false }).first().click();
+    }
+
+    async pinBeforeRoll(songName: string) {
+        await this.screen.getByRole("button", { name: "+ Pin songs before rolling" }).click();
+        await expect(this.addSongDialog).toBeVisible();
+        await this.addSongSearch.fill(songName);
+        await this.addSongDialog.getByRole("button", { name: songName, exact: false }).first().click();
+    }
+
+    pinButton(songName: string) {
+        return this.setlistSongs.filter({ hasText: songName }).getByRole("button", { name: `Pin ${songName}` });
     }
 
     async closeAddSongDialog() {

--- a/tests/pages/SongEditorPage.ts
+++ b/tests/pages/SongEditorPage.ts
@@ -13,6 +13,7 @@ export class SongEditorPage {
     readonly nameInput: Locator;
     readonly keySelect: Locator;
     readonly notesInput: Locator;
+    readonly energySelect: Locator;
     readonly duplicateButton: Locator;
     readonly deleteButton: Locator;
 
@@ -26,6 +27,7 @@ export class SongEditorPage {
         this.nameInput = this.overlay.getByPlaceholder("Song title");
         this.keySelect = this.overlay.locator("select").first();
         this.notesInput = this.overlay.getByPlaceholder("Anything to remember on stage...");
+        this.energySelect = this.overlay.locator("label").filter({ hasText: "Energy" }).locator("select");
         this.duplicateButton = this.overlay.getByRole("button", { name: "Duplicate song" });
         this.deleteButton = this.overlay.getByRole("button", { name: "Delete song" });
     }
@@ -44,6 +46,10 @@ export class SongEditorPage {
 
     async fillNotes(notes: string) {
         await this.notesInput.fill(notes);
+    }
+
+    async selectEnergy(energy: number) {
+        await this.energySelect.selectOption(String(energy));
     }
 
     /** Toggle the Cover / Instrumental / Unpracticed / Not a good opener / closer chips */


### PR DESCRIPTION
## What changed

- add song-level play priority, energy, and preferred-position metadata
- split generation into song selection and ordering phases
- add set-shape, song-mix, transition-smoothness, and selection-variety controls
- remove the post-generation shuffle that could weaken optimized ordering
- add pre-roll song pinning and per-song pins after a roll
- preserve pinned songs at their current positions while rerolling the remaining slots
- persist pins with the active working set while omitting them from saved historical setlists

## Why

The previous roller primarily optimized equipment transitions. It had little information about which songs users wanted, how a set should build musically, or which parts of a promising roll should survive a reroll. These changes let users express those intentions directly while retaining existing gear and tuning constraints.

## User impact

Users can shape the energy arc and song mix of a roll, mark songs as must-play/preferred/rested, explicitly pin songs before rolling, and keep selected songs in place while rerolling everything else.

## Validation

- npm run lint
- npm test — 346 tests passed
- npm run build
- Svelte autofixer validation on changed components
- targeted Playwright coverage was added for both pin workflows; execution requires armadietto, which was unavailable locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pin songs before rolling to guarantee their inclusion in the generated setlist.
  * Pin songs within a setlist to preserve their positions during rerolls.
  * Configure song play priority, energy, and preferred position.
  * Added set-shaping controls for selection variety, rotation, transitions, and energy flow.
  * Renamed “Tweak the Chaos” to “Shape the Set.”
* **Bug Fixes**
  * Improved handling and validation of song programming settings, including legacy songs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->